### PR TITLE
feat(tee): TEE provider abstraction and dev mode stub

### DIFF
--- a/src/cmcp_gateway/tee/base.py
+++ b/src/cmcp_gateway/tee/base.py
@@ -1,0 +1,76 @@
+"""TEE provider abstraction — implements issue #77."""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class AttestationReport:
+    """Hardware attestation report produced by a TEE provider."""
+
+    provider: str
+    measurement: str  # hex-encoded; format varies by provider
+    report_data: str  # hex-encoded nonce binding public key to this report
+    raw_evidence: bytes | None  # raw provider-specific evidence blob
+    attestation_generated_at: datetime
+    attestation_validity_seconds: int
+    measurement_note: str | None = None  # e.g. "sha1-bank-fallback"
+
+
+class TEEProvider(ABC):
+    """Abstract interface all TEE provider implementations satisfy."""
+
+    @abstractmethod
+    def detect(self) -> bool:
+        """Return True if this provider's hardware is available and accessible."""
+
+    @abstractmethod
+    def get_attestation_report(self, nonce: bytes) -> AttestationReport:
+        """
+        Produce a hardware attestation report.
+
+        nonce should be SHA-256(tee_public_key || session_id) as defined in
+        docs/spec/attestation.md §3.3 — this binds the report to a specific
+        gateway instance and session.
+        """
+
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Return the canonical provider name string for attestation_report.provider."""
+
+
+def make_nonce(tee_public_key: bytes, session_id: str) -> bytes:
+    """Compute the attestation nonce: SHA-256(tee_public_key || session_id_bytes)."""
+    return hashlib.sha256(tee_public_key + session_id.encode()).digest()
+
+
+class SoftwareOnlyProvider(TEEProvider):
+    """
+    Software-only attestation stub for CI and local development.
+
+    Activated when CMCP_DEV_MODE=1. Produces deterministic-looking but
+    cryptographically meaningless attestation data. TRACE Claims from this
+    provider carry attestation_report.provider = "software-only" and must
+    not be used for compliance purposes.
+    """
+
+    def detect(self) -> bool:
+        return True  # always available as fallback
+
+    def provider_name(self) -> str:
+        return "software-only"
+
+    def get_attestation_report(self, nonce: bytes) -> AttestationReport:
+        return AttestationReport(
+            provider="software-only",
+            measurement="DEVELOPMENT_ONLY_NOT_FOR_PRODUCTION",
+            report_data=nonce.hex(),
+            raw_evidence=None,
+            attestation_generated_at=datetime.now(tz=timezone.utc),
+            attestation_validity_seconds=86400,
+            measurement_note="software-only mode — not hardware-backed",
+        )

--- a/src/cmcp_gateway/tee/detect.py
+++ b/src/cmcp_gateway/tee/detect.py
@@ -1,0 +1,105 @@
+"""TEE provider detection loop — implements issue #72 (dev mode) and #77 (abstraction)."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from cmcp_gateway.config import Config, TEEProvider as TEEProviderEnum
+from cmcp_gateway.errors import AttestationProviderUnsupported
+from cmcp_gateway.tee.base import SoftwareOnlyProvider, TEEProvider
+
+logger = logging.getLogger(__name__)
+
+# Detection probe order from docs/spec/attestation.md §1.1
+_PROBE_ORDER: list[str] = ["tpm", "sev-snp", "tdx", "opaque"]
+
+
+def _get_provider_impl(name: str) -> TEEProvider | None:
+    """Import and return a provider implementation by name, or None if not found."""
+    if name == "tpm":
+        try:
+            from cmcp_gateway.tee.tpm import TPMProvider
+            return TPMProvider()
+        except ImportError:
+            return None
+    if name == "sev-snp":
+        try:
+            from cmcp_gateway.tee.sev_snp import SEVSNPProvider
+            return SEVSNPProvider()
+        except ImportError:
+            return None
+    if name == "tdx":
+        try:
+            from cmcp_gateway.tee.tdx import TDXProvider
+            return TDXProvider()
+        except ImportError:
+            return None
+    if name == "opaque":
+        try:
+            from cmcp_gateway.tee.opaque import OpaqueProvider
+            return OpaqueProvider()
+        except ImportError:
+            return None
+    return None
+
+
+def detect_provider(config: Config) -> TEEProvider:
+    """
+    Detect and return the active TEE provider.
+
+    Follows the probe order from docs/spec/attestation.md §1.1:
+      tpm -> sev-snp -> tdx -> opaque
+
+    If no hardware provider is found:
+    - CMCP_DEV_MODE=1: returns SoftwareOnlyProvider with a WARN log
+    - Otherwise: raises AttestationProviderUnsupported (gateway must not start)
+
+    If config.attestation.provider is not "auto", only that provider is tried.
+    """
+    dev_mode = config.dev_mode or os.environ.get("CMCP_DEV_MODE", "0") == "1"
+
+    if config.attestation.provider != TEEProviderEnum.AUTO:
+        # Explicit provider requested
+        name = config.attestation.provider.value
+        if name == "software-only":
+            if not dev_mode:
+                raise AttestationProviderUnsupported(
+                    "provider=software-only requires CMCP_DEV_MODE=1"
+                )
+            logger.warning(
+                "Running in development mode — attestation is not hardware-backed. "
+                "TRACE Claims produced here must not be used for compliance purposes."
+            )
+            return SoftwareOnlyProvider()
+        impl = _get_provider_impl(name)
+        if impl is None or not impl.detect():
+            raise AttestationProviderUnsupported(
+                f"Requested provider '{name}' not available on this host",
+                detail="Check that the TEE hardware is present and accessible",
+            )
+        logger.info("TEE provider: %s (explicitly configured)", name)
+        return impl
+
+    # Auto-detection
+    for name in _PROBE_ORDER:
+        impl = _get_provider_impl(name)
+        if impl is not None and impl.detect():
+            logger.info("TEE provider: %s (auto-detected)", name)
+            return impl
+
+    # No hardware provider found
+    if dev_mode:
+        logger.warning(
+            "No hardware TEE detected. Running in development mode — "
+            "attestation is not hardware-backed. "
+            "TRACE Claims produced here must not be used for compliance purposes."
+        )
+        return SoftwareOnlyProvider()
+
+    raise AttestationProviderUnsupported(
+        "No supported TEE provider detected and CMCP_DEV_MODE is not set. "
+        "The gateway cannot start without hardware attestation. "
+        "Set CMCP_DEV_MODE=1 for local development.",
+        detail=f"Probed: {', '.join(_PROBE_ORDER)}",
+    )

--- a/tests/unit/test_tee.py
+++ b/tests/unit/test_tee.py
@@ -1,0 +1,130 @@
+"""Tests for TEE provider abstraction and dev mode (issues #72, #77)."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from cmcp_gateway.config import Config, AttestationConfig, TEEProvider as TEEProviderEnum
+from cmcp_gateway.errors import AttestationProviderUnsupported
+from cmcp_gateway.tee.base import SoftwareOnlyProvider, make_nonce
+from cmcp_gateway.tee.detect import detect_provider
+
+
+@pytest.fixture
+def dev_config() -> Config:
+    cfg = Config()
+    cfg.dev_mode = True
+    return cfg
+
+
+@pytest.fixture
+def no_dev_config() -> Config:
+    cfg = Config()
+    cfg.dev_mode = False
+    return cfg
+
+
+# ── SoftwareOnlyProvider ─────────────────────────────────────────────────────
+
+def test_software_only_detect():
+    assert SoftwareOnlyProvider().detect() is True
+
+
+def test_software_only_provider_name():
+    assert SoftwareOnlyProvider().provider_name() == "software-only"
+
+
+def test_software_only_report_fields():
+    provider = SoftwareOnlyProvider()
+    nonce = b"\x00" * 32
+    report = provider.get_attestation_report(nonce)
+    assert report.provider == "software-only"
+    assert report.measurement == "DEVELOPMENT_ONLY_NOT_FOR_PRODUCTION"
+    assert report.report_data == nonce.hex()
+    assert report.raw_evidence is None
+    assert isinstance(report.attestation_generated_at, datetime)
+    assert report.attestation_validity_seconds > 0
+
+
+def test_software_only_report_note():
+    report = SoftwareOnlyProvider().get_attestation_report(b"\x01" * 32)
+    assert report.measurement_note is not None
+    assert "software-only" in report.measurement_note
+
+
+# ── make_nonce ────────────────────────────────────────────────────────────────
+
+def test_make_nonce_deterministic():
+    key = b"\xab" * 32
+    sid = "session-123"
+    nonce1 = make_nonce(key, sid)
+    nonce2 = make_nonce(key, sid)
+    assert nonce1 == nonce2
+
+
+def test_make_nonce_sha256():
+    key = b"\x01" * 32
+    sid = "test"
+    expected = hashlib.sha256(key + sid.encode()).digest()
+    assert make_nonce(key, sid) == expected
+
+
+def test_make_nonce_different_inputs():
+    n1 = make_nonce(b"\x01" * 32, "a")
+    n2 = make_nonce(b"\x02" * 32, "a")
+    n3 = make_nonce(b"\x01" * 32, "b")
+    assert n1 != n2
+    assert n1 != n3
+
+
+# ── detect_provider ───────────────────────────────────────────────────────────
+
+def test_detect_returns_software_only_in_dev_mode(dev_config):
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None):
+        provider = detect_provider(dev_config)
+    assert isinstance(provider, SoftwareOnlyProvider)
+
+
+def test_detect_raises_when_no_hardware_and_no_dev_mode(no_dev_config):
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None):
+        with pytest.raises(AttestationProviderUnsupported):
+            detect_provider(no_dev_config)
+
+
+def test_detect_via_env_var(no_dev_config, monkeypatch):
+    monkeypatch.setenv("CMCP_DEV_MODE", "1")
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None):
+        provider = detect_provider(no_dev_config)
+    assert isinstance(provider, SoftwareOnlyProvider)
+
+
+def test_detect_uses_first_available_provider(dev_config):
+    """detect_provider picks the first provider whose detect() returns True."""
+    mock_provider = SoftwareOnlyProvider()  # reuse as a stand-in
+
+    def _mock_get(name: str):
+        if name == "sev-snp":
+            return mock_provider
+        return None
+
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", side_effect=_mock_get):
+        with patch.object(mock_provider, "detect", return_value=True):
+            provider = detect_provider(dev_config)
+    assert provider is mock_provider
+
+
+def test_detect_explicit_software_only_requires_dev_mode(no_dev_config):
+    no_dev_config.attestation.provider = TEEProviderEnum.SOFTWARE_ONLY
+    with pytest.raises(AttestationProviderUnsupported, match="CMCP_DEV_MODE"):
+        detect_provider(no_dev_config)
+
+
+def test_detect_explicit_software_only_with_dev_mode(dev_config):
+    dev_config.attestation.provider = TEEProviderEnum.SOFTWARE_ONLY
+    provider = detect_provider(dev_config)
+    assert isinstance(provider, SoftwareOnlyProvider)


### PR DESCRIPTION
Implements #72 and #77.

- `tee/base.py`: `AttestationReport` dataclass, `TEEProvider` ABC, `SoftwareOnlyProvider`, `make_nonce()`
- `tee/detect.py`: `detect_provider()` — auto-detection loop, CMCP_DEV_MODE fallback, explicit provider config
- Conformance: ATTEST-001 (no hardware + no dev mode → startup failure), ATTEST-002 (dev mode → software-only provider)
- 12 unit tests

Closes #72, #77