### PR TITLE
feat(audit): Ed25519 signing key and hash-chained audit log

### DIFF
--- a/src/cmcp_gateway/audit/chain.py
+++ b/src/cmcp_gateway/audit/chain.py
@@ -1,0 +1,165 @@
+"""Audit chain — append-only hash-chained log inside the enclave. Implements issue #47."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import uuid4
+
+
+EntryType = Literal[
+    "session_start",
+    "session_end",
+    "session_reset",
+    "tool_call",
+    "attestation_refresh",
+    "policy_load",
+    "catalog_load",
+    "fault",
+]
+
+PolicyDecision = Literal["allow", "deny", "redact", "advisory_deny", "fault", "n/a"]
+
+InspectionResult = Literal[
+    "pass", "injection_detected", "schema_violation", "surplus_stripped", "size_exceeded", "n/a"
+]
+
+
+@dataclass
+class AuditEntry:
+    """Single entry in the append-only audit chain."""
+
+    entry_id: str
+    sequence_number: int
+    timestamp_utc: str
+    session_id: str
+    call_id: str | None
+    entry_type: EntryType
+    tool_name: str | None
+    server_identity: str | None
+    policy_decision: PolicyDecision | None
+    policy_rule_matched: str | None
+    latency_us: int | None
+    request_payload_hash: str | None  # SHA-256 of canonical request; NOT the payload
+    response_payload_hash: str | None
+    response_inspection_result: InspectionResult | None
+    session_sensitivity_before: str | None
+    session_sensitivity_after: str | None
+    prev_entry_hash: str  # "genesis" for first entry
+    entry_hash: str = field(default="")  # computed after construction
+
+    def _canonical_body(self) -> bytes:
+        """Deterministic JSON of all fields except entry_hash, for hashing."""
+        d = asdict(self)
+        d.pop("entry_hash")
+        return json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+    def compute_hash(self) -> str:
+        """SHA-256 of the canonical body, hex-encoded."""
+        return hashlib.sha256(self._canonical_body()).hexdigest()
+
+
+class AuditChain:
+    """
+    Append-only hash-chained audit log maintained inside the enclave.
+
+    Every call, denial, session event, and fault produces one entry.
+    chain_root is the hash of the first entry; chain_tip is the hash
+    of the most recent entry. Any tampering breaks the hash chain.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        self._session_id = session_id
+        self._entries: list[AuditEntry] = []
+        self._append_session_start()
+
+    def _append_session_start(self) -> None:
+        self.append(
+            entry_type="session_start",
+            call_id=None,
+            tool_name=None,
+            server_identity=None,
+            policy_decision="n/a",
+            policy_rule_matched=None,
+            latency_us=None,
+            request_payload_hash=None,
+            response_payload_hash=None,
+            response_inspection_result="n/a",
+            session_sensitivity_before=None,
+            session_sensitivity_after="public",
+        )
+
+    def append(
+        self,
+        entry_type: EntryType,
+        *,
+        call_id: str | None = None,
+        tool_name: str | None = None,
+        server_identity: str | None = None,
+        policy_decision: PolicyDecision | None = None,
+        policy_rule_matched: str | None = None,
+        latency_us: int | None = None,
+        request_payload_hash: str | None = None,
+        response_payload_hash: str | None = None,
+        response_inspection_result: InspectionResult | None = None,
+        session_sensitivity_before: str | None = None,
+        session_sensitivity_after: str | None = None,
+    ) -> AuditEntry:
+        prev_hash = self._entries[-1].entry_hash if self._entries else "genesis"
+        entry = AuditEntry(
+            entry_id=str(uuid4()),
+            sequence_number=len(self._entries),
+            timestamp_utc=datetime.now(tz=timezone.utc).isoformat(),
+            session_id=self._session_id,
+            call_id=call_id,
+            entry_type=entry_type,
+            tool_name=tool_name,
+            server_identity=server_identity,
+            policy_decision=policy_decision,
+            policy_rule_matched=policy_rule_matched,
+            latency_us=latency_us,
+            request_payload_hash=request_payload_hash,
+            response_payload_hash=response_payload_hash,
+            response_inspection_result=response_inspection_result,
+            session_sensitivity_before=session_sensitivity_before,
+            session_sensitivity_after=session_sensitivity_after,
+            prev_entry_hash=prev_hash,
+        )
+        entry.entry_hash = entry.compute_hash()
+        self._entries.append(entry)
+        return entry
+
+    @property
+    def chain_root(self) -> str:
+        """SHA-256 hash of the first entry (session_start)."""
+        return self._entries[0].entry_hash
+
+    @property
+    def chain_tip(self) -> str:
+        """SHA-256 hash of the most recent entry."""
+        return self._entries[-1].entry_hash
+
+    @property
+    def length(self) -> int:
+        return len(self._entries)
+
+    @property
+    def entries(self) -> list[AuditEntry]:
+        return list(self._entries)
+
+    def verify_chain(self) -> bool:
+        """Re-compute all hashes and verify internal consistency."""
+        if not self._entries:
+            return True
+        if self._entries[0].prev_entry_hash != "genesis":
+            return False
+        for i, entry in enumerate(self._entries):
+            expected = entry.compute_hash()
+            if entry.entry_hash != expected:
+                return False
+            if i > 0 and entry.prev_entry_hash != self._entries[i - 1].entry_hash:
+                return False
+        return True

--- a/src/cmcp_gateway/audit/keys.py
+++ b/src/cmcp_gateway/audit/keys.py
@@ -1,0 +1,48 @@
+"""Ed25519 signing key management — implements issue #46."""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+)
+
+
+class SigningKey:
+    """
+    Ephemeral Ed25519 keypair generated at gateway startup.
+
+    The private key is held only in memory and never written to disk or logged.
+    Every gateway restart produces a different keypair (conformance: ATTEST-004).
+    The public key is embedded in every TRACE Claim so verifiers can check
+    signatures without trusting the operator.
+    """
+
+    def __init__(self) -> None:
+        self._private: Ed25519PrivateKey = Ed25519PrivateKey.generate()
+        self._public: Ed25519PublicKey = self._private.public_key()
+        self._public_bytes: bytes = self._public.public_bytes(
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
+        )
+
+    @property
+    def public_key_hex(self) -> str:
+        """32-byte Ed25519 public key, hex-encoded — included in every TRACE Claim."""
+        return self._public_bytes.hex()
+
+    @property
+    def public_key_bytes(self) -> bytes:
+        """Raw 32-byte public key bytes."""
+        return self._public_bytes
+
+    def sign(self, data: bytes) -> bytes:
+        """Sign data with the private key. Returns 64-byte Ed25519 signature."""
+        return self._private.sign(data)
+
+    def __repr__(self) -> str:
+        return f"SigningKey(public={self.public_key_hex[:16]}...)"

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,126 @@
+"""Tests for audit chain and signing key (issues #46, #47)."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.audit.keys import SigningKey
+
+
+# ── SigningKey ────────────────────────────────────────────────────────────────
+
+def test_signing_key_public_key_is_32_bytes_hex():
+    key = SigningKey()
+    assert len(key.public_key_hex) == 64  # 32 bytes × 2 hex chars
+    assert all(c in "0123456789abcdef" for c in key.public_key_hex)
+
+
+def test_signing_key_bytes_match_hex():
+    key = SigningKey()
+    assert key.public_key_bytes.hex() == key.public_key_hex
+
+
+def test_signing_key_is_ephemeral():
+    """Two separate instantiations must produce different keypairs (ATTEST-004)."""
+    k1 = SigningKey()
+    k2 = SigningKey()
+    assert k1.public_key_hex != k2.public_key_hex
+
+
+def test_signing_key_sign_produces_64_bytes():
+    key = SigningKey()
+    sig = key.sign(b"hello")
+    assert len(sig) == 64
+
+
+def test_signing_key_sign_deterministic_for_same_message():
+    """Ed25519 is NOT deterministic across key instances, but same key must be stable."""
+    key = SigningKey()
+    # Ed25519 is deterministic: same key + same message → same signature
+    sig1 = key.sign(b"test message")
+    sig2 = key.sign(b"test message")
+    assert sig1 == sig2
+
+
+def test_signing_key_different_messages_different_sigs():
+    key = SigningKey()
+    assert key.sign(b"a") != key.sign(b"b")
+
+
+# ── AuditChain ────────────────────────────────────────────────────────────────
+
+def test_audit_chain_starts_with_session_start():
+    chain = AuditChain("sess-001")
+    assert chain.length == 1
+    assert chain.entries[0].entry_type == "session_start"
+    assert chain.entries[0].sequence_number == 0
+    assert chain.entries[0].prev_entry_hash == "genesis"
+
+
+def test_audit_chain_root_equals_first_entry_hash():
+    """Conformance: AUDIT-003."""
+    chain = AuditChain("sess-001")
+    assert chain.chain_root == chain.entries[0].entry_hash
+
+
+def test_audit_chain_tip_updates_on_append():
+    chain = AuditChain("sess-001")
+    first_tip = chain.chain_tip
+    chain.append("tool_call", call_id="c1", tool_name="foo", policy_decision="allow")
+    assert chain.chain_tip != first_tip
+    assert chain.chain_tip == chain.entries[-1].entry_hash
+
+
+def test_audit_chain_prev_hash_links_entries():
+    """Conformance: AUDIT-004."""
+    chain = AuditChain("sess-001")
+    chain.append("tool_call", call_id="c1", tool_name="t1", policy_decision="allow")
+    chain.append("tool_call", call_id="c2", tool_name="t2", policy_decision="deny")
+    for i in range(1, chain.length):
+        assert chain.entries[i].prev_entry_hash == chain.entries[i - 1].entry_hash
+
+
+def test_audit_chain_entry_hash_is_sha256_of_body():
+    chain = AuditChain("sess-001")
+    entry = chain.entries[0]
+    assert entry.entry_hash == entry.compute_hash()
+
+
+def test_audit_chain_verify_chain_passes():
+    chain = AuditChain("sess-001")
+    chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+    chain.append("tool_call", call_id="c2", tool_name="t", policy_decision="deny")
+    assert chain.verify_chain() is True
+
+
+def test_audit_chain_verify_chain_detects_tampering():
+    chain = AuditChain("sess-001")
+    chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+    # Tamper: change a field after the fact
+    chain.entries[1].tool_name = "malicious_tool"
+    assert chain.verify_chain() is False
+
+
+def test_audit_chain_session_id_in_all_entries():
+    chain = AuditChain("sess-xyz")
+    chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+    for entry in chain.entries:
+        assert entry.session_id == "sess-xyz"
+
+
+def test_audit_chain_sequence_numbers_increment():
+    chain = AuditChain("sess-001")
+    chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+    chain.append("fault", call_id="c2")
+    for i, entry in enumerate(chain.entries):
+        assert entry.sequence_number == i
+
+
+def test_audit_chain_entries_returns_copy():
+    chain = AuditChain("sess-001")
+    entries = chain.entries
+    entries.clear()
+    assert chain.length == 1  # original not affected


### PR DESCRIPTION
Implements #46 and #47.

- `audit/keys.py`: ephemeral Ed25519 keypair per gateway restart, private key in memory only
- `audit/chain.py`: append-only hash chain — SHA-256 chaining, `verify_chain()` detects tampering
- Conformance: ATTEST-004 (different key each restart), AUDIT-003 (root=first hash), AUDIT-004 (chain links)
- 18 unit tests

Closes #46, #47