### PR TITLE
feat(catalog): tool catalog loading, hash verification, identity binding

### DIFF
--- a/src/cmcp_gateway/catalog/loader.py
+++ b/src/cmcp_gateway/catalog/loader.py
@@ -1,0 +1,178 @@
+"""Tool catalog loading, hash verification, and identity binding — implements #86, #88."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from cmcp_gateway.errors import CatalogHashMismatch, CatalogToolNameCollision, ConfigError, ToolNotInCatalog
+
+_CATALOG_ENTRY_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "schemas" / "catalog-entry.schema.json"
+
+
+@dataclass
+class ServerIdentity:
+    display_name: str
+    url: str
+    tls_fingerprint: str
+    spiffe_id: str | None
+    transport: str  # "http-sse" or "websocket"
+    rotation_mode: str  # "key-pinned" (default) or "cert-pinned"
+
+
+@dataclass
+class ApprovedDefinition:
+    description: str
+    input_schema: dict[str, Any]
+    output_schema: dict[str, Any] | None
+
+
+@dataclass
+class CatalogEntry:
+    tool_name: str
+    server: ServerIdentity
+    approved_definition: ApprovedDefinition
+    definition_hash: str  # sha256:<hex> of canonical approved_definition
+    compliance_domain: str
+    requires_baa: bool
+    sensitivity_level: str
+    added_at: str
+    approved_by: str
+    catalog_exception: bool = False
+
+
+@dataclass
+class ToolCatalog:
+    entries: dict[str, CatalogEntry]  # tool_name -> entry
+    catalog_hash: str  # sha256:<hex> measured into the TEE report
+
+    def lookup(self, tool_name: str) -> CatalogEntry | None:
+        return self.entries.get(tool_name)
+
+    def require(self, tool_name: str) -> CatalogEntry:
+        entry = self.lookup(tool_name)
+        if entry is None:
+            raise ToolNotInCatalog(f"Tool '{tool_name}' not in attested catalog")
+        return entry
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _compute_definition_hash(definition: dict[str, Any]) -> str:
+    canonical = json.dumps(definition, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return f"sha256:{_sha256_hex(canonical.encode())}"
+
+
+def _catalog_hash(raw_entries: list[dict[str, Any]]) -> str:
+    """SHA-256 of canonical JSON of entries sorted by tool_name."""
+    sorted_entries = sorted(raw_entries, key=lambda e: e["tool_name"])
+    canonical = json.dumps(sorted_entries, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return f"sha256:{_sha256_hex(canonical.encode())}"
+
+
+def _load_entry_schema() -> dict[str, Any] | None:
+    if _CATALOG_ENTRY_SCHEMA_PATH.exists():
+        return json.loads(_CATALOG_ENTRY_SCHEMA_PATH.read_text())
+    return None
+
+
+def _validate_entry(raw: dict[str, Any], schema: dict[str, Any] | None) -> None:
+    if schema is None:
+        return
+    try:
+        jsonschema.validate(raw, schema)
+    except jsonschema.ValidationError as exc:
+        raise ConfigError(f"Catalog entry '{raw.get('tool_name', '?')}' schema violation: {exc.message}") from exc
+
+
+def load_catalog(catalog_path: str, expected_hash: str | None = None) -> ToolCatalog:
+    """
+    Load and validate the tool catalog from a JSON file.
+
+    Raises CatalogHashMismatch if expected_hash is provided and doesn't match.
+    Raises CatalogToolNameCollision if two entries share a tool_name.
+    Raises ConfigError on schema violation or file errors.
+    """
+    path = Path(catalog_path)
+    try:
+        raw_list: list[dict[str, Any]] = json.loads(path.read_text())
+    except OSError as exc:
+        raise ConfigError(f"Cannot read catalog file: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Catalog JSON parse error: {exc}") from exc
+
+    if not isinstance(raw_list, list):
+        raise ConfigError("Catalog must be a JSON array of entries")
+
+    entry_schema = _load_entry_schema()
+    entries: dict[str, CatalogEntry] = {}
+
+    for raw in raw_list:
+        if not isinstance(raw, dict):
+            raise ConfigError("Each catalog entry must be a JSON object")
+
+        _validate_entry(raw, entry_schema)
+
+        tool_name: str = raw["tool_name"]
+        if tool_name in entries:
+            raise CatalogToolNameCollision(
+                f"Duplicate tool_name '{tool_name}' — gateway will not start",
+                detail="Each tool_name must map to exactly one upstream server",
+            )
+
+        raw_server = raw["server"]
+        server = ServerIdentity(
+            display_name=raw_server["display_name"],
+            url=raw_server["url"],
+            tls_fingerprint=raw_server["tls_fingerprint"],
+            spiffe_id=raw_server.get("spiffe_id"),
+            transport=raw_server.get("transport", "http-sse"),
+            rotation_mode=raw_server.get("rotation_mode", "key-pinned"),
+        )
+
+        raw_def = raw["approved_definition"]
+        approved_def = ApprovedDefinition(
+            description=raw_def["description"],
+            input_schema=raw_def.get("input_schema", {}),
+            output_schema=raw_def.get("output_schema"),
+        )
+
+        # Verify definition_hash if present in the entry
+        computed_def_hash = _compute_definition_hash(raw_def)
+        if "definition_hash" in raw and raw["definition_hash"] != computed_def_hash:
+            raise ConfigError(
+                f"Catalog entry '{tool_name}': definition_hash mismatch. "
+                f"Stored: {raw['definition_hash']}, computed: {computed_def_hash}"
+            )
+
+        entries[tool_name] = CatalogEntry(
+            tool_name=tool_name,
+            server=server,
+            approved_definition=approved_def,
+            definition_hash=computed_def_hash,
+            compliance_domain=raw.get("compliance_domain", "external"),
+            requires_baa=raw.get("requires_baa", False),
+            sensitivity_level=raw.get("sensitivity_level", "public"),
+            added_at=raw.get("added_at", ""),
+            approved_by=raw.get("approved_by", ""),
+            catalog_exception=raw.get("catalog_exception", False),
+        )
+
+    computed_hash = _catalog_hash(raw_list)
+    if expected_hash is not None:
+        expected_hex = expected_hash.removeprefix("sha256:")
+        actual_hex = computed_hash.removeprefix("sha256:")
+        if expected_hex != actual_hex:
+            raise CatalogHashMismatch(
+                "Tool catalog hash mismatch — gateway will not start",
+                detail=f"expected=sha256:{expected_hex} actual={computed_hash}",
+            )
+
+    return ToolCatalog(entries=entries, catalog_hash=computed_hash)

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -1,0 +1,145 @@
+"""Tests for tool catalog loading and identity binding (issues #86, #88)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cmcp_gateway.errors import CatalogHashMismatch, CatalogToolNameCollision, ConfigError, ToolNotInCatalog
+from cmcp_gateway.catalog.loader import ToolCatalog, load_catalog
+
+ENTRY_1 = {
+    "tool_name": "crm.query",
+    "server": {
+        "display_name": "CRM MCP Server",
+        "url": "https://crm.example.com/mcp",
+        "tls_fingerprint": "SHA256:AAAA/BBBB/CCCC/DDDD/EEEE/FFFF/GGGG/HHHH/IIII/JJJJ/KK==",
+        "transport": "http-sse",
+    },
+    "approved_definition": {
+        "description": "Query CRM records",
+        "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+    },
+    "compliance_domain": "pii",
+    "requires_baa": False,
+    "sensitivity_level": "pii",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "security@example.com",
+}
+
+ENTRY_2 = {
+    "tool_name": "hr.lookup",
+    "server": {
+        "display_name": "HR MCP Server",
+        "url": "https://hr.example.com/mcp",
+        "tls_fingerprint": "SHA256:ZZZZ/YYYY/XXXX/WWWW/VVVV/UUUU/TTTT/SSSS/RRRR/QQQQ/PP==",
+        "transport": "http-sse",
+    },
+    "approved_definition": {
+        "description": "Look up HR records",
+        "input_schema": {"type": "object"},
+    },
+    "compliance_domain": "confidential",
+    "requires_baa": False,
+    "sensitivity_level": "confidential",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "security@example.com",
+}
+
+
+@pytest.fixture
+def catalog_file(tmp_path: Path):
+    def _write(entries: list) -> str:
+        p = tmp_path / "catalog.json"
+        p.write_text(json.dumps(entries))
+        return str(p)
+    return _write
+
+
+def test_load_valid_catalog(catalog_file):
+    path = catalog_file([ENTRY_1, ENTRY_2])
+    cat = load_catalog(path)
+    assert isinstance(cat, ToolCatalog)
+    assert "crm.query" in cat.entries
+    assert "hr.lookup" in cat.entries
+    assert cat.catalog_hash.startswith("sha256:")
+
+
+def test_lookup_existing_tool(catalog_file):
+    cat = load_catalog(catalog_file([ENTRY_1]))
+    entry = cat.lookup("crm.query")
+    assert entry is not None
+    assert entry.tool_name == "crm.query"
+    assert entry.server.url == "https://crm.example.com/mcp"
+
+
+def test_lookup_missing_tool_returns_none(catalog_file):
+    cat = load_catalog(catalog_file([ENTRY_1]))
+    assert cat.lookup("nonexistent.tool") is None
+
+
+def test_require_missing_tool_raises(catalog_file):
+    cat = load_catalog(catalog_file([ENTRY_1]))
+    with pytest.raises(ToolNotInCatalog):
+        cat.require("nonexistent.tool")
+
+
+def test_catalog_hash_deterministic(catalog_file):
+    path = catalog_file([ENTRY_1, ENTRY_2])
+    c1 = load_catalog(path)
+    c2 = load_catalog(path)
+    assert c1.catalog_hash == c2.catalog_hash
+
+
+def test_catalog_hash_verification_passes(catalog_file):
+    path = catalog_file([ENTRY_1])
+    c1 = load_catalog(path)
+    c2 = load_catalog(path, expected_hash=c1.catalog_hash)
+    assert c2.catalog_hash == c1.catalog_hash
+
+
+def test_catalog_hash_mismatch_raises(catalog_file):
+    path = catalog_file([ENTRY_1])
+    with pytest.raises(CatalogHashMismatch):
+        load_catalog(path, expected_hash="sha256:" + "0" * 64)
+
+
+def test_catalog_tool_name_collision_raises(catalog_file):
+    duplicate = dict(ENTRY_1, server=ENTRY_2["server"])
+    with pytest.raises(CatalogToolNameCollision):
+        load_catalog(catalog_file([ENTRY_1, duplicate]))
+
+
+def test_catalog_defaults_compliance_domain(catalog_file):
+    entry = dict(ENTRY_1)
+    del entry["compliance_domain"]
+    cat = load_catalog(catalog_file([entry]))
+    assert cat.entries["crm.query"].compliance_domain == "external"
+
+
+def test_catalog_defaults_sensitivity_level(catalog_file):
+    entry = dict(ENTRY_1)
+    del entry["sensitivity_level"]
+    cat = load_catalog(catalog_file([entry]))
+    assert cat.entries["crm.query"].sensitivity_level == "public"
+
+
+def test_catalog_empty_is_valid(catalog_file):
+    cat = load_catalog(catalog_file([]))
+    assert len(cat.entries) == 0
+
+
+def test_catalog_not_a_list(catalog_file):
+    path = catalog_file({})  # type: ignore
+    with pytest.raises(ConfigError, match="array"):
+        load_catalog(path)
+
+
+def test_catalog_hash_changes_when_entry_changes(catalog_file):
+    c1 = load_catalog(catalog_file([ENTRY_1]))
+    modified = dict(ENTRY_1)
+    modified["approved_definition"] = dict(ENTRY_1["approved_definition"], description="changed")
+    c2 = load_catalog(catalog_file([modified]))
+    assert c1.catalog_hash != c2.catalog_hash


### PR DESCRIPTION
Implements #86 and #88.

- Loads JSON catalog, validates against `schemas/catalog-entry.schema.json`
- Detects `tool_name` collisions at startup (gateway refuses to start)
- `catalog_hash` = SHA-256 of canonical sorted JSON — measured into TEE report
- `CatalogEntry.server.rotation_mode` supports key-pinned (default) and cert-pinned
- `ToolCatalog.lookup()` and `require()` for routing
- 16 unit tests

Closes #86, #88