### PR TITLE
feat(session): session sensitivity state machine

### DIFF
--- a/src/cmcp_gateway/session/state.py
+++ b/src/cmcp_gateway/session/state.py
@@ -1,0 +1,98 @@
+"""Session sensitivity state machine — implements issue #84."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+# Sensitivity level ordering — monotonically increasing only.
+# hipaa_phi, mnpi, trade_secret are all at level 3 (equal highest).
+SENSITIVITY_ORDER: dict[str, int] = {
+    "public": 0,
+    "pii": 1,
+    "confidential": 2,
+    "hipaa_phi": 3,
+    "mnpi": 3,
+    "trade_secret": 3,
+}
+
+
+def _max_sensitivity(a: str, b: str) -> str:
+    """Return whichever sensitivity level is higher. Ties return 'a'."""
+    if SENSITIVITY_ORDER.get(b, 0) > SENSITIVITY_ORDER.get(a, 0):
+        return b
+    return a
+
+
+@dataclass
+class InjectionEvent:
+    call_id: str
+    timestamp: str
+
+
+@dataclass
+class SessionState:
+    """
+    Per-session sensitivity state machine.
+
+    State transitions are monotonically increasing — sensitivity can only rise,
+    never fall automatically. A session reset (operator-only, issue #92) is the
+    only way to lower sensitivity.
+
+    update_from_inspection() is the ONLY place where session sensitivity state
+    is updated. It is called by InspectionPipeline after all inspection stages
+    complete, including for denied responses (a denied high-sensitivity response
+    still raises session sensitivity because the agent knows the call was attempted).
+    """
+
+    session_id: str
+    max_sensitivity: str = "public"
+    sensitivity_raised_at: str | None = None
+    sensitivity_raised_by_call: str | None = None
+    injection_events: list[InjectionEvent] = field(default_factory=list)
+    reset_count: int = 0
+
+    def update_from_inspection(
+        self,
+        call_id: str,
+        sensitivity_tags: list[str],
+        injection_detected: bool,
+        response_allowed: bool,  # noqa: ARG002 — logged for future use
+    ) -> None:
+        """
+        Update session state from an inspection result.
+
+        Called by InspectionPipeline after all stages complete.
+        """
+        for tag in sensitivity_tags:
+            new_max = _max_sensitivity(self.max_sensitivity, tag)
+            if new_max != self.max_sensitivity:
+                self.max_sensitivity = new_max
+                self.sensitivity_raised_at = datetime.now(tz=timezone.utc).isoformat()
+                self.sensitivity_raised_by_call = call_id
+
+        if injection_detected:
+            self.injection_events.append(
+                InjectionEvent(
+                    call_id=call_id,
+                    timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                )
+            )
+
+    def reset(self, *, reason: str, authorized_by: str) -> tuple[str, str]:
+        """
+        Reset session sensitivity to 'public'. Returns (previous_session_id, new_session_id).
+
+        This is an operator-only action. The caller is responsible for writing
+        the session_reset audit entry.
+        """
+        previous_session_id = self.session_id
+        self.session_id = str(uuid4())
+        self.max_sensitivity = "public"
+        self.sensitivity_raised_at = None
+        self.sensitivity_raised_by_call = None
+        self.reset_count += 1
+        # reason and authorized_by are logged by the caller in the audit chain
+        return previous_session_id, self.session_id

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,112 @@
+"""Tests for session sensitivity state machine (issue #84)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cmcp_gateway.session.state import SENSITIVITY_ORDER, SessionState, _max_sensitivity
+
+
+# ── _max_sensitivity ──────────────────────────────────────────────────────────
+
+def test_max_sensitivity_prefers_higher():
+    assert _max_sensitivity("public", "pii") == "pii"
+    assert _max_sensitivity("pii", "public") == "pii"
+    assert _max_sensitivity("pii", "confidential") == "confidential"
+    assert _max_sensitivity("confidential", "hipaa_phi") == "hipaa_phi"
+
+
+def test_max_sensitivity_equal_returns_first():
+    # hipaa_phi and mnpi are equal level
+    assert _max_sensitivity("hipaa_phi", "mnpi") == "hipaa_phi"
+
+
+def test_sensitivity_order_monotonic():
+    levels = ["public", "pii", "confidential"]
+    for i in range(len(levels) - 1):
+        assert SENSITIVITY_ORDER[levels[i]] < SENSITIVITY_ORDER[levels[i + 1]]
+
+
+# ── SessionState ──────────────────────────────────────────────────────────────
+
+def test_initial_sensitivity_is_public():
+    state = SessionState(session_id="s1")
+    assert state.max_sensitivity == "public"
+
+
+def test_update_raises_sensitivity():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", sensitivity_tags=["pii"], injection_detected=False, response_allowed=True)
+    assert state.max_sensitivity == "pii"
+
+
+def test_update_is_monotonically_increasing():
+    """Sensitivity never decreases automatically."""
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["hipaa_phi"], False, True)
+    state.update_from_inspection("c2", ["public"], False, True)
+    assert state.max_sensitivity == "hipaa_phi"
+
+
+def test_update_records_raising_call():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["pii"], False, True)
+    assert state.sensitivity_raised_by_call == "c1"
+    assert state.sensitivity_raised_at is not None
+
+
+def test_update_no_raise_keeps_none():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", [], False, True)
+    assert state.sensitivity_raised_by_call is None
+
+
+def test_update_records_injection_event():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", [], injection_detected=True, response_allowed=False)
+    assert len(state.injection_events) == 1
+    assert state.injection_events[0].call_id == "c1"
+
+
+def test_update_raises_sensitivity_on_denied_response():
+    """Denied high-sensitivity response still raises session sensitivity."""
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["mnpi"], injection_detected=False, response_allowed=False)
+    assert state.max_sensitivity == "mnpi"
+
+
+def test_multiple_updates_accumulate_injection_events():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", [], True, False)
+    state.update_from_inspection("c2", [], True, False)
+    assert len(state.injection_events) == 2
+
+
+def test_reset_lowers_sensitivity():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["hipaa_phi"], False, True)
+    assert state.max_sensitivity == "hipaa_phi"
+    state.reset(reason="task switch", authorized_by="operator@example.com")
+    assert state.max_sensitivity == "public"
+
+
+def test_reset_generates_new_session_id():
+    state = SessionState(session_id="s1")
+    prev, new = state.reset(reason="test", authorized_by="op")
+    assert prev == "s1"
+    assert new != "s1"
+    assert state.session_id == new
+
+
+def test_reset_increments_reset_count():
+    state = SessionState(session_id="s1")
+    state.reset(reason="r1", authorized_by="op")
+    state.reset(reason="r2", authorized_by="op")
+    assert state.reset_count == 2
+
+
+def test_update_highest_tag_wins_per_update():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["pii", "mnpi", "confidential"], False, True)
+    assert state.max_sensitivity in ("mnpi", "hipaa_phi", "trade_secret")
+    assert SENSITIVITY_ORDER[state.max_sensitivity] == 3


### PR DESCRIPTION
Implements #84.

- `SessionState.update_from_inspection()`: monotonically increasing sensitivity, records raising call, appends injection events — called by inspection pipeline (only update point)
- `reset()`: operator-only, lowers sensitivity, generates new session_id
- `SENSITIVITY_ORDER`: public(0) < pii(1) < confidential(2) < hipaa_phi=mnpi=trade_secret(3)
- 15 unit tests

Closes #84