### PR TITLE
feat(assembly): gateway startup sequence — ordered fail-closed validation

### DIFF
--- a/src/cmcp_gateway/startup.py
+++ b/src/cmcp_gateway/startup.py
@@ -1,0 +1,162 @@
+"""Gateway startup sequence with fail-closed validation — implements issue #66."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from cmcp_gateway.audit.keys import SigningKey
+from cmcp_gateway.catalog.loader import ToolCatalog, load_catalog
+from cmcp_gateway.config import Config, load_config
+from cmcp_gateway.errors import (
+    AttestationProviderUnsupported,
+    CatalogHashMismatch,
+    CatalogToolNameCollision,
+    ConfigError,
+    PolicyHashMismatch,
+)
+from cmcp_gateway.policy.bundle import PolicyBundle, load_policy_bundle
+from cmcp_gateway.tee.base import AttestationReport, TEEProvider
+from cmcp_gateway.tee.detect import detect_provider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GatewayContext:
+    """All validated components ready for the gateway to use."""
+
+    config: Config
+    tee_provider: TEEProvider
+    attestation_report: AttestationReport
+    signing_key: SigningKey
+    policy_bundle: PolicyBundle
+    catalog: ToolCatalog
+
+
+def _fatal(code: str, message: str, **fields: Any) -> None:
+    """Log a FATAL structured entry and exit with code 1."""
+    entry = {
+        "level": "FATAL",
+        "event": code,
+        "message": message,
+        **fields,
+    }
+    logger.critical("%s", entry)
+
+
+def run_startup(config_path: str) -> GatewayContext:
+    """
+    Execute the ordered startup sequence. Any failure before step 6 (network bind)
+    is fatal — the gateway exits with code 1.
+
+    Startup order per docs/spec/failure-modes.md:
+    1. Load and validate config
+    2. Detect TEE provider and attest
+    3. Generate ephemeral signing keypair
+    4. Load and verify policy bundle hash
+    5. Load and verify catalog hash
+    (Step 6: bind network port — done by the caller after this returns)
+    """
+    # Step 1: config
+    try:
+        config = load_config(config_path)
+    except ConfigError as exc:
+        _fatal("CONFIG_ERROR", str(exc))
+        sys.exit(1)
+
+    # Step 2: TEE detection and attestation
+    try:
+        tee_provider = detect_provider(config)
+    except AttestationProviderUnsupported as exc:
+        _fatal(
+            "ATTESTATION_PROVIDER_UNSUPPORTED",
+            str(exc),
+            detail=exc.detail or "",
+            action="startup_aborted",
+        )
+        sys.exit(1)
+
+    # Step 3: signing key
+    signing_key = SigningKey()
+    logger.info("Signing key generated: %s...", signing_key.public_key_hex[:16])
+
+    # Attest with nonce = SHA-256(public_key || "startup")
+    import hashlib
+    nonce = hashlib.sha256(signing_key.public_key_bytes + b"startup").digest()
+    try:
+        attestation_report = tee_provider.get_attestation_report(nonce)
+    except Exception as exc:
+        _fatal(
+            "ATTESTATION_REPORT_UNAVAILABLE",
+            f"TEE provider '{tee_provider.provider_name()}' failed to produce attestation report",
+            error=str(exc),
+            action="startup_aborted",
+        )
+        sys.exit(1)
+
+    logger.info(
+        "TEE attestation complete: provider=%s measurement=%s...",
+        attestation_report.provider,
+        attestation_report.measurement[:16],
+    )
+
+    # Step 4: policy bundle
+    policy_expected_hash = os.environ.get("CMCP_POLICY_HASH")
+    try:
+        policy_bundle = load_policy_bundle(config.policy_bundle_path, expected_hash=policy_expected_hash)
+    except PolicyHashMismatch as exc:
+        _fatal(
+            "POLICY_HASH_MISMATCH",
+            str(exc),
+            detail=exc.detail or "",
+            action="startup_aborted",
+        )
+        sys.exit(1)
+    except ConfigError as exc:
+        _fatal("CONFIG_ERROR", f"Policy bundle invalid: {exc}")
+        sys.exit(1)
+
+    logger.info("Policy bundle loaded: hash=%s", policy_bundle.bundle_hash)
+
+    # Step 5: catalog
+    catalog_expected_hash = os.environ.get("CMCP_CATALOG_HASH")
+    try:
+        catalog = load_catalog(config.catalog_path, expected_hash=catalog_expected_hash)
+    except CatalogHashMismatch as exc:
+        _fatal(
+            "CATALOG_HASH_MISMATCH",
+            str(exc),
+            detail=exc.detail or "",
+            action="startup_aborted",
+        )
+        sys.exit(1)
+    except CatalogToolNameCollision as exc:
+        _fatal(
+            "CATALOG_TOOL_NAME_COLLISION",
+            str(exc),
+            detail=exc.detail or "",
+            action="startup_aborted",
+        )
+        sys.exit(1)
+    except ConfigError as exc:
+        _fatal("CONFIG_ERROR", f"Catalog invalid: {exc}")
+        sys.exit(1)
+
+    logger.info(
+        "Catalog loaded: %d tools, hash=%s",
+        len(catalog.entries),
+        catalog.catalog_hash,
+    )
+
+    return GatewayContext(
+        config=config,
+        tee_provider=tee_provider,
+        attestation_report=attestation_report,
+        signing_key=signing_key,
+        policy_bundle=policy_bundle,
+        catalog=catalog,
+    )

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -1,0 +1,120 @@
+"""Tests for startup sequence and failure handling (issue #66)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cmcp_gateway.startup import GatewayContext, run_startup
+
+
+MANIFEST = {
+    "version": "1.0.0",
+    "authored_at": "2026-06-04T00:00:00Z",
+    "author_identity": "test@example.com",
+    "commit_sha": "abc123",
+}
+
+CEDAR_POLICY = 'permit(principal, action, resource) when { true };'
+SCHEMA = '{"cMCP": {}}'
+
+CATALOG_ENTRY = {
+    "tool_name": "test.tool",
+    "server": {
+        "display_name": "Test",
+        "url": "https://test.example.com/mcp",
+        "tls_fingerprint": "SHA256:AAAA/BBBB/CCCC/DDDD/EEEE/FFFF/GGGG/HHHH/IIII/JJJJ/KK==",
+        "transport": "http-sse",
+    },
+    "approved_definition": {"description": "test", "input_schema": {}},
+    "compliance_domain": "external",
+    "requires_baa": False,
+    "sensitivity_level": "public",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "test",
+}
+
+
+@pytest.fixture
+def complete_setup(tmp_path: Path, monkeypatch):
+    """Set up a complete valid config + policy + catalog for startup tests."""
+    monkeypatch.setenv("CMCP_DEV_MODE", "1")
+
+    # Config
+    config_path = tmp_path / "cmcp-config.yaml"
+    policy_dir = tmp_path / "policy"
+    policy_dir.mkdir()
+    catalog_path = tmp_path / "catalog.json"
+
+    config_path.write_text(
+        f"policy_bundle_path: {policy_dir}\ncatalog_path: {catalog_path}\n"
+    )
+    (policy_dir / "manifest.json").write_text(json.dumps(MANIFEST))
+    (policy_dir / "allow.cedar").write_text(CEDAR_POLICY)
+    (policy_dir / "schema.cedarschema").write_text(SCHEMA)
+    catalog_path.write_text(json.dumps([CATALOG_ENTRY]))
+
+    return str(config_path)
+
+
+def test_startup_succeeds_in_dev_mode(complete_setup):
+    ctx = run_startup(complete_setup)
+    assert isinstance(ctx, GatewayContext)
+    assert ctx.config.dev_mode is True
+    assert ctx.signing_key is not None
+    assert ctx.policy_bundle is not None
+    assert ctx.catalog is not None
+
+
+def test_startup_returns_gateway_context_with_all_fields(complete_setup):
+    ctx = run_startup(complete_setup)
+    assert ctx.tee_provider is not None
+    assert ctx.attestation_report is not None
+    assert ctx.attestation_report.provider == "software-only"
+
+
+def test_startup_fails_on_missing_config(tmp_path):
+    """Conformance: startup exits on invalid config."""
+    with pytest.raises(SystemExit) as exc_info:
+        run_startup(str(tmp_path / "nonexistent.yaml"))
+    assert exc_info.value.code == 1
+
+
+def test_startup_fails_on_no_tee_no_dev_mode(tmp_path):
+    """Conformance: ATTEST-001 — no hardware TEE + no dev mode → exit 1."""
+    config_path = tmp_path / "cmcp-config.yaml"
+    policy_dir = tmp_path / "policy"
+    policy_dir.mkdir()
+    catalog_path = tmp_path / "catalog.json"
+    config_path.write_text(f"policy_bundle_path: {policy_dir}\ncatalog_path: {catalog_path}\n")
+    (policy_dir / "manifest.json").write_text(json.dumps(MANIFEST))
+    (policy_dir / "allow.cedar").write_text(CEDAR_POLICY)
+    (policy_dir / "schema.cedarschema").write_text(SCHEMA)
+    catalog_path.write_text("[]")
+
+    # No CMCP_DEV_MODE, no hardware TEE → should exit 1
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                run_startup(str(config_path))
+    assert exc_info.value.code == 1
+
+
+def test_startup_fails_on_policy_hash_mismatch(complete_setup, monkeypatch):
+    """Conformance: POLICY_HASH_MISMATCH → exit 1."""
+    monkeypatch.setenv("CMCP_POLICY_HASH", "sha256:" + "0" * 64)
+    with pytest.raises(SystemExit) as exc_info:
+        run_startup(complete_setup)
+    assert exc_info.value.code == 1
+
+
+def test_startup_fails_on_catalog_hash_mismatch(complete_setup, monkeypatch):
+    """Conformance: CATALOG_HASH_MISMATCH → exit 1."""
+    monkeypatch.setenv("CMCP_CATALOG_HASH", "sha256:" + "0" * 64)
+    with pytest.raises(SystemExit) as exc_info:
+        run_startup(complete_setup)
+    assert exc_info.value.code == 1


### PR DESCRIPTION
Implements #66.

Ordered startup: config → TEE detect+attest → signing key → policy hash → catalog hash. Any failure before network bind exits with code 1 and a structured FATAL log.

- ATTEST-001: no hardware + no dev mode → exit 1
- POLICY_HASH_MISMATCH and CATALOG_HASH_MISMATCH → exit 1
- Expected hashes from `CMCP_POLICY_HASH` / `CMCP_CATALOG_HASH` env vars
- 7 unit tests

Closes #66