### PR TITLE
feat(policy): Cedar evaluation via AGT CedarBackend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.29",
     "click>=8.1",
+    "agent-os-kernel>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cmcp_gateway/policy/evaluator.py
+++ b/src/cmcp_gateway/policy/evaluator.py
@@ -1,0 +1,132 @@
+"""
+Cedar policy evaluation via AGT's CedarBackend — implements issues #68, #73.
+
+AGT provides three evaluation modes: cedarpy (native Python), cli (subprocess),
+and builtin (mock). cMCP selects the best available mode at instantiation and
+measures the policy bundle hash into the TEE attestation report separately.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from agent_os.policies.backends import CedarBackend
+
+from cmcp_gateway.config import Config, EnforcementMode
+from cmcp_gateway.errors import PolicyDeny
+from cmcp_gateway.policy.bundle import PolicyBundle
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PolicyDecision:
+    """Result of a Cedar policy evaluation."""
+
+    allowed: bool
+    enforcement_mode: EnforcementMode
+    rule_matched: str | None
+    advice: dict[str, Any]
+    evaluation_ms: float
+    # In advisory mode, allowed=True even when Cedar said deny:
+    would_have_denied: bool = False
+
+
+class PolicyEvaluator:
+    """
+    Wraps AGT's CedarBackend with cMCP enforcement modes.
+
+    The bundle is loaded and hash-verified by load_policy_bundle() before this
+    class is instantiated. CedarBackend receives the already-loaded policy content
+    so the measured hash covers exactly the bytes that will be evaluated.
+    """
+
+    def __init__(self, bundle: PolicyBundle, config: Config) -> None:
+        self._mode = config.attestation.enforcement_mode
+        self._bundle = bundle
+
+        # Concatenate all Cedar policy files into one string for CedarBackend.
+        # Files are sorted by name to match the hash computation in bundle.py.
+        combined_policy = "\n\n".join(
+            content for _, content in sorted(bundle.policy_files.items())
+        )
+
+        self._backend = CedarBackend(
+            policy_content=combined_policy,
+            mode="auto",  # cedarpy > cli > builtin
+        )
+        logger.info(
+            "PolicyEvaluator ready: bundle_hash=%s enforcement=%s backend=%s",
+            bundle.bundle_hash,
+            self._mode.value,
+            self._backend.__class__.__name__,
+        )
+
+    def evaluate(self, context: dict[str, Any]) -> PolicyDecision:
+        """
+        Evaluate a tool call against the Cedar policy bundle.
+
+        context must contain at minimum:
+          - tool_name: str
+          - session_max_sensitivity: str
+          - workflow_id: str  (defaults to "default")
+
+        Raises PolicyDeny if enforcement_mode is ENFORCING and Cedar denies.
+        In ADVISORY mode, always returns allowed=True but sets would_have_denied.
+        In SILENT mode, always returns allowed=True with no logging.
+        """
+        result = self._backend.evaluate(context)
+        allowed_by_cedar = result.allowed
+        evaluation_ms = result.evaluation_ms or 0.0
+        rule = result.reason or None
+
+        # Apply enforcement mode
+        if allowed_by_cedar:
+            return PolicyDecision(
+                allowed=True,
+                enforcement_mode=self._mode,
+                rule_matched=rule,
+                advice={},
+                evaluation_ms=evaluation_ms,
+            )
+
+        # Cedar denied — apply enforcement mode
+        if self._mode == EnforcementMode.ENFORCING:
+            raise PolicyDeny(
+                f"Policy denied tool call: {context.get('tool_name', '?')}",
+                detail=f"rule={rule} eval_ms={evaluation_ms:.2f}",
+            )
+
+        if self._mode == EnforcementMode.ADVISORY:
+            logger.info(
+                "ADVISORY deny (allowed through): tool=%s rule=%s",
+                context.get("tool_name"), rule,
+            )
+            return PolicyDecision(
+                allowed=True,
+                enforcement_mode=self._mode,
+                rule_matched=rule,
+                advice={},
+                evaluation_ms=evaluation_ms,
+                would_have_denied=True,
+            )
+
+        # SILENT mode — allow, no log
+        return PolicyDecision(
+            allowed=True,
+            enforcement_mode=self._mode,
+            rule_matched=rule,
+            advice={},
+            evaluation_ms=evaluation_ms,
+            would_have_denied=True,
+        )
+
+    @property
+    def bundle_hash(self) -> str:
+        return self._bundle.bundle_hash
+
+    @property
+    def enforcement_mode(self) -> EnforcementMode:
+        return self._mode

--- a/tests/unit/test_policy_evaluator.py
+++ b/tests/unit/test_policy_evaluator.py
@@ -1,0 +1,177 @@
+"""Tests for Cedar policy evaluation via AGT (issues #68, #73)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cmcp_gateway.config import Config, AttestationConfig, EnforcementMode
+from cmcp_gateway.errors import PolicyDeny
+from cmcp_gateway.policy.bundle import PolicyBundle, PolicyManifest
+from cmcp_gateway.policy.evaluator import PolicyDecision, PolicyEvaluator
+
+
+def _make_bundle(policy_content: str = 'permit(principal, action, resource);') -> PolicyBundle:
+    return PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-05T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": policy_content},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+
+
+def _make_config(mode: EnforcementMode = EnforcementMode.ENFORCING) -> Config:
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=mode)
+    return cfg
+
+
+ALLOW_CONTEXT = {
+    "tool_name": "crm.query",
+    "session_max_sensitivity": "public",
+    "workflow_id": "default",
+}
+
+
+# ── Enforcing mode ────────────────────────────────────────────────────────────
+
+def test_enforcing_allow():
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=True, reason="permit rule", evaluation_ms=0.5
+        )
+        MockBackend.return_value = mock
+
+        evaluator = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ENFORCING))
+        decision = evaluator.evaluate(ALLOW_CONTEXT)
+
+    assert decision.allowed is True
+    assert decision.would_have_denied is False
+
+
+def test_enforcing_deny_raises():
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=False, reason="forbid rule", evaluation_ms=0.3
+        )
+        MockBackend.return_value = mock
+
+        evaluator = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ENFORCING))
+        with pytest.raises(PolicyDeny, match="Policy denied"):
+            evaluator.evaluate(ALLOW_CONTEXT)
+
+
+# ── Advisory mode ─────────────────────────────────────────────────────────────
+
+def test_advisory_deny_allows_through():
+    """In advisory mode, Cedar denials are allowed but flagged."""
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=False, reason="forbid rule", evaluation_ms=0.2
+        )
+        MockBackend.return_value = mock
+
+        evaluator = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ADVISORY))
+        decision = evaluator.evaluate(ALLOW_CONTEXT)
+
+    assert decision.allowed is True
+    assert decision.would_have_denied is True
+
+
+def test_advisory_allow_does_not_flag():
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=True, reason=None, evaluation_ms=0.1
+        )
+        MockBackend.return_value = mock
+
+        evaluator = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ADVISORY))
+        decision = evaluator.evaluate(ALLOW_CONTEXT)
+
+    assert decision.allowed is True
+    assert decision.would_have_denied is False
+
+
+# ── Silent mode ───────────────────────────────────────────────────────────────
+
+def test_silent_deny_allows_through_no_log(caplog):
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=False, reason="forbid", evaluation_ms=0.1
+        )
+        MockBackend.return_value = mock
+
+        evaluator = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.SILENT))
+        with caplog.at_level("INFO"):
+            decision = evaluator.evaluate(ALLOW_CONTEXT)
+
+    assert decision.allowed is True
+    assert "ADVISORY deny" not in caplog.text
+
+
+# ── CedarBackend receives policy content ─────────────────────────────────────
+
+def test_cedar_backend_receives_sorted_policy_content():
+    """CedarBackend gets sorted policy file contents concatenated."""
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(allowed=True, reason=None, evaluation_ms=0.0)
+        MockBackend.return_value = mock
+
+        bundle = _make_bundle()
+        bundle.policy_files = {
+            "z-last.cedar": "permit(principal, action, resource);",
+            "a-first.cedar": "// comment",
+        }
+        PolicyEvaluator(bundle, _make_config())
+
+    _, kwargs = MockBackend.call_args
+    content = kwargs.get("policy_content", "")
+    assert "// comment" in content
+    assert content.index("// comment") < content.index("permit(")
+
+
+# ── Properties ────────────────────────────────────────────────────────────────
+
+def test_evaluator_exposes_bundle_hash():
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend"):
+        e = PolicyEvaluator(_make_bundle(), _make_config())
+    assert e.bundle_hash == "sha256:" + "0" * 64
+
+
+def test_evaluator_exposes_enforcement_mode():
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend"):
+        e = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ADVISORY))
+    assert e.enforcement_mode == EnforcementMode.ADVISORY
+
+
+# ── PolicyDecision ────────────────────────────────────────────────────────────
+
+def test_decision_conformance_policy_003():
+    """POLICY-003: advisory mode logs would_have_denied=True."""
+    with patch("cmcp_gateway.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=False, reason="test forbid", evaluation_ms=0.0
+        )
+        MockBackend.return_value = mock
+        e = PolicyEvaluator(_make_bundle(), _make_config(EnforcementMode.ADVISORY))
+        d = e.evaluate(ALLOW_CONTEXT)
+
+    assert isinstance(d, PolicyDecision)
+    assert d.allowed is True
+    assert d.would_have_denied is True
+    assert d.enforcement_mode == EnforcementMode.ADVISORY


### PR DESCRIPTION
Integrates AGT's `CedarBackend` (auto-selects cedarpy/cli/builtin) instead of writing a Cedar runner from scratch.

`PolicyEvaluator` wraps it with cMCP enforcement modes (enforcing/advisory/silent). Bundle hash covers exactly the bytes the backend evaluates — same bytes measured into the TEE attestation report at startup.

- Adds `agent-os-kernel>=4.0` to pyproject.toml
- 12 unit tests including POLICY-003 (advisory mode)

Closes #68, #73