### PR TITLE
fix: move agent-os-kernel to optional dep, correct version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,12 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.29",
     "click>=8.1",
-    "agent-os-kernel>=4.0",
 ]
 
 [project.optional-dependencies]
+agt = [
+    "agent-os-kernel>=3.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -43,6 +45,7 @@ dev = [
     "types-pyyaml",
     "bandit[toml]>=1.7",
     "pip-audit>=2.6",
+    "agent-os-kernel>=3.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Root cause

\gent-os-kernel>=4.0\ was declared as a hard dependency in \pyproject.toml\, but:
1. Version 4.0 **does not exist** — latest is 3.7.0
2. \scanner.py\ imports it with \	ry/except ImportError\ and a full no-op fallback — it was never a hard requirement

This caused \pip install -e '.[dev]'\ to fail on every CI matrix combination, blocking all 6 jobs.

## Fix

- Remove \gent-os-kernel\ from required \dependencies\
- Add new \[agt]\ optional extra for users who want AGT catalog scanning: \gent-os-kernel>=3.0\
- Add \gent-os-kernel>=3.0\ to \[dev]\ so CI exercises the scanner code path

## Test plan

- [ ] \pip install -e '.[dev]'\ succeeds on Python 3.11/3.12/3.13
- [ ] All 6 CI matrix jobs pass
- [ ] \pip install -e '.[agt]'\ works for users who want the AGT scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)