### PR TITLE
feat(dx): implement cmcp start/validate-bundle commands and Docker packaging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: Docker publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tag name
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/agentrust-io/cmcp-gateway:${{ steps.tag.outputs.tag }}
+            ghcr.io/agentrust-io/cmcp-gateway:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install package
+COPY pyproject.toml .
+COPY src/ src/
+RUN python -m pip install --upgrade pip setuptools && pip install -e ".[dev]"
+
+# Config, policy, catalog injected via volume mounts
+RUN mkdir -p /etc/cmcp
+
+EXPOSE 8443
+
+CMD ["cmcp", "start", "--config", "/etc/cmcp/config.yaml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  gateway:
+    build: .
+    ports:
+      - "8443:8443"
+    environment:
+      CMCP_DEV_MODE: "1"
+    volumes:
+      - ./examples/config.yaml:/etc/cmcp/config.yaml:ro
+      - ./examples/policy:/etc/cmcp/policy:ro
+      - ./examples/catalog.json:/etc/cmcp/catalog.json:ro
+    depends_on:
+      - mock-mcp-server
+
+  mock-mcp-server:
+    image: python:3.11-slim
+    ports:
+      - "8080:8080"
+    command: >
+      python -c "
+      import http.server, json, sys
+
+      class Handler(http.server.BaseHTTPRequestHandler):
+          def log_message(self, format, *args):
+              pass
+          def do_POST(self):
+              length = int(self.headers.get('Content-Length', 0))
+              body = self.rfile.read(length)
+              try:
+                  msg = json.loads(body)
+              except Exception:
+                  msg = {}
+              response = json.dumps({
+                  'jsonrpc': '2.0',
+                  'id': msg.get('id'),
+                  'result': {'content': [{'type': 'text', 'text': 'mock response'}]}
+              }).encode()
+              self.send_response(200)
+              self.send_header('Content-Type', 'application/json')
+              self.send_header('Content-Length', str(len(response)))
+              self.end_headers()
+              self.wfile.write(response)
+
+      server = http.server.HTTPServer(('0.0.0.0', 8080), Handler)
+      print('mock-mcp-server listening on :8080', flush=True)
+      server.serve_forever()
+      "

--- a/src/cmcp_gateway/cli.py
+++ b/src/cmcp_gateway/cli.py
@@ -17,8 +17,38 @@ def main() -> None:
 @click.option("--config", required=True, type=click.Path(exists=True), help="Path to cmcp-config.yaml")
 def start(config: str) -> None:
     """Start the cMCP Gateway."""
-    click.echo(f"Starting cMCP Gateway with config: {config}")
-    raise NotImplementedError("Gateway start implemented in track:assembly issues")
+    import uvicorn
+    from uuid import uuid4
+
+    from cmcp_gateway.audit.chain import AuditChain
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+    from cmcp_gateway.mcp.server import MCPServer
+    from cmcp_gateway.policy.evaluator import PolicyEvaluator
+    from cmcp_gateway.session.state import SessionState
+    from cmcp_gateway.startup import run_startup
+
+    ctx = run_startup(config)
+
+    session = SessionState(session_id=str(uuid4()))
+    audit_chain = AuditChain(session_id=session.session_id)
+    policy_evaluator = PolicyEvaluator(bundle=ctx.policy_bundle, config=ctx.config)
+    proxy = CMCPProxy(
+        catalog=ctx.catalog,
+        policy_evaluator=policy_evaluator,
+        session=session,
+        audit_chain=audit_chain,
+        config=ctx.config,
+    )
+    server = MCPServer(proxy=proxy)
+
+    host, _, port_str = ctx.config.listen_addr.rpartition(":")
+    port = int(port_str)
+
+    click.echo(
+        f"cMCP Gateway starting — TEE: {ctx.attestation_report.provider},"
+        f" listen: {ctx.config.listen_addr}"
+    )
+    uvicorn.run(server.app, host=host, port=port)
 
 
 @main.command("validate-config")
@@ -40,4 +70,24 @@ def validate_config(config: str) -> None:
 @click.option("--expected-hash", required=True, help="Expected SHA-256 hash (sha256:<hex>)")
 def validate_bundle(bundle_path: str, expected_hash: str) -> None:
     """Validate a Cedar policy bundle hash before deployment."""
-    raise NotImplementedError("Bundle validation implemented in track:policy issues")
+    from cmcp_gateway.policy.bundle import load_policy_bundle
+
+    try:
+        bundle = load_policy_bundle(bundle_path)
+    except Exception as exc:
+        click.echo(f"✗ Bundle load error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    bundle_hash = bundle.bundle_hash
+    # Normalise both sides to bare hex for comparison
+    expected_hex = expected_hash.removeprefix("sha256:")
+    actual_hex = bundle_hash.removeprefix("sha256:")
+
+    if actual_hex == expected_hex:
+        click.echo(f"✓ Bundle valid: {bundle_hash}")
+    else:
+        click.echo(
+            f"✗ Bundle hash mismatch: expected {expected_hash}, got {bundle_hash}",
+            err=True,
+        )
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- Implements `cmcp start`: calls `run_startup`, wires `SessionState` + `AuditChain` + `PolicyEvaluator` + `CMCPProxy` + `MCPServer`, logs a startup banner with TEE provider, then calls `uvicorn.run`
- Implements `cmcp validate-bundle`: loads bundle via `load_policy_bundle`, compares hash, exits 0/1
- Adds `Dockerfile` (python:3.11-slim, installs package, exposes 8443)
- Adds `docker-compose.yml` with `gateway` service (volume mounts for config/policy/catalog, `CMCP_DEV_MODE=1`) and `mock-mcp-server` (inline Python HTTP server on port 8080)
- Adds `.github/workflows/docker.yml`: builds and pushes to `ghcr.io/agentrust-io/cmcp-gateway:{tag}` and `:latest` on `v*` tag pushes

## Test plan

- [x] 159 unit tests pass (`python -m pytest tests/unit/ -q`)
- [x] `mypy src/cmcp_gateway/cli.py` — zero errors in cli.py (pre-existing errors in other modules unchanged)
- [ ] Smoke test: `docker compose up` with example config mounts, verify gateway starts and `/health` returns 200
- [ ] `cmcp validate-bundle --bundle-path examples/policy --expected-hash sha256:<hash>` exits 0 on match, 1 on mismatch

Closes #87, Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)