### PR TITLE
fix: suppress bandit B404/B603/B607 in tpm.py; sort cli.py imports

### DIFF
--- a/src/cmcp_gateway/cli.py
+++ b/src/cmcp_gateway/cli.py
@@ -17,8 +17,9 @@ def main() -> None:
 @click.option("--config", required=True, type=click.Path(exists=True), help="Path to cmcp-config.yaml")
 def start(config: str) -> None:
     """Start the cMCP Gateway."""
-    import uvicorn
     from uuid import uuid4
+
+    import uvicorn
 
     from cmcp_gateway.audit.chain import AuditChain
     from cmcp_gateway.mcp.proxy import CMCPProxy

--- a/src/cmcp_gateway/tee/sev_snp.py
+++ b/src/cmcp_gateway/tee/sev_snp.py
@@ -65,8 +65,6 @@ class SEVSNPProvider(TEEProvider):
         # struct: 96s user_data, I vmpl, 28s reserved
         req = struct.pack("96sI28s", user_data, vmpl, b"\x00" * 28)
 
-        # Response buffer: 4-byte status + 4-byte report_size + 24-byte reserved + report
-        resp = bytearray(_SNP_RESP_SIZE)
         # Place request into response buffer (ioctl arg is a combined req/resp struct)
         # The kernel driver takes a pointer to snp_guest_request_ioctl which contains
         # pointers; however the simplified /dev/sev-guest interface accepts the request

--- a/src/cmcp_gateway/tee/tpm.py
+++ b/src/cmcp_gateway/tee/tpm.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-import subprocess
+import subprocess  # nosec B404
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -123,7 +123,7 @@ class TPMProvider(TEEProvider):
     def _report_via_subprocess(self, nonce: bytes) -> AttestationReport:
         """Read PCRs 0-7 using tpm2_pcrread subprocess."""
         try:
-            result = subprocess.run(  # noqa: S603
+            result = subprocess.run(  # noqa: S603  # nosec B603, B607
                 ["tpm2_pcrread", "sha256:0,1,2,3,4,5,6,7"],  # noqa: S607
                 capture_output=True,
                 text=True,
@@ -135,7 +135,7 @@ class TPMProvider(TEEProvider):
 
         if result.returncode != 0:
             # Try SHA-1
-            result = subprocess.run(  # noqa: S603
+            result = subprocess.run(  # noqa: S603  # nosec B603, B607
                 ["tpm2_pcrread", "sha1:0,1,2,3,4,5,6,7"],  # noqa: S607
                 capture_output=True,
                 text=True,

--- a/src/cmcp_gateway/tee/tpm.py
+++ b/src/cmcp_gateway/tee/tpm.py
@@ -36,10 +36,7 @@ class TPMProvider(TEEProvider):
         try:
             if sys.platform != "linux":
                 return False
-            for dev in _TPM_DEVICES:
-                if dev.exists():
-                    return True
-            return False
+            return any(dev.exists() for dev in _TPM_DEVICES)
         except Exception:  # noqa: BLE001
             return False
 
@@ -59,8 +56,8 @@ class TPMProvider(TEEProvider):
         from tpm2_pytss.ESAPI import ESAPI  # type: ignore[import-not-found]
         from tpm2_pytss.types import (  # type: ignore[import-not-found]
             TPM2_ALG,
-            TPML_PCR_SELECTION,
             TPM2B_DATA,
+            TPML_PCR_SELECTION,
         )
 
         with ESAPI() as ectx:

--- a/tests/unit/test_tee_providers.py
+++ b/tests/unit/test_tee_providers.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -64,9 +64,8 @@ def test_sev_snp_get_report_raises_on_ioctl_failure(monkeypatch: pytest.MonkeyPa
     mock_fd.__enter__ = MagicMock(return_value=mock_fd)
     mock_fd.__exit__ = MagicMock(return_value=False)
 
-    with patch("builtins.open", return_value=mock_fd):
-        with pytest.raises(RuntimeError, match="SEV-SNP attestation failed"):
-            SEVSNPProvider().get_attestation_report(b"\x00" * 32)
+    with patch("builtins.open", return_value=mock_fd), pytest.raises(RuntimeError, match="SEV-SNP attestation failed"):
+        SEVSNPProvider().get_attestation_report(b"\x00" * 32)
 
 
 def test_sev_snp_get_report_raises_when_fcntl_unavailable(
@@ -112,9 +111,8 @@ def test_tdx_get_report_raises_on_ioctl_failure(monkeypatch: pytest.MonkeyPatch)
     mock_fd.__enter__ = MagicMock(return_value=mock_fd)
     mock_fd.__exit__ = MagicMock(return_value=False)
 
-    with patch("builtins.open", return_value=mock_fd):
-        with pytest.raises(RuntimeError, match="TDX attestation failed"):
-            TDXProvider().get_attestation_report(b"\x00" * 32)
+    with patch("builtins.open", return_value=mock_fd), pytest.raises(RuntimeError, match="TDX attestation failed"):
+        TDXProvider().get_attestation_report(b"\x00" * 32)
 
 
 # ── TPMProvider ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `tpm.py`: add `# nosec B404` on `import subprocess` and `# nosec B603, B607` on two `subprocess.run()` calls — these invoke the system `tpm2_pcrread` binary with a hardcoded arg list, no user input
- `cli.py`: reorder imports inside `start()` so stdlib (`uuid`) precedes third-party (`uvicorn`) — fixes ruff I001

## Why merged without this fix
PRs #123 and #127 were merged while CI was failing. This PR restores green CI on main.