### PR TITLE
feat(session): mid-session failure handling and session reset

### DIFF
--- a/src/cmcp_gateway/audit/chain.py
+++ b/src/cmcp_gateway/audit/chain.py
@@ -20,6 +20,8 @@ EntryType = Literal[
     "catalog_load",
     "fault",
     "suspicious_call_sequence",
+    "attestation_stale",
+    "catalog_drift",
 ]
 
 PolicyDecision = Literal["allow", "deny", "redact", "advisory_deny", "fault", "n/a"]

--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -68,6 +68,9 @@ class CMCPProxy:
         audit_chain: AuditChain,
         config: Config,
         call_log: CallLog | None = None,
+        attestation_generated_at: datetime | None = None,
+        attestation_validity_seconds: int = 86400,
+        catalog_hash: str | None = None,
     ) -> None:
         self._catalog = catalog
         self._policy = policy_evaluator
@@ -76,6 +79,9 @@ class CMCPProxy:
         self._config = config
         self._enforcement = config.attestation.enforcement_mode
         self._call_log: CallLog = call_log if call_log is not None else CallLog(session_id=session.session_id)
+        self._attestation_generated_at = attestation_generated_at
+        self._attestation_validity_seconds = attestation_validity_seconds
+        self._catalog_hash = catalog_hash or catalog.catalog_hash
 
         # Build AGT GovernancePolicy from cMCP catalog
         allowed_tools = list(catalog.entries.keys())
@@ -88,6 +94,53 @@ class CMCPProxy:
             policy=gov_policy,
             response_scanner=MCPResponseScanner(),
         )
+
+    def _check_health(self) -> str | None:
+        """
+        Check attestation staleness and catalog drift.
+
+        Returns a reason string if unhealthy, or None if healthy.
+        Side-effects: sets flags on session and appends audit entries on first detection.
+        """
+        # Attestation staleness check
+        if self._attestation_generated_at is not None and not self._session.attestation_stale:
+            age = datetime.now(UTC) - self._attestation_generated_at
+            if age.total_seconds() > self._attestation_validity_seconds:
+                logger.warning(
+                    "Attestation stale: age_seconds=%.0f validity_seconds=%d",
+                    age.total_seconds(),
+                    self._attestation_validity_seconds,
+                )
+                self._session.attestation_stale = True
+                self._audit.append(
+                    "attestation_stale",
+                    session_sensitivity_before=self._session.max_sensitivity,
+                    session_sensitivity_after=self._session.max_sensitivity,
+                )
+
+        if self._session.attestation_stale:
+            return "attestation_stale"
+
+        # Catalog drift check
+        if not self._session.catalog_drift:
+            current_hash = self._catalog.catalog_hash
+            if current_hash != self._catalog_hash:
+                logger.warning(
+                    "Catalog drift detected: expected=%s actual=%s",
+                    self._catalog_hash,
+                    current_hash,
+                )
+                self._session.catalog_drift = True
+                self._audit.append(
+                    "catalog_drift",
+                    session_sensitivity_before=self._session.max_sensitivity,
+                    session_sensitivity_after=self._session.max_sensitivity,
+                )
+
+        if self._session.catalog_drift:
+            return "catalog_drift"
+
+        return None
 
     def _build_cedar_context(
         self,
@@ -174,6 +227,20 @@ class CMCPProxy:
         called_at = datetime.now(UTC)
         sensitivity_before = self._session.max_sensitivity
         would_have_denied = False
+
+        # Step 0: health check (attestation staleness, catalog drift)
+        unhealthy_reason = self._check_health()
+        if unhealthy_reason is not None:
+            return CallResult(
+                call_id=call_id,
+                tool_name=tool_name,
+                allowed=False,
+                would_have_denied=False,
+                response=None,
+                deny_reason=unhealthy_reason,
+                latency_us=int((time.perf_counter() - t0) * 1_000_000),
+                audit_entry_hash=self._audit.chain_tip,
+            )
 
         _payload_bytes = json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode()
         request_payload_hash = f"sha256:{hashlib.sha256(_payload_bytes).hexdigest()}"

--- a/src/cmcp_gateway/mcp/server.py
+++ b/src/cmcp_gateway/mcp/server.py
@@ -24,7 +24,9 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
+from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.mcp.proxy import CMCPProxy
+from cmcp_gateway.session.state import SessionState
 
 if TYPE_CHECKING:
     from cmcp_gateway.audit.chain import AuditChain
@@ -80,6 +82,7 @@ class MCPServer:
         proxy: CMCPProxy,
         *,
         session_manager: SessionManager | None = None,
+        session: SessionState | None = None,
         audit_chain: AuditChain | None = None,
         bearer_token: str | None = None,
         session: SessionState | None = None,
@@ -87,9 +90,11 @@ class MCPServer:
     ) -> None:
         self._proxy = proxy
         self._session_manager = session_manager
+        self._session = session
         self._audit_chain = audit_chain
         self._session = session
         self._max_request_bytes = max_request_bytes
+        self._audit = audit_chain
         self._kernel = StatelessKernel()
         middleware = (
             [Middleware(_BearerAuthMiddleware, bearer_token=bearer_token)]
@@ -220,6 +225,23 @@ class MCPServer:
             )
 
         if not result.allowed:
+            _HEALTH_REASONS = {"attestation_stale", "catalog_drift"}
+            if result.deny_reason in _HEALTH_REASONS:
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32000,
+                            "message": result.deny_reason,
+                            "data": {
+                                "error_code": result.deny_reason.upper(),
+                                "call_id": call_id,
+                            },
+                        },
+                        "id": rpc_id,
+                    },
+                    status_code=503,
+                )
             # INJECT-003: log deny_reason internally; do not reflect internal detail to caller
             error_code = (
                 "TOOL_NOT_IN_CATALOG"

--- a/src/cmcp_gateway/mcp/server.py
+++ b/src/cmcp_gateway/mcp/server.py
@@ -24,9 +24,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
-from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.mcp.proxy import CMCPProxy
-from cmcp_gateway.session.state import SessionState
 
 if TYPE_CHECKING:
     from cmcp_gateway.audit.chain import AuditChain
@@ -82,7 +80,6 @@ class MCPServer:
         proxy: CMCPProxy,
         *,
         session_manager: SessionManager | None = None,
-        session: SessionState | None = None,
         audit_chain: AuditChain | None = None,
         bearer_token: str | None = None,
         session: SessionState | None = None,
@@ -90,7 +87,6 @@ class MCPServer:
     ) -> None:
         self._proxy = proxy
         self._session_manager = session_manager
-        self._session = session
         self._audit_chain = audit_chain
         self._session = session
         self._max_request_bytes = max_request_bytes

--- a/src/cmcp_gateway/session/state.py
+++ b/src/cmcp_gateway/session/state.py
@@ -53,6 +53,8 @@ class SessionState:
     injection_events: list[InjectionEvent] = field(default_factory=list)
     reset_count: int = 0
     suspicious_sequences: int = 0
+    attestation_stale: bool = False
+    catalog_drift: bool = False
 
     def update_from_inspection(
         self,
@@ -95,5 +97,7 @@ class SessionState:
         self.sensitivity_raised_by_call = None
         self.suspicious_sequences = 0
         self.reset_count += 1
+        self.attestation_stale = False
+        self.catalog_drift = False
         # reason and authorized_by are logged by the caller in the audit chain
         return previous_session_id, self.session_id

--- a/tests/unit/test_mid_session_failure.py
+++ b/tests/unit/test_mid_session_failure.py
@@ -1,0 +1,258 @@
+"""Tests for mid-session failure handling (issue #71).
+
+Covers:
+- Attestation staleness detection and 503 response
+- Catalog drift detection and 503 response
+- Audit entries logged on first detection
+- Healthy proxy passes calls through normally
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_gateway.config import AttestationConfig, Config, EnforcementMode
+from cmcp_gateway.policy.evaluator import PolicyDecision, PolicyEvaluator
+from cmcp_gateway.session.state import SessionState
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
+    return CatalogEntry(
+        tool_name=tool_name,
+        server=ServerIdentity(
+            display_name="Test",
+            url="https://test.example.com/mcp",
+            tls_fingerprint="SHA256:AAAA/BBBB==",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="test tool",
+            input_schema={},
+            output_schema=None,
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="external",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-05T00:00:00Z",
+        approved_by="test",
+    )
+
+
+def _make_catalog(catalog_hash: str = "sha256:" + "a" * 64) -> ToolCatalog:
+    return ToolCatalog(entries={"test.tool": _make_entry()}, catalog_hash=catalog_hash)
+
+
+def _make_evaluator() -> PolicyEvaluator:
+    evaluator = MagicMock(spec=PolicyEvaluator)
+    evaluator.evaluate.return_value = PolicyDecision(
+        allowed=True,
+        enforcement_mode=EnforcementMode.ENFORCING,
+        rule_matched=None,
+        advice={},
+        evaluation_ms=0.1,
+        would_have_denied=False,
+    )
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+    return evaluator
+
+
+def _make_proxy(
+    attestation_generated_at: datetime | None = None,
+    attestation_validity_seconds: int = 3600,
+    catalog_hash: str | None = None,
+    catalog: ToolCatalog | None = None,
+):
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    cat = catalog or _make_catalog()
+    ev = _make_evaluator()
+    session = SessionState(session_id="sess-health-001")
+    chain = AuditChain("sess-health-001")
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            cat, ev, session, chain, cfg,
+            attestation_generated_at=attestation_generated_at,
+            attestation_validity_seconds=attestation_validity_seconds,
+            catalog_hash=catalog_hash,
+        )
+        proxy._mcp_gateway = MagicMock()
+        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+            sensitivity_tags=[], injection_detected=False
+        ))
+    return proxy, session, chain
+
+
+# ── Attestation staleness ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attestation_not_stale_request_proceeds():
+    """Fresh attestation: tool call succeeds normally."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=60)
+    proxy, session, _ = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+    )
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is True
+    assert session.attestation_stale is False
+
+
+@pytest.mark.asyncio
+async def test_attestation_stale_returns_503_reason():
+    """Expired attestation: call_tool returns deny with reason 'attestation_stale'."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=7200)
+    proxy, session, _ = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+    )
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is False
+    assert result.deny_reason == "attestation_stale"
+
+
+@pytest.mark.asyncio
+async def test_attestation_stale_sets_flag_on_session():
+    """Expired attestation sets session.attestation_stale = True."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=7200)
+    proxy, session, _ = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+    )
+    assert session.attestation_stale is False
+    await proxy.call_tool("c1", "test.tool", {})
+    assert session.attestation_stale is True
+
+
+@pytest.mark.asyncio
+async def test_attestation_stale_appends_audit_entry():
+    """Attestation staleness detection appends an 'attestation_stale' audit entry."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=7200)
+    proxy, _, chain = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+    )
+    initial_length = chain.length
+    await proxy.call_tool("c1", "test.tool", {})
+    stale_entries = [e for e in chain.entries if e.entry_type == "attestation_stale"]
+    assert len(stale_entries) == 1
+    assert chain.length > initial_length
+
+
+@pytest.mark.asyncio
+async def test_attestation_stale_audit_entry_logged_only_once():
+    """Audit entry for staleness is only written once, not on every call."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=7200)
+    proxy, _, chain = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+    )
+    await proxy.call_tool("c1", "test.tool", {})
+    await proxy.call_tool("c2", "test.tool", {})
+    stale_entries = [e for e in chain.entries if e.entry_type == "attestation_stale"]
+    assert len(stale_entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_attestation_generated_at_skips_staleness_check():
+    """Without attestation_generated_at, staleness check is skipped and calls proceed."""
+    proxy, session, _ = _make_proxy(attestation_generated_at=None)
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is True
+    assert session.attestation_stale is False
+
+
+# ── Catalog drift ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_catalog_drift_detected_returns_503_reason():
+    """Catalog hash mismatch: call_tool returns deny with reason 'catalog_drift'."""
+    original_hash = "sha256:" + "a" * 64
+    different_hash = "sha256:" + "b" * 64
+    # catalog has different_hash but proxy is told original_hash was the startup hash
+    cat = _make_catalog(catalog_hash=different_hash)
+    proxy, session, _ = _make_proxy(catalog=cat, catalog_hash=original_hash)
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is False
+    assert result.deny_reason == "catalog_drift"
+
+
+@pytest.mark.asyncio
+async def test_catalog_drift_sets_flag_on_session():
+    """Catalog drift sets session.catalog_drift = True."""
+    cat = _make_catalog(catalog_hash="sha256:" + "b" * 64)
+    proxy, session, _ = _make_proxy(catalog=cat, catalog_hash="sha256:" + "a" * 64)
+    assert session.catalog_drift is False
+    await proxy.call_tool("c1", "test.tool", {})
+    assert session.catalog_drift is True
+
+
+@pytest.mark.asyncio
+async def test_catalog_drift_appends_audit_entry():
+    """Catalog drift detection appends a 'catalog_drift' audit entry."""
+    cat = _make_catalog(catalog_hash="sha256:" + "b" * 64)
+    proxy, _, chain = _make_proxy(catalog=cat, catalog_hash="sha256:" + "a" * 64)
+    await proxy.call_tool("c1", "test.tool", {})
+    drift_entries = [e for e in chain.entries if e.entry_type == "catalog_drift"]
+    assert len(drift_entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_catalog_drift_audit_entry_logged_only_once():
+    """Audit entry for drift is only written once, not on every call."""
+    cat = _make_catalog(catalog_hash="sha256:" + "b" * 64)
+    proxy, _, chain = _make_proxy(catalog=cat, catalog_hash="sha256:" + "a" * 64)
+    await proxy.call_tool("c1", "test.tool", {})
+    await proxy.call_tool("c2", "test.tool", {})
+    drift_entries = [e for e in chain.entries if e.entry_type == "catalog_drift"]
+    assert len(drift_entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_catalog_no_drift_proceeds():
+    """Matching catalog hash: calls proceed normally."""
+    matching_hash = "sha256:" + "a" * 64
+    cat = _make_catalog(catalog_hash=matching_hash)
+    proxy, session, _ = _make_proxy(catalog=cat, catalog_hash=matching_hash)
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is True
+    assert session.catalog_drift is False
+
+
+# ── Attestation staleness takes precedence over catalog drift ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_attestation_stale_checked_before_catalog_drift():
+    """When both conditions apply, attestation_stale is returned first."""
+    generated_at = datetime.now(UTC) - timedelta(seconds=7200)
+    cat = _make_catalog(catalog_hash="sha256:" + "b" * 64)
+    proxy, _, _ = _make_proxy(
+        attestation_generated_at=generated_at,
+        attestation_validity_seconds=3600,
+        catalog=cat,
+        catalog_hash="sha256:" + "a" * 64,
+    )
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.deny_reason == "attestation_stale"

--- a/tests/unit/test_session_reset.py
+++ b/tests/unit/test_session_reset.py
@@ -1,0 +1,228 @@
+"""Tests for session reset endpoint (issue #92).
+
+Covers:
+- POST /sessions/{id}/reset returns 200 with old/new session IDs
+- POST /sessions/{wrong_id}/reset returns 404
+- Reset clears attestation_stale and catalog_drift flags
+- Audit entry appended on reset
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_gateway.config import AttestationConfig, Config, EnforcementMode
+from cmcp_gateway.mcp.server import MCPServer
+from cmcp_gateway.policy.evaluator import PolicyDecision, PolicyEvaluator
+from cmcp_gateway.session.state import SessionState
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_catalog() -> ToolCatalog:
+    entry = CatalogEntry(
+        tool_name="test.tool",
+        server=ServerIdentity(
+            display_name="Test",
+            url="https://test.example.com/mcp",
+            tls_fingerprint="SHA256:AAAA/BBBB==",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="test tool",
+            input_schema={},
+            output_schema=None,
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="external",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-05T00:00:00Z",
+        approved_by="test",
+    )
+    return ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "a" * 64)
+
+
+def _make_evaluator() -> PolicyEvaluator:
+    evaluator = MagicMock(spec=PolicyEvaluator)
+    evaluator.evaluate.return_value = PolicyDecision(
+        allowed=True,
+        enforcement_mode=EnforcementMode.ENFORCING,
+        rule_matched=None,
+        advice={},
+        evaluation_ms=0.1,
+        would_have_denied=False,
+    )
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+    return evaluator
+
+
+def _make_server(session_id: str = "sess-reset-001"):
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    cat = _make_catalog()
+    ev = _make_evaluator()
+    session = SessionState(session_id=session_id)
+    chain = AuditChain(session_id)
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(cat, ev, session, chain, cfg)
+        proxy._mcp_gateway = MagicMock()
+        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+            sensitivity_tags=[], injection_detected=False
+        ))
+
+    server = MCPServer(proxy, session=session, audit_chain=chain)
+    return server, session, chain
+
+
+# ── Endpoint happy path ───────────────────────────────────────────────────────
+
+
+def test_reset_returns_200_with_session_ids():
+    """POST /sessions/{id}/reset returns 200 with old/new session IDs and status."""
+    server, session, _ = _make_server("sess-reset-001")
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post(f"/sessions/{original_id}/reset")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["old_session_id"] == original_id
+    assert body["new_session_id"] != original_id
+    assert body["status"] == "reset"
+
+
+def test_reset_new_session_id_matches_session_state():
+    """After reset, session.session_id equals the new_session_id returned."""
+    server, session, _ = _make_server("sess-reset-002")
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post(f"/sessions/{original_id}/reset")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert session.session_id == body["new_session_id"]
+
+
+# ── 404 for wrong session_id ──────────────────────────────────────────────────
+
+
+def test_reset_wrong_session_id_returns_404():
+    """POST /sessions/{wrong_id}/reset returns 404."""
+    server, _, _ = _make_server("sess-reset-003")
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post("/sessions/completely-wrong-id/reset")
+
+    assert resp.status_code == 404
+
+
+def test_reset_wrong_session_id_does_not_change_session():
+    """404 response leaves the session unchanged."""
+    server, session, _ = _make_server("sess-reset-004")
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    client.post("/sessions/completely-wrong-id/reset")
+
+    assert session.session_id == original_id
+
+
+# ── Flag clearing ─────────────────────────────────────────────────────────────
+
+
+def test_reset_clears_attestation_stale_flag():
+    """Reset clears session.attestation_stale."""
+    server, session, _ = _make_server("sess-reset-005")
+    session.attestation_stale = True
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post(f"/sessions/{original_id}/reset")
+
+    assert resp.status_code == 200
+    assert session.attestation_stale is False
+
+
+def test_reset_clears_catalog_drift_flag():
+    """Reset clears session.catalog_drift."""
+    server, session, _ = _make_server("sess-reset-006")
+    session.catalog_drift = True
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post(f"/sessions/{original_id}/reset")
+
+    assert resp.status_code == 200
+    assert session.catalog_drift is False
+
+
+# ── Audit entry ───────────────────────────────────────────────────────────────
+
+
+def test_reset_appends_session_reset_audit_entry():
+    """Reset appends a 'session_reset' audit entry."""
+    server, session, chain = _make_server("sess-reset-007")
+    original_id = session.session_id
+
+    initial_length = chain.length
+    client = TestClient(server.app, raise_server_exceptions=True)
+    client.post(f"/sessions/{original_id}/reset")
+
+    reset_entries = [e for e in chain.entries if e.entry_type == "session_reset"]
+    assert len(reset_entries) == 1
+    assert chain.length > initial_length
+
+
+def test_reset_audit_chain_remains_valid():
+    """Hash chain is internally consistent after a reset."""
+    server, session, chain = _make_server("sess-reset-008")
+    original_id = session.session_id
+
+    client = TestClient(server.app, raise_server_exceptions=True)
+    client.post(f"/sessions/{original_id}/reset")
+
+    assert chain.verify_chain() is True
+
+
+# ── No session configured ─────────────────────────────────────────────────────
+
+
+def test_reset_without_session_configured_returns_501():
+    """MCPServer without session/audit_chain returns 501."""
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    cat = _make_catalog()
+    ev = _make_evaluator()
+    session = SessionState(session_id="bare-sess")
+    chain = AuditChain("bare-sess")
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(cat, ev, session, chain, cfg)
+        proxy._mcp_gateway = MagicMock()
+
+    server = MCPServer(proxy)  # no session or audit_chain kwargs
+    client = TestClient(server.app, raise_server_exceptions=True)
+    resp = client.post("/sessions/bare-sess/reset")
+    assert resp.status_code == 501


### PR DESCRIPTION
## Summary

- Implements issue #71: `CMCPProxy._check_health()` detects attestation staleness (age > `attestation_validity_seconds`) and catalog drift (hash mismatch), sets flags on `SessionState`, logs a WARNING audit entry on first detection, and returns 503 to callers for subsequent tool calls
- Implements issue #92: `POST /sessions/{session_id}/reset` on `MCPServer` calls `SessionState.reset()`, appends a `session_reset` audit entry, clears both health flags, and returns `{old_session_id, new_session_id, status}` — 404 if session ID doesn't match
- `SessionState` gains `attestation_stale: bool` and `catalog_drift: bool` fields, both cleared by `reset()`; `AuditChain.EntryType` extended with `"attestation_stale"` and `"catalog_drift"`

## Test plan

- [ ] `tests/unit/test_mid_session_failure.py` — 12 tests covering fresh attestation passes, stale rejects with correct reason, flag set on session, audit entry written once, no-`attestation_generated_at` skips check, catalog drift detected and deduped, precedence ordering
- [ ] `tests/unit/test_session_reset.py` — 9 tests covering 200 happy path, session ID round-trip, 404 wrong ID, session unchanged on 404, flag clearing for both fields, audit entry appended, chain integrity, 501 when not configured
- [ ] All 199 existing tests continue to pass

Closes #71, Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)