### PR TITLE
chore(ci): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to run CI on"
+        required: false
+        default: ""
 
 jobs:
   test:


### PR DESCRIPTION
Adds workflow_dispatch so CI can be manually triggered on any branch. Useful when push/PR events don't fire CI automatically.