### PR TITLE
fix(security): reject non-UTF-8 responses and fix injection tracking

### DIFF
--- a/src/cmcp_gateway/inspection/pipeline.py
+++ b/src/cmcp_gateway/inspection/pipeline.py
@@ -333,10 +333,35 @@ class InspectionPipeline:
         stage_results["classification"] = "allow"
 
         # Stage 4: injection detection (AGT PromptInjectionDetector + MCPResponseScanner)
+        # INJECT-005: scan bytes decoded strictly — non-UTF-8 is treated as a deny to
+        # prevent bypass via invalid byte sequences that errors="replace" would corrupt.
         try:
-            response_text = response_text_for_s3
-        except Exception:
-            response_text = ""
+            response_text = response_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            deny_reasons.append("INJECT-005: non-UTF-8 response rejected before injection scan")
+            injection_pattern = "non-utf8-response"
+            stage_results["injection"] = "deny"
+            final = "deny"
+            if session is not None:
+                session.update_from_inspection(
+                    call_id=call_id,
+                    sensitivity_tags=sensitivity_tags,
+                    injection_detected=True,
+                    response_allowed=False,
+                )
+            return InspectionResult(
+                call_id=call_id,
+                final_decision="deny",
+                deny_reason="; ".join(deny_reasons),
+                sensitivity_tags=sensitivity_tags,
+                stripped_fields=stripped_fields,
+                injection_pattern_matched=injection_pattern,
+                stage_results=stage_results,
+                response_payload_hash=response_payload_hash,
+                modified_response=None,
+            )
+
+        agt_mcp_denied = False
 
         # AGT MCPResponseScanner catches MCP-specific threats (tool poisoning in responses)
         if self._agt_response_scanner is not None:
@@ -348,7 +373,10 @@ class InspectionPipeline:
                     threat_name = str(agt_scan.threats[0]) if agt_scan.threats else "mcp_threat"
                     deny_reasons.append(f"AGT MCPResponseScanner: {threat_name}")
                     injection_pattern = f"agt_mcp:{threat_name}"
+                    # POLICY-006: record deny from AGT scanner before running regex stage;
+                    # regex stage below must not overwrite a deny with allow.
                     stage_results["injection"] = "deny"
+                    agt_mcp_denied = True
             except Exception:  # nosec B110
                 pass
 
@@ -357,7 +385,10 @@ class InspectionPipeline:
             self._injection_patterns,
             _agt_detector=self._agt_injection_detector,
         )
-        stage_results["injection"] = s4.decision
+        # POLICY-006: only overwrite injection decision if regex/AGT detector found a new deny,
+        # or if the stage had not yet been set to deny by the MCPResponseScanner above.
+        if s4.decision == "deny" or not agt_mcp_denied:
+            stage_results["injection"] = s4.decision
         if s4.decision == "deny":
             deny_reasons.append(s4.reason or "injection detected")
             injection_pattern = s4.injection_pattern
@@ -366,7 +397,8 @@ class InspectionPipeline:
 
         # Handoff to session state — happens even for denied responses
         # (a denied high-sensitivity response still raises session sensitivity)
-        injection_detected = s4.decision == "deny"
+        # INJECT-004: injection_detected must reflect both scanners, not only s4.
+        injection_detected = s4.decision == "deny" or agt_mcp_denied
         if session is not None:
             session.update_from_inspection(
                 call_id=call_id,

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -185,3 +185,68 @@ def test_pipeline_calls_session_update_on_deny():
     _, kwargs = mock_session.update_from_inspection.call_args
     assert kwargs["injection_detected"] is True
     assert kwargs["response_allowed"] is False
+
+
+# ── INJECT-005: non-UTF-8 response handling ───────────────────────────────────
+
+def test_pipeline_denies_non_utf8_response():
+    """INJECT-005: non-UTF-8 bytes must be rejected before injection scanning."""
+    pipeline = InspectionPipeline()
+    entry = _make_entry()
+    non_utf8 = b"\xff\xfe invalid utf-8 payload"
+    result = pipeline.run("call-1", entry, non_utf8)
+    assert result.final_decision == "deny"
+    assert result.injection_pattern_matched == "non-utf8-response"
+
+
+def test_pipeline_non_utf8_calls_session_update_with_injection_detected():
+    """INJECT-004: injection_detected=True even for non-UTF-8 path."""
+    pipeline = InspectionPipeline()
+    entry = _make_entry()
+    mock_session = MagicMock()
+    pipeline.run("call-1", entry, b"\xff\xfe bad", session=mock_session)
+    mock_session.update_from_inspection.assert_called_once()
+    _, kwargs = mock_session.update_from_inspection.call_args
+    assert kwargs["injection_detected"] is True
+    assert kwargs["response_allowed"] is False
+
+
+# ── POLICY-006 / INJECT-004: AGT MCPResponseScanner deny propagation ──────────
+
+def test_agt_mcp_scanner_deny_sets_injection_detected_on_session():
+    """INJECT-004: AGT MCPResponseScanner deny must set injection_detected on session."""
+    pipeline = InspectionPipeline()
+    entry = _make_entry()
+
+    # Inject a mock AGT response scanner that returns unsafe
+    mock_scanner = MagicMock()
+    mock_scan_result = MagicMock()
+    mock_scan_result.is_safe = False
+    mock_scan_result.threats = ["tool_poisoning"]
+    mock_scanner.scan_response.return_value = mock_scan_result
+    pipeline._agt_response_scanner = mock_scanner
+
+    mock_session = MagicMock()
+    pipeline.run("call-1", entry, NORMAL_RESPONSE, session=mock_session)
+
+    _, kwargs = mock_session.update_from_inspection.call_args
+    assert kwargs["injection_detected"] is True
+    assert kwargs["response_allowed"] is False
+
+
+def test_agt_mcp_scanner_deny_is_not_overwritten_by_regex_allow():
+    """POLICY-006: regex stage returning allow must not overwrite AGT scanner deny."""
+    pipeline = InspectionPipeline()
+    entry = _make_entry()
+
+    mock_scanner = MagicMock()
+    mock_scan_result = MagicMock()
+    mock_scan_result.is_safe = False
+    mock_scan_result.threats = ["tool_poisoning"]
+    mock_scanner.scan_response.return_value = mock_scan_result
+    pipeline._agt_response_scanner = mock_scanner
+
+    # NORMAL_RESPONSE has no regex injection patterns
+    result = pipeline.run("call-1", entry, NORMAL_RESPONSE)
+    assert result.final_decision == "deny"
+    assert result.stage_results["injection"] == "deny"


### PR DESCRIPTION
## Summary

- Closes #154 (POLICY-006): AGT MCPResponseScanner deny no longer overwritten by regex-stage allow
- Closes #155 (INJECT-004): `injection_detected` now reflects both scanners; session always records `InjectionEvent` when either fires
- Closes #156 (INJECT-005): non-UTF-8 responses rejected before injection scanning; `errors="replace"` would corrupt byte sequences an attacker could exploit to bypass pattern matching

## Test plan

- [ ] `test_pipeline_denies_non_utf8_response` — non-UTF-8 payload → deny with `non-utf8-response` pattern
- [ ] `test_pipeline_non_utf8_calls_session_update_with_injection_detected` — `injection_detected=True` on non-UTF-8 path
- [ ] `test_agt_mcp_scanner_deny_sets_injection_detected_on_session` — AGT MCP scanner deny sets `injection_detected=True` on session
- [ ] `test_agt_mcp_scanner_deny_is_not_overwritten_by_regex_allow` — final decision is "deny" even when regex stage returns "allow"
- [ ] All 232 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)