### PR TITLE
fix(security): use session-unique attestation nonce and raise on malformed report_data

### DIFF
--- a/src/cmcp_gateway/audit/trace_claim.py
+++ b/src/cmcp_gateway/audit/trace_claim.py
@@ -192,10 +192,17 @@ def _build_runtime(report: AttestationReportInfo) -> RuntimeInfo:
         if report.measurement.startswith(("sha256:", "sha384:"))
         else f"sha256:{report.measurement}"
     )
+    # CRYPTO-003: raise on malformed report_data instead of silently dropping the nonce.
+    # A missing nonce removes the binding between the attestation report and the session;
+    # a malformed report_data indicates a broken or compromised TEE shim.
     try:
         nonce = base64.urlsafe_b64encode(bytes.fromhex(report.report_data)).rstrip(b"=").decode()
-    except ValueError:
-        nonce = None
+    except ValueError as exc:
+        raise ValueError(
+            f"TEE attestation report contains malformed report_data: {exc!r}. "
+            "The nonce binding to the session cannot be established. "
+            "Check the TEE provider implementation."
+        ) from exc
 
     return RuntimeInfo(platform=platform, measurement=measurement, nonce=nonce)  # type: ignore[arg-type]
 

--- a/src/cmcp_gateway/startup.py
+++ b/src/cmcp_gateway/startup.py
@@ -84,9 +84,13 @@ def run_startup(config_path: str) -> GatewayContext:
     signing_key = SigningKey()
     logger.info("Signing key generated: %s...", signing_key.public_key_hex[:16])
 
-    # Attest with nonce = SHA-256(public_key || "startup")
+    # CRYPTO-002: nonce must be session-unique. Use SHA-256(public_key || random_session_id)
+    # so two gateways with different random bytes produce different nonces even if they
+    # share the same keypair (e.g. during blue-green deploy).
     import hashlib
-    nonce = hashlib.sha256(signing_key.public_key_bytes + b"startup").digest()
+    import secrets
+    session_id = secrets.token_bytes(32)
+    nonce = hashlib.sha256(signing_key.public_key_bytes + session_id).digest()
     try:
         attestation_report = tee_provider.get_attestation_report(nonce)
     except Exception as exc:

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -217,3 +217,35 @@ def test_to_dict_includes_signature_field():
     d = _to_dict(claim)
     assert "signature" in d
     assert d["signature"] == ""
+
+
+# ── CRYPTO-003: nonce binding ─────────────────────────────────────────────────
+
+
+def test_build_runtime_valid_report_data_produces_nonce():
+    """CRYPTO-003: valid hex report_data must produce a nonce in RuntimeInfo."""
+    from cmcp_gateway.audit.trace_claim import _build_runtime, AttestationReportInfo
+    report = AttestationReportInfo(
+        provider="sev-snp",
+        measurement="sha256:" + "a" * 64,
+        report_data="deadbeef" * 8,  # valid hex
+        attestation_generated_at="2026-06-06T00:00:00+00:00",
+        attestation_validity_seconds=86400,
+    )
+    runtime = _build_runtime(report)
+    assert runtime.nonce is not None
+
+
+def test_build_runtime_malformed_report_data_raises():
+    """CRYPTO-003: malformed report_data must raise ValueError, not set nonce=None."""
+    import pytest
+    from cmcp_gateway.audit.trace_claim import _build_runtime, AttestationReportInfo
+    report = AttestationReportInfo(
+        provider="sev-snp",
+        measurement="sha256:" + "a" * 64,
+        report_data="not-hex!!",
+        attestation_generated_at="2026-06-06T00:00:00+00:00",
+        attestation_validity_seconds=86400,
+    )
+    with pytest.raises(ValueError, match="malformed report_data"):
+        _build_runtime(report)

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -224,7 +224,7 @@ def test_to_dict_includes_signature_field():
 
 def test_build_runtime_valid_report_data_produces_nonce():
     """CRYPTO-003: valid hex report_data must produce a nonce in RuntimeInfo."""
-    from cmcp_gateway.audit.trace_claim import _build_runtime, AttestationReportInfo
+    from cmcp_gateway.audit.trace_claim import AttestationReportInfo, _build_runtime
     report = AttestationReportInfo(
         provider="sev-snp",
         measurement="sha256:" + "a" * 64,
@@ -239,7 +239,8 @@ def test_build_runtime_valid_report_data_produces_nonce():
 def test_build_runtime_malformed_report_data_raises():
     """CRYPTO-003: malformed report_data must raise ValueError, not set nonce=None."""
     import pytest
-    from cmcp_gateway.audit.trace_claim import _build_runtime, AttestationReportInfo
+
+    from cmcp_gateway.audit.trace_claim import AttestationReportInfo, _build_runtime
     report = AttestationReportInfo(
         provider="sev-snp",
         measurement="sha256:" + "a" * 64,


### PR DESCRIPTION
## Summary

- Closes #152 (CRYPTO-002): attestation nonce is now `SHA-256(public_key || random_session_id)` — prevents two gateway instances from producing the same nonce during blue-green deploys
- Closes #153 (CRYPTO-003): `_build_runtime()` now raises `ValueError` on malformed `report_data` instead of silently producing a `RuntimeInfo` with `nonce=None`; a missing nonce removes the session binding from the TRACE Claim

## Test plan

- [ ] `test_build_runtime_valid_report_data_produces_nonce` — valid hex produces a nonce
- [ ] `test_build_runtime_malformed_report_data_raises` — invalid hex raises `ValueError` with descriptive message
- [ ] All 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)