### PR TITLE
fix(security): require bearer token authentication on MCP endpoint

### DIFF
--- a/src/cmcp_gateway/config.py
+++ b/src/cmcp_gateway/config.py
@@ -48,6 +48,7 @@ class Config:
     listen_addr: str = "0.0.0.0:8443"
     max_response_size_bytes: int = 2 * 1024 * 1024  # 2MB
     dev_mode: bool = False
+    bearer_token: str | None = None
 
 
 _KNOWN_TOP_KEYS = {"attestation", "policy_bundle_path", "catalog_path", "listen_addr", "max_response_size_bytes"}
@@ -109,6 +110,7 @@ def load_config(path: str) -> Config:
         raise ConfigError("max_response_size_bytes must be a positive integer")
 
     dev_mode = os.environ.get("CMCP_DEV_MODE", "0") == "1"
+    bearer_token = os.environ.get("CMCP_BEARER_TOKEN") or None
 
     return Config(
         attestation=AttestationConfig(
@@ -122,4 +124,5 @@ def load_config(path: str) -> Config:
         listen_addr=raw.get("listen_addr", "0.0.0.0:8443"),
         max_response_size_bytes=max_bytes,
         dev_mode=dev_mode,
+        bearer_token=bearer_token,
     )

--- a/src/cmcp_gateway/mcp/server.py
+++ b/src/cmcp_gateway/mcp/server.py
@@ -10,6 +10,7 @@ Phase 1 scope: HTTP/SSE transport only. stdio excluded (docs/spec/transport.md).
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import uuid
@@ -17,6 +18,8 @@ from typing import TYPE_CHECKING, Any
 
 from agent_os.stateless import StatelessKernel
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
@@ -28,6 +31,39 @@ if TYPE_CHECKING:
     from cmcp_gateway.session.manager import SessionManager
 
 logger = logging.getLogger(__name__)
+
+# Endpoints exempt from bearer-token auth (Kubernetes liveness / readiness probes)
+_AUTH_EXEMPT_PATHS = {"/health"}
+
+
+class _BearerAuthMiddleware(BaseHTTPMiddleware):
+    """AUTH-001 (CRITICAL): validate Authorization: Bearer <token> on all protected endpoints."""
+
+    def __init__(self, app: Any, *, bearer_token: str) -> None:
+        super().__init__(app)
+        self._token = bearer_token
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        if request.url.path in _AUTH_EXEMPT_PATHS:
+            return await call_next(request)
+        auth = request.headers.get("Authorization", "")
+        prefix = "Bearer "
+        if not auth.startswith(prefix):
+            return JSONResponse(
+                {"error": "unauthorized", "error_code": "MISSING_BEARER_TOKEN"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer realm=\"cmcp-gateway\""},
+            )
+        provided = auth[len(prefix):]
+        # Constant-time compare to prevent timing oracle on the token
+        if not hmac.compare_digest(provided, self._token):
+            logger.warning("AUTH_FAILURE: invalid bearer token from %s", request.client)
+            return JSONResponse(
+                {"error": "unauthorized", "error_code": "INVALID_BEARER_TOKEN"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer realm=\"cmcp-gateway\""},
+            )
+        return await call_next(request)
 
 
 class MCPServer:
@@ -44,22 +80,31 @@ class MCPServer:
         *,
         session_manager: SessionManager | None = None,
         audit_chain: AuditChain | None = None,
+        bearer_token: str | None = None,
     ) -> None:
         self._proxy = proxy
         self._session_manager = session_manager
         self._audit_chain = audit_chain
         self._kernel = StatelessKernel()
-        self.app = Starlette(routes=[
-            Route("/mcp", self._handle_mcp, methods=["POST"]),
-            Route("/health", self._health, methods=["GET"]),
-            Route("/tools/list", self._list_tools, methods=["GET"]),
-            Route(
-                "/sessions/{session_id}/trace-claim",
-                self._get_trace_claim,
-                methods=["GET"],
-            ),
-            Route("/audit/export", self._audit_export, methods=["GET"]),
-        ])
+        middleware = (
+            [Middleware(_BearerAuthMiddleware, bearer_token=bearer_token)]
+            if bearer_token is not None
+            else []
+        )
+        self.app = Starlette(
+            routes=[
+                Route("/mcp", self._handle_mcp, methods=["POST"]),
+                Route("/health", self._health, methods=["GET"]),
+                Route("/tools/list", self._list_tools, methods=["GET"]),
+                Route(
+                    "/sessions/{session_id}/trace-claim",
+                    self._get_trace_claim,
+                    methods=["GET"],
+                ),
+                Route("/audit/export", self._audit_export, methods=["GET"]),
+            ],
+            middleware=middleware,
+        )
 
     async def _handle_mcp(self, request: Request) -> Response:
         """Handle MCP JSON-RPC 2.0 calls."""

--- a/src/cmcp_gateway/startup.py
+++ b/src/cmcp_gateway/startup.py
@@ -104,6 +104,17 @@ def run_startup(config_path: str) -> GatewayContext:
         attestation_report.measurement[:16],
     )
 
+    # AUTH-001 (CRITICAL): require a bearer token in production to authenticate
+    # inbound MCP calls. Without it, any network client can invoke any tool.
+    if config.bearer_token is None and not config.dev_mode:
+        _fatal(
+            "BEARER_TOKEN_REQUIRED",
+            "CMCP_BEARER_TOKEN env var is not set. "
+            "Set it to a secret token that agent hosts must present in the "
+            "Authorization header. Set CMCP_DEV_MODE=1 only in development.",
+        )
+        sys.exit(1)
+
     # Step 4: policy bundle
     policy_expected_hash = os.environ.get("CMCP_POLICY_HASH")
     try:

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -1,0 +1,95 @@
+"""Tests for MCP server bearer-token authentication (AUTH-001)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from cmcp_gateway.mcp.server import MCPServer
+
+
+def _make_server(bearer_token: str | None = None) -> MCPServer:
+    proxy = MagicMock()
+    proxy._catalog = MagicMock()
+    proxy._catalog.entries = {}
+    proxy.call_tool = AsyncMock(return_value=MagicMock(
+        allowed=True, deny_reason=None, response="ok",
+        audit_entry_hash="sha256:" + "0" * 64,
+        would_have_denied=False, latency_us=100,
+    ))
+    with patch("cmcp_gateway.mcp.server.StatelessKernel"):
+        return MCPServer(proxy, bearer_token=bearer_token)
+
+
+# ── No auth configured (dev mode) ────────────────────────────────────────────
+
+def test_no_auth_allows_any_request():
+    server = _make_server(bearer_token=None)
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post("/mcp", json={"jsonrpc": "2.0", "method": "initialize", "id": 1})
+    assert resp.status_code == 200
+
+
+def test_health_always_accessible_without_token():
+    server = _make_server(bearer_token="secret")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+# ── Auth enabled ──────────────────────────────────────────────────────────────
+
+def test_missing_auth_header_returns_401():
+    """AUTH-001 (CRITICAL): request without Authorization → 401."""
+    server = _make_server(bearer_token="super-secret-token")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post("/mcp", json={"jsonrpc": "2.0", "method": "initialize", "id": 1})
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["error_code"] == "MISSING_BEARER_TOKEN"
+
+
+def test_wrong_token_returns_401():
+    server = _make_server(bearer_token="correct-token")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["error_code"] == "INVALID_BEARER_TOKEN"
+
+
+def test_correct_token_allows_request():
+    server = _make_server(bearer_token="correct-token")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+        headers={"Authorization": "Bearer correct-token"},
+    )
+    assert resp.status_code == 200
+
+
+def test_auth_response_includes_www_authenticate_header():
+    server = _make_server(bearer_token="secret")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post("/mcp", json={})
+    assert "WWW-Authenticate" in resp.headers
+
+
+def test_tools_list_requires_auth():
+    server = _make_server(bearer_token="secret")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.get("/tools/list")
+    assert resp.status_code == 401
+
+
+def test_audit_export_requires_auth():
+    server = _make_server(bearer_token="secret")
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.get("/audit/export?session_id=sess-1")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Closes #138 (AUTH-001 CRITICAL): adds `_BearerAuthMiddleware` to the Starlette app; all endpoints except `/health` require `Authorization: Bearer <token>`
- `CMCP_BEARER_TOKEN` env var is read in `load_config()` and required at startup unless `CMCP_DEV_MODE=1`
- `hmac.compare_digest()` prevents timing-oracle attacks on the secret token
- `/health` is exempt so Kubernetes liveness/readiness probes continue to work without credentials

## Test plan

- [ ] `test_missing_auth_header_returns_401` — unauthenticated POST to `/mcp` → 401
- [ ] `test_wrong_token_returns_401` — wrong token → 401 with `INVALID_BEARER_TOKEN`
- [ ] `test_correct_token_allows_request` — correct token → 200
- [ ] `test_health_always_accessible_without_token` — `/health` → 200 without credentials
- [ ] `test_no_auth_allows_any_request` — no token configured (dev mode) → 200
- [ ] All 236 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)