### PR TITLE
feat(policy): per-workflow Cedar policy scope

### DIFF
--- a/src/cmcp_gateway/audit/chain.py
+++ b/src/cmcp_gateway/audit/chain.py
@@ -47,6 +47,7 @@ class AuditEntry:
     response_inspection_result: InspectionResult | None
     session_sensitivity_before: str | None
     session_sensitivity_after: str | None
+    workflow_id: str | None
     prev_entry_hash: str  # "genesis" for first entry
     entry_hash: str = field(default="")  # computed after construction
 
@@ -89,6 +90,7 @@ class AuditChain:
             response_inspection_result="n/a",
             session_sensitivity_before=None,
             session_sensitivity_after="public",
+            workflow_id=None,
         )
 
     def append(
@@ -106,6 +108,7 @@ class AuditChain:
         response_inspection_result: InspectionResult | None = None,
         session_sensitivity_before: str | None = None,
         session_sensitivity_after: str | None = None,
+        workflow_id: str | None = None,
     ) -> AuditEntry:
         prev_hash = self._entries[-1].entry_hash if self._entries else "genesis"
         entry = AuditEntry(
@@ -125,6 +128,7 @@ class AuditChain:
             response_inspection_result=response_inspection_result,
             session_sensitivity_before=session_sensitivity_before,
             session_sensitivity_after=session_sensitivity_after,
+            workflow_id=workflow_id,
             prev_entry_hash=prev_hash,
         )
         entry.entry_hash = entry.compute_hash()

--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -84,25 +84,31 @@ class CMCPProxy:
         )
 
     def _build_cedar_context(
-        self, tool_name: str, arguments: dict[str, Any]
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        workflow_id: str | None = None,
     ) -> dict[str, Any]:
         """Build the Cedar evaluation context from call details + session state."""
         entry = self._catalog.lookup(tool_name)
-        return {
+        ctx: dict[str, Any] = {
             "tool_name": tool_name,
             "server_identity": entry.server.url if entry else "",
             "compliance_domain": entry.compliance_domain if entry else "external",
             "baa_covered": (not entry.requires_baa) if entry else False,
             "destination_class": "external",
             "session_max_sensitivity": self._session.max_sensitivity,
-            "workflow_id": getattr(self._session, "workflow_id", "default"),
         }
+        if workflow_id is not None:
+            ctx["workflow_id"] = workflow_id
+        return ctx
 
     async def call_tool(
         self,
         call_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        workflow_id: str | None = None,
     ) -> CallResult:
         """
         Execute one MCP tool call through the full enforcement pipeline.
@@ -138,6 +144,7 @@ class CMCPProxy:
                 request_payload_hash=None,
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
+                workflow_id=workflow_id,
             )
             return CallResult(
                 call_id=call_id,
@@ -151,7 +158,7 @@ class CMCPProxy:
             )
 
         # Step 2: Cedar policy evaluation
-        cedar_context = self._build_cedar_context(tool_name, arguments)
+        cedar_context = self._build_cedar_context(tool_name, arguments, workflow_id)
         policy_rule: str | None = None
         try:
             decision = self._policy.evaluate(cedar_context)
@@ -167,6 +174,7 @@ class CMCPProxy:
                 policy_rule_matched=str(exc),
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
+                workflow_id=workflow_id,
             )
             return CallResult(
                 call_id=call_id,
@@ -200,6 +208,7 @@ class CMCPProxy:
                 policy_rule_matched=f"agt_gateway:{type(exc).__name__}",
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
+                workflow_id=workflow_id,
             )
             return CallResult(
                 call_id=call_id,
@@ -235,6 +244,7 @@ class CMCPProxy:
             latency_us=latency_us,
             session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
+            workflow_id=workflow_id,
         )
 
         return CallResult(

--- a/src/cmcp_gateway/mcp/server.py
+++ b/src/cmcp_gateway/mcp/server.py
@@ -123,9 +123,10 @@ class MCPServer:
         tool_name: str = params.get("name", "")
         arguments: dict[str, Any] = params.get("arguments", {})
         call_id = str(uuid.uuid4())
+        workflow_id: str | None = params.get("_cmcp", {}).get("workflow_id")
 
         try:
-            result = await self._proxy.call_tool(call_id, tool_name, arguments)
+            result = await self._proxy.call_tool(call_id, tool_name, arguments, workflow_id=workflow_id)
         except Exception as exc:
             logger.error("TEE_FAULT during call_tool: call_id=%s error=%s", call_id, exc)
             return JSONResponse(
@@ -158,17 +159,20 @@ class MCPServer:
                 status_code=403,
             )
 
+        cmcp_meta: dict[str, Any] = {
+            "call_id": call_id,
+            "audit_entry_hash": result.audit_entry_hash,
+            "would_have_denied": result.would_have_denied,
+            "latency_us": result.latency_us,
+        }
+        if workflow_id is not None:
+            cmcp_meta["workflow_id"] = workflow_id
         return JSONResponse({
             "jsonrpc": "2.0",
             "id": rpc_id,
             "result": {
                 "content": [{"type": "text", "text": str(result.response)}],
-                "_cmcp": {
-                    "call_id": call_id,
-                    "audit_entry_hash": result.audit_entry_hash,
-                    "would_have_denied": result.would_have_denied,
-                    "latency_us": result.latency_us,
-                },
+                "_cmcp": cmcp_meta,
             },
         })
 

--- a/tests/unit/test_workflow_scope.py
+++ b/tests/unit/test_workflow_scope.py
@@ -1,0 +1,228 @@
+"""Tests for per-workflow Cedar policy scope (issue #79)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_gateway.config import AttestationConfig, Config, EnforcementMode
+from cmcp_gateway.policy.evaluator import PolicyDecision, PolicyEvaluator
+from cmcp_gateway.session.state import SessionState
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
+    return CatalogEntry(
+        tool_name=tool_name,
+        server=ServerIdentity(
+            display_name="Test",
+            url="https://test.example.com/mcp",
+            tls_fingerprint="SHA256:AAAA/BBBB==",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="test tool",
+            input_schema={},
+            output_schema=None,
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="external",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-05T00:00:00Z",
+        approved_by="test",
+    )
+
+
+def _make_catalog(*tools: str) -> ToolCatalog:
+    entries = {t: _make_entry(t) for t in (tools or ("test.tool",))}
+    return ToolCatalog(entries=entries, catalog_hash="sha256:" + "1" * 64)
+
+
+def _make_evaluator() -> PolicyEvaluator:
+    evaluator = MagicMock(spec=PolicyEvaluator)
+    evaluator.evaluate.return_value = PolicyDecision(
+        allowed=True,
+        enforcement_mode=EnforcementMode.ENFORCING,
+        rule_matched=None,
+        advice={},
+        evaluation_ms=0.1,
+        would_have_denied=False,
+    )
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+    return evaluator
+
+
+def _make_proxy(evaluator=None):
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    cat = _make_catalog()
+    ev = evaluator or _make_evaluator()
+    session = SessionState(session_id="sess-wf-001")
+    chain = AuditChain("sess-wf-001")
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(cat, ev, session, chain, cfg)
+        proxy._mcp_gateway = MagicMock()
+        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+            sensitivity_tags=[], injection_detected=False
+        ))
+    return proxy, ev, chain
+
+
+# ── Cedar context tests ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_workflow_id_omits_key_from_cedar_context():
+    """Without workflow_id, the Cedar context should not contain a workflow_id key."""
+    proxy, evaluator, _ = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {})
+
+    evaluator.evaluate.assert_called_once()
+    ctx = evaluator.evaluate.call_args[0][0]
+    assert "workflow_id" not in ctx
+
+
+@pytest.mark.asyncio
+async def test_workflow_id_included_in_cedar_context():
+    """When workflow_id is provided, it appears in the Cedar context dict."""
+    proxy, evaluator, _ = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {}, workflow_id="workflow_x")
+
+    evaluator.evaluate.assert_called_once()
+    ctx = evaluator.evaluate.call_args[0][0]
+    assert ctx.get("workflow_id") == "workflow_x"
+
+
+# ── Audit entry tests ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_audit_entry_has_no_workflow_id_when_not_provided():
+    """Audit entry workflow_id is None when call_tool is invoked without one."""
+    proxy, _, chain = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {})
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert len(tool_entries) == 1
+    assert tool_entries[0].workflow_id is None
+
+
+@pytest.mark.asyncio
+async def test_audit_entry_records_workflow_id():
+    """Audit entry workflow_id is set when call_tool is invoked with workflow_id."""
+    proxy, _, chain = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {}, workflow_id="workflow_x")
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert len(tool_entries) == 1
+    assert tool_entries[0].workflow_id == "workflow_x"
+
+
+@pytest.mark.asyncio
+async def test_audit_chain_still_valid_with_workflow_id():
+    """Audit chain hash integrity holds after a call with workflow_id."""
+    proxy, _, chain = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {}, workflow_id="workflow_x")
+    assert chain.verify_chain()
+
+
+# ── MCPServer integration ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_server_extracts_workflow_id_from_cmcp_params():
+    """MCPServer passes workflow_id from request _cmcp field to call_tool."""
+    from starlette.testclient import TestClient
+
+    from cmcp_gateway.mcp.server import MCPServer
+
+    proxy, _, chain = _make_proxy()
+    # Wrap call_tool so we can inspect arguments
+    original = proxy.call_tool
+    captured: dict = {}
+
+    async def _spy(call_id, tool_name, arguments, *, workflow_id=None):
+        captured["workflow_id"] = workflow_id
+        return await original(call_id, tool_name, arguments, workflow_id=workflow_id)
+
+    proxy.call_tool = _spy
+
+    server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=True)
+
+    resp = client.post("/mcp", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "test.tool",
+            "arguments": {},
+            "_cmcp": {"workflow_id": "workflow_x"},
+        },
+    })
+    assert resp.status_code == 200
+    assert captured.get("workflow_id") == "workflow_x"
+
+
+@pytest.mark.asyncio
+async def test_server_response_includes_workflow_id_when_provided():
+    """MCPServer echoes workflow_id in the response _cmcp block."""
+    from starlette.testclient import TestClient
+
+    from cmcp_gateway.mcp.server import MCPServer
+
+    proxy, _, _ = _make_proxy()
+    server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=True)
+
+    resp = client.post("/mcp", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "test.tool",
+            "arguments": {},
+            "_cmcp": {"workflow_id": "workflow_x"},
+        },
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["_cmcp"]["workflow_id"] == "workflow_x"
+
+
+@pytest.mark.asyncio
+async def test_server_response_omits_workflow_id_when_not_provided():
+    """MCPServer does not include workflow_id in _cmcp if not in request."""
+    from starlette.testclient import TestClient
+
+    from cmcp_gateway.mcp.server import MCPServer
+
+    proxy, _, _ = _make_proxy()
+    server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=True)
+
+    resp = client.post("/mcp", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "test.tool",
+            "arguments": {},
+        },
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "workflow_id" not in body["result"]["_cmcp"]


### PR DESCRIPTION
## Summary

- Extends `AuditEntry` with a `workflow_id: str | None` field and threads it through `AuditChain.append()`
- `CMCPProxy.call_tool()` accepts an optional `workflow_id` kwarg; when provided, it is included in the Cedar evaluation context dict as `context.workflow_id` and recorded in the audit entry
- `MCPServer._handle_tool_call()` extracts `workflow_id` from `params["_cmcp"]["workflow_id"]` and echoes it back in the response `_cmcp` block

Cedar policies can now restrict tool access per-workflow:
```cedar
permit(principal, action == Action::"call_tool", resource)
when { context.tool == "tool_a" && context.workflow_id == "workflow_x" };
```

## Test plan

- [ ] `test_no_workflow_id_omits_key_from_cedar_context` — no `workflow_id` key in Cedar context when not provided
- [ ] `test_workflow_id_included_in_cedar_context` — `workflow_id` present in Cedar context when provided
- [ ] `test_audit_entry_has_no_workflow_id_when_not_provided` — audit entry `workflow_id` is `None`
- [ ] `test_audit_entry_records_workflow_id` — audit entry `workflow_id` is set
- [ ] `test_audit_chain_still_valid_with_workflow_id` — chain hash integrity unchanged
- [ ] `test_server_extracts_workflow_id_from_cmcp_params` — server passes `workflow_id` to proxy
- [ ] `test_server_response_includes_workflow_id_when_provided` — `_cmcp` block echoes `workflow_id`
- [ ] `test_server_response_omits_workflow_id_when_not_provided` — no extra key in `_cmcp` block
- [ ] Full suite: 242 passed

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)