### PR TITLE
fix(config): fail closed on unknown keys and deduplicate dev_mode read (CONF-001, CONF-002)

### DIFF
--- a/src/cmcp_gateway/config.py
+++ b/src/cmcp_gateway/config.py
@@ -71,8 +71,9 @@ def load_config(path: str) -> Config:
 
     for key in raw:
         if key not in _KNOWN_TOP_KEYS:
-            import warnings
-            warnings.warn(f"Unknown config key '{key}' — ignored", stacklevel=2)
+            raise ConfigError(
+                f"Unknown config key '{key}'. Valid keys: {sorted(_KNOWN_TOP_KEYS)}"
+            )
 
     attest_raw = raw.get("attestation", {})
     if not isinstance(attest_raw, dict):
@@ -80,8 +81,9 @@ def load_config(path: str) -> Config:
 
     for key in attest_raw:
         if key not in _KNOWN_ATTEST_KEYS:
-            import warnings
-            warnings.warn(f"Unknown attestation key '{key}' — ignored", stacklevel=2)
+            raise ConfigError(
+                f"Unknown attestation key '{key}'. Valid keys: {sorted(_KNOWN_ATTEST_KEYS)}"
+            )
 
     try:
         provider = TEEProvider(attest_raw.get("provider", "auto"))

--- a/src/cmcp_gateway/tee/detect.py
+++ b/src/cmcp_gateway/tee/detect.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from cmcp_gateway.config import Config
 from cmcp_gateway.config import TEEProvider as TEEProviderEnum
@@ -58,7 +57,7 @@ def detect_provider(config: Config) -> TEEProvider:
 
     If config.attestation.provider is not "auto", only that provider is tried.
     """
-    dev_mode = config.dev_mode or os.environ.get("CMCP_DEV_MODE", "0") == "1"
+    dev_mode = config.dev_mode
 
     if config.attestation.provider != TEEProviderEnum.AUTO:
         # Explicit provider requested

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,6 @@
 """Tests for configuration parser (issue #64)."""
 
 import textwrap
-import warnings
 from pathlib import Path
 
 import pytest
@@ -69,12 +68,11 @@ def test_invalid_validity_seconds(config_file):
         load_config(path)
 
 
-def test_unknown_key_warns(config_file):
+def test_unknown_key_raises(config_file):
+    """CONF-001 — unknown config keys must fail closed, not silently ignore."""
     path = config_file("unknown_key: value\n")
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    with pytest.raises(ConfigError, match="unknown_key"):
         load_config(path)
-    assert any("unknown_key" in str(warning.message) for warning in w)
 
 
 def test_empty_config_uses_defaults(config_file):

--- a/tests/unit/test_tee.py
+++ b/tests/unit/test_tee.py
@@ -96,11 +96,12 @@ def test_detect_raises_when_no_hardware_and_no_dev_mode(no_dev_config):
         detect_provider(no_dev_config)
 
 
-def test_detect_via_env_var(no_dev_config, monkeypatch):
+def test_detect_env_var_alone_does_not_bypass_config(no_dev_config, monkeypatch):
+    """CONF-002 — CMCP_DEV_MODE in env after config load must not enable software-only."""
     monkeypatch.setenv("CMCP_DEV_MODE", "1")
-    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None):
-        provider = detect_provider(no_dev_config)
-    assert isinstance(provider, SoftwareOnlyProvider)
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", return_value=None), \
+         pytest.raises(AttestationProviderUnsupported):
+        detect_provider(no_dev_config)
 
 
 def test_detect_uses_first_available_provider(dev_config):


### PR DESCRIPTION
## What

**CONF-001 (#150)** — Unknown config keys (top-level or under `attestation`) now raise `ConfigError` instead of `warnings.warn`. A mistyped key like `bearer-token` (instead of the env var) would previously silently apply an insecure default; now the gateway fails closed at startup.

**CONF-002 (#151)** — `detect_provider()` was re-reading `CMCP_DEV_MODE` directly from `os.environ` at line 61, creating a TOCTOU window between `load_config()` and TEE detection. Fixed to use `config.dev_mode` exclusively. Updated the test that previously verified the double-read behavior to now verify the correct behavior (env var alone after config load does not bypass dev mode gate).

## Test plan
- [ ] CI passes
- [ ] Config with unknown key raises `ConfigError` (not a warning)
- [ ] Setting `CMCP_DEV_MODE=1` after config is loaded does not enable software-only provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)