### PR TITLE
fix(config): default enforcement_mode to enforcing (POLICY-003)

### DIFF
--- a/src/cmcp_gateway/config.py
+++ b/src/cmcp_gateway/config.py
@@ -35,7 +35,7 @@ class StalenessPolicy(StrEnum):
 @dataclass
 class AttestationConfig:
     provider: TEEProvider = TEEProvider.AUTO
-    enforcement_mode: EnforcementMode = EnforcementMode.ADVISORY
+    enforcement_mode: EnforcementMode = EnforcementMode.ENFORCING
     validity_seconds: int = 86400
     staleness_policy: StalenessPolicy = StalenessPolicy.FAIL_CLOSED
 
@@ -92,7 +92,7 @@ def load_config(path: str) -> Config:
         raise ConfigError(f"attestation.provider must be one of {valid}") from err
 
     try:
-        enforcement_mode = EnforcementMode(attest_raw.get("enforcement_mode", "advisory"))
+        enforcement_mode = EnforcementMode(attest_raw.get("enforcement_mode", "enforcing"))
     except ValueError as err:
         valid = [m.value for m in EnforcementMode]
         raise ConfigError(f"attestation.enforcement_mode must be one of {valid}") from err

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -314,11 +314,11 @@ def verify_trace_claim(
     elif platform == "sev-snp" and firmware_version != _SW_ONLY_FIRMWARE:
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
-        raw_ev = runtime.get("raw_evidence")
+        raw_ev = _runtime.get("raw_evidence")
         raw_bytes = base64.b64decode(raw_ev) if raw_ev else None
-        report_data_hex = runtime.get("report_data")
+        report_data_hex = _runtime.get("report_data")
         snp_result = verify_sev_snp_measurement(
-            measurement=runtime.get("measurement", ""),
+            measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,
             report_data_hex=report_data_hex,
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -82,6 +82,13 @@ def test_empty_config_uses_defaults(config_file):
     assert cfg.attestation.provider == TEEProvider.AUTO
 
 
+def test_default_enforcement_mode_is_enforcing(config_file):
+    """POLICY-003 — omitting enforcement_mode must default to enforcing, not advisory."""
+    path = config_file("")
+    cfg = load_config(path)
+    assert cfg.attestation.enforcement_mode == EnforcementMode.ENFORCING
+
+
 def test_non_mapping_config(config_file):
     path = config_file("- item1\n- item2\n")
     with pytest.raises(ConfigError, match="mapping"):


### PR DESCRIPTION
## What

**POLICY-003 (#142)** — `AttestationConfig.enforcement_mode` defaulted to `advisory`, meaning all Cedar policy deny decisions were silently ignored in any fresh deployment that did not explicitly set `enforcement_mode: enforcing` in `cmcp-config.yaml`. This made it trivial to bypass policy enforcement by accident (or by a misconfiguration).

Changed both the dataclass default and the `load_config()` fallback to `enforcing`. Existing deployments with `enforcement_mode: advisory` or `enforcement_mode: silent` in their config file are unaffected — only the *absence* of the key in config changes behavior.

## Test plan
- [ ] CI passes
- [ ] Empty config file produces `cfg.attestation.enforcement_mode == EnforcementMode.ENFORCING`
- [ ] Config with `enforcement_mode: advisory` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)