### PR TITLE
feat(session): per-session call log and temporal adjacency tracking

### DIFF
--- a/src/cmcp_gateway/audit/chain.py
+++ b/src/cmcp_gateway/audit/chain.py
@@ -19,6 +19,7 @@ EntryType = Literal[
     "policy_load",
     "catalog_load",
     "fault",
+    "suspicious_call_sequence",
 ]
 
 PolicyDecision = Literal["allow", "deny", "redact", "advisory_deny", "fault", "n/a"]
@@ -48,6 +49,7 @@ class AuditEntry:
     response_inspection_result: InspectionResult | None
     session_sensitivity_before: str | None
     session_sensitivity_after: str | None
+    detail: dict[str, str | int] | None  # optional structured detail (e.g. suspicious_call_sequence)
     prev_entry_hash: str  # "genesis" for first entry
     entry_hash: str = field(default="")  # computed after construction
 
@@ -107,6 +109,7 @@ class AuditChain:
         response_inspection_result: InspectionResult | None = None,
         session_sensitivity_before: str | None = None,
         session_sensitivity_after: str | None = None,
+        detail: dict[str, str | int] | None = None,
     ) -> AuditEntry:
         prev_hash = self._entries[-1].entry_hash if self._entries else "genesis"
         entry = AuditEntry(
@@ -126,6 +129,7 @@ class AuditChain:
             response_inspection_result=response_inspection_result,
             session_sensitivity_before=session_sensitivity_before,
             session_sensitivity_after=session_sensitivity_after,
+            detail=detail,
             prev_entry_hash=prev_hash,
         )
         entry.entry_hash = entry.compute_hash()

--- a/src/cmcp_gateway/audit/trace_claim.py
+++ b/src/cmcp_gateway/audit/trace_claim.py
@@ -120,6 +120,16 @@ class GatewayTrace(BaseModel):
     cnf: ConfirmationKey
 
 
+class CallLogSummary(BaseModel):
+    """Per-session call log summary included in the gateway addenda."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_calls: int
+    tools_called: list[str]
+    suspicious_sequences_detected: int
+
+
 class GatewayAddenda(BaseModel):
     """cmcp-specific fields outside the canonical TRACE spec."""
 
@@ -133,6 +143,7 @@ class GatewayAddenda(BaseModel):
     attestation_validity_seconds: int
     attestation_stale: bool
     catalog_exceptions: list[dict[str, str]] = Field(default_factory=list)
+    call_log_summary: CallLogSummary | None = None
 
 
 class GatewayClaim(BaseModel):
@@ -239,6 +250,7 @@ def generate_trace_claim(
     audit_chain_length: int,
     attestation_stale: bool = False,
     catalog_exceptions: list[dict[str, str]] | None = None,
+    call_log_summary: CallLogSummary | None = None,
     do_sign: bool = True,
 ) -> GatewayClaim:
     """Generate a GatewayClaim from session data, validate it via Pydantic, and optionally sign it.
@@ -294,6 +306,7 @@ def generate_trace_claim(
         attestation_validity_seconds=attestation_report.attestation_validity_seconds,
         attestation_stale=attestation_stale,
         catalog_exceptions=catalog_exceptions or [],
+        call_log_summary=call_log_summary,
     )
 
     claim = GatewayClaim(trace=trace, gateway=gateway)

--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from agent_os.mcp_gateway import GovernancePolicy, MCPGateway  # type: ignore[attr-defined]
@@ -25,6 +26,7 @@ from cmcp_gateway.catalog.loader import ToolCatalog
 from cmcp_gateway.config import Config
 from cmcp_gateway.errors import PolicyDeny
 from cmcp_gateway.policy.evaluator import PolicyEvaluator
+from cmcp_gateway.session.call_log import CallLog, CallRecord
 from cmcp_gateway.session.state import SessionState
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,7 @@ class CMCPProxy:
         session: SessionState,
         audit_chain: AuditChain,
         config: Config,
+        call_log: CallLog | None = None,
     ) -> None:
         self._catalog = catalog
         self._policy = policy_evaluator
@@ -70,6 +73,7 @@ class CMCPProxy:
         self._audit = audit_chain
         self._config = config
         self._enforcement = config.attestation.enforcement_mode
+        self._call_log: CallLog = call_log if call_log is not None else CallLog(session_id=session.session_id)
 
         # Build AGT GovernancePolicy from cMCP catalog
         allowed_tools = list(catalog.entries.keys())
@@ -98,6 +102,42 @@ class CMCPProxy:
             "workflow_id": getattr(self._session, "workflow_id", "default"),
         }
 
+    def _record_call(
+        self,
+        tool_name: str,
+        called_at: datetime,
+        duration_ms: float,
+        allowed: bool,
+        sensitivity_before: str,
+        stage_results: dict[str, str],
+    ) -> None:
+        """
+        Append a CallRecord to the session call log and check for suspicious
+        sequences. On detection: write a suspicious_call_sequence audit entry
+        and increment session.suspicious_sequences.
+        """
+        sensitivity_raised = self._session.max_sensitivity != sensitivity_before
+        self._call_log.record(
+            CallRecord(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=duration_ms,
+                allowed=allowed,
+                sensitivity_raised=sensitivity_raised,
+                stage_results=stage_results,
+            )
+        )
+        if self._call_log.suspicious_sequence():
+            consecutive = self._call_log.consecutive_count(tool_name)
+            self._audit.append(
+                "suspicious_call_sequence",
+                tool_name=tool_name,
+                detail={"repeated_tool": tool_name, "consecutive_calls": consecutive},
+                session_sensitivity_before=self._session.max_sensitivity,
+                session_sensitivity_after=self._session.max_sensitivity,
+            )
+            self._session.suspicious_sequences += 1
+
     async def call_tool(
         self,
         call_id: str,
@@ -114,6 +154,7 @@ class CMCPProxy:
           4. Forward to upstream (via AGT)
           5. Audit chain write
           6. Session state update
+          7. Call log record + suspicious-sequence check
 
         Returns CallResult regardless of allow/deny so the caller can always
         write a complete audit entry.
@@ -121,6 +162,7 @@ class CMCPProxy:
         import time
 
         t0 = time.perf_counter()
+        called_at = datetime.now(UTC)
         sensitivity_before = self._session.max_sensitivity
         would_have_denied = False
 
@@ -139,6 +181,15 @@ class CMCPProxy:
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
             )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"catalog": "deny"},
+            )
             return CallResult(
                 call_id=call_id,
                 tool_name=tool_name,
@@ -146,7 +197,7 @@ class CMCPProxy:
                 would_have_denied=False,
                 response=None,
                 deny_reason=deny_reason,
-                latency_us=int((time.perf_counter() - t0) * 1_000_000),
+                latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
 
@@ -168,6 +219,15 @@ class CMCPProxy:
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
             )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"policy": "deny"},
+            )
             return CallResult(
                 call_id=call_id,
                 tool_name=tool_name,
@@ -175,7 +235,7 @@ class CMCPProxy:
                 would_have_denied=False,
                 response=None,
                 deny_reason=str(exc),
-                latency_us=int((time.perf_counter() - t0) * 1_000_000),
+                latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
 
@@ -201,6 +261,15 @@ class CMCPProxy:
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
             )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"agt_gateway": "deny"},
+            )
             return CallResult(
                 call_id=call_id,
                 tool_name=tool_name,
@@ -208,7 +277,7 @@ class CMCPProxy:
                 would_have_denied=would_have_denied,
                 response=None,
                 deny_reason=str(exc),
-                latency_us=int((time.perf_counter() - t0) * 1_000_000),
+                latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
 
@@ -276,6 +345,17 @@ class CMCPProxy:
             latency_us=latency_us,
             session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
+        )
+
+        # Step 6: call log record + suspicious-sequence check
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        self._record_call(
+            tool_name=tool_name,
+            called_at=called_at,
+            duration_ms=elapsed_ms,
+            allowed=True,
+            sensitivity_before=sensitivity_before,
+            stage_results={"policy": str(policy_decision)},
         )
 
         return CallResult(

--- a/src/cmcp_gateway/session/call_log.py
+++ b/src/cmcp_gateway/session/call_log.py
@@ -1,0 +1,74 @@
+"""Per-session call log and temporal adjacency tracking — implements issue #94."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class CallRecord:
+    tool_name: str
+    called_at: datetime
+    duration_ms: float
+    allowed: bool
+    sensitivity_raised: bool  # True if this call raised session sensitivity level
+    stage_results: dict[str, str]  # stage name -> decision string
+
+
+@dataclass
+class CallLog:
+    session_id: str
+    records: list[CallRecord] = field(default_factory=list)
+
+    def record(self, call: CallRecord) -> None:
+        self.records.append(call)
+
+    def recent(self, n: int = 10) -> list[CallRecord]:
+        """Return the last n records."""
+        return self.records[-n:]
+
+    def tools_called(self) -> list[str]:
+        """Return unique tool names in call order (first-seen)."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for r in self.records:
+            if r.tool_name not in seen:
+                seen.add(r.tool_name)
+                result.append(r.tool_name)
+        return result
+
+    def adjacent_pairs(self) -> list[tuple[str, str]]:
+        """Return (tool_i, tool_i+1) pairs for consecutive calls."""
+        names = [r.tool_name for r in self.records]
+        return list(zip(names, names[1:], strict=False))
+
+    def suspicious_sequence(self, threshold: int = 3) -> bool:
+        """
+        Return True if the same tool was called more than `threshold` times
+        consecutively — a potential injection/replay pattern.
+        """
+        if not self.records:
+            return False
+        count = 1
+        for i in range(1, len(self.records)):
+            if self.records[i].tool_name == self.records[i - 1].tool_name:
+                count += 1
+                if count > threshold:
+                    return True
+            else:
+                count = 1
+        return False
+
+    def consecutive_count(self, tool_name: str) -> int:
+        """Return the current run length of `tool_name` at the tail of the log."""
+        count = 0
+        for r in reversed(self.records):
+            if r.tool_name == tool_name:
+                count += 1
+            else:
+                break
+        return count
+
+
+__all__ = ["CallLog", "CallRecord"]

--- a/src/cmcp_gateway/session/manager.py
+++ b/src/cmcp_gateway/session/manager.py
@@ -15,11 +15,13 @@ from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.trace_claim import (
     AttestationReportInfo,
     CallGraphSummary,
+    CallLogSummary,
     CallSummary,
     PolicyBundleInfo,
     ToolCatalogInfo,
     generate_trace_claim,
 )
+from cmcp_gateway.session.call_log import CallLog
 from cmcp_gateway.session.state import SessionState
 from cmcp_gateway.startup import GatewayContext
 
@@ -43,7 +45,11 @@ class SessionManager:
         return state, chain
 
     def close_session(
-        self, session_id: str, state: SessionState, chain: AuditChain
+        self,
+        session_id: str,
+        state: SessionState,
+        chain: AuditChain,
+        call_log: CallLog | None = None,
     ) -> dict[str, Any]:
         """
         Close a session:
@@ -141,6 +147,14 @@ class SessionManager:
             ),
         )
 
+        call_log_summary: CallLogSummary | None = None
+        if call_log is not None:
+            call_log_summary = CallLogSummary(
+                total_calls=len(call_log.records),
+                tools_called=call_log.tools_called(),
+                suspicious_sequences_detected=state.suspicious_sequences,
+            )
+
         claim = generate_trace_claim(
             session_id=session_id,
             signing_key=ctx.signing_key,
@@ -153,6 +167,7 @@ class SessionManager:
             audit_chain_length=chain.length,
             attestation_stale=attestation_stale,
             catalog_exceptions=catalog_exceptions,
+            call_log_summary=call_log_summary,
             do_sign=True,
         )
 

--- a/src/cmcp_gateway/session/state.py
+++ b/src/cmcp_gateway/session/state.py
@@ -52,6 +52,7 @@ class SessionState:
     sensitivity_raised_by_call: str | None = None
     injection_events: list[InjectionEvent] = field(default_factory=list)
     reset_count: int = 0
+    suspicious_sequences: int = 0
 
     def update_from_inspection(
         self,
@@ -92,6 +93,7 @@ class SessionState:
         self.max_sensitivity = "public"
         self.sensitivity_raised_at = None
         self.sensitivity_raised_by_call = None
+        self.suspicious_sequences = 0
         self.reset_count += 1
         # reason and authorized_by are logged by the caller in the audit chain
         return previous_session_id, self.session_id

--- a/tests/unit/test_call_log.py
+++ b/tests/unit/test_call_log.py
@@ -1,0 +1,128 @@
+"""Tests for CallLog and temporal adjacency tracking (issue #94)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from cmcp_gateway.session.call_log import CallLog, CallRecord
+
+
+def _rec(tool: str) -> CallRecord:
+    return CallRecord(
+        tool_name=tool,
+        called_at=datetime.now(UTC),
+        duration_ms=1.0,
+        allowed=True,
+        sensitivity_raised=False,
+        stage_results={"policy": "allow"},
+    )
+
+
+# ── empty log ─────────────────────────────────────────────────────────────────
+
+def test_empty_adjacent_pairs():
+    log = CallLog(session_id="s1")
+    assert log.adjacent_pairs() == []
+
+
+def test_empty_suspicious_sequence():
+    log = CallLog(session_id="s1")
+    assert log.suspicious_sequence() is False
+
+
+# ── single entry ──────────────────────────────────────────────────────────────
+
+def test_single_entry_tools_called():
+    log = CallLog(session_id="s1")
+    log.record(_rec("tool.a"))
+    assert log.tools_called() == ["tool.a"]
+
+
+def test_single_entry_not_suspicious():
+    log = CallLog(session_id="s1")
+    log.record(_rec("tool.a"))
+    assert log.suspicious_sequence() is False
+
+
+# ── alternating tools ─────────────────────────────────────────────────────────
+
+def test_alternating_not_suspicious():
+    log = CallLog(session_id="s1")
+    for tool in ["a", "b", "a", "b", "a", "b"]:
+        log.record(_rec(tool))
+    assert log.suspicious_sequence() is False
+
+
+# ── same tool 4x (threshold=3): suspicious ────────────────────────────────────
+
+def test_same_tool_four_times_suspicious():
+    log = CallLog(session_id="s1")
+    for _ in range(4):
+        log.record(_rec("tool.x"))
+    assert log.suspicious_sequence(threshold=3) is True
+
+
+# ── same tool exactly 3x then different: not suspicious ───────────────────────
+
+def test_same_tool_three_then_different_not_suspicious():
+    log = CallLog(session_id="s1")
+    for _ in range(3):
+        log.record(_rec("tool.x"))
+    log.record(_rec("tool.y"))
+    assert log.suspicious_sequence(threshold=3) is False
+
+
+# ── recent(n) returns last n ──────────────────────────────────────────────────
+
+def test_recent_returns_last_n():
+    log = CallLog(session_id="s1")
+    tools = [f"tool.{i}" for i in range(10)]
+    for t in tools:
+        log.record(_rec(t))
+    recent = log.recent(5)
+    assert len(recent) == 5
+    assert [r.tool_name for r in recent] == tools[-5:]
+
+
+def test_recent_fewer_than_n():
+    log = CallLog(session_id="s1")
+    log.record(_rec("tool.a"))
+    log.record(_rec("tool.b"))
+    assert len(log.recent(10)) == 2
+
+
+# ── tools_called preserves first-seen order ───────────────────────────────────
+
+def test_tools_called_first_seen_order():
+    log = CallLog(session_id="s1")
+    for tool in ["c", "a", "b", "a", "c", "d"]:
+        log.record(_rec(tool))
+    assert log.tools_called() == ["c", "a", "b", "d"]
+
+
+# ── adjacent_pairs ────────────────────────────────────────────────────────────
+
+def test_adjacent_pairs_single():
+    log = CallLog(session_id="s1")
+    log.record(_rec("a"))
+    assert log.adjacent_pairs() == []
+
+
+def test_adjacent_pairs_multiple():
+    log = CallLog(session_id="s1")
+    for t in ["a", "b", "c"]:
+        log.record(_rec(t))
+    assert log.adjacent_pairs() == [("a", "b"), ("b", "c")]
+
+
+# ── suspicious resets after different tool breaks run ─────────────────────────
+
+def test_suspicious_reset_mid_sequence():
+    log = CallLog(session_id="s1")
+    for _ in range(4):
+        log.record(_rec("x"))   # suspicious after 4th
+    assert log.suspicious_sequence(threshold=3) is True
+    log.record(_rec("y"))       # breaks run
+    log.record(_rec("x"))
+    # now x has run of 1 — still overall suspicious because earlier 4-run is in history
+    assert log.suspicious_sequence(threshold=3) is True

--- a/tests/unit/test_call_log_integration.py
+++ b/tests/unit/test_call_log_integration.py
@@ -1,0 +1,183 @@
+"""Integration tests: CallLog wired into CMCPProxy (issue #94)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_gateway.config import AttestationConfig, Config, EnforcementMode
+from cmcp_gateway.errors import PolicyDeny
+from cmcp_gateway.policy.evaluator import PolicyDecision, PolicyEvaluator
+from cmcp_gateway.session.call_log import CallLog
+from cmcp_gateway.session.state import SessionState
+
+
+def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
+    return CatalogEntry(
+        tool_name=tool_name,
+        server=ServerIdentity(
+            display_name="Test",
+            url="https://test.example.com/mcp",
+            tls_fingerprint="SHA256:AAAA/BBBB==",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="test tool",
+            input_schema={},
+            output_schema=None,
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="external",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-05T00:00:00Z",
+        approved_by="test",
+    )
+
+
+def _make_catalog(*tools: str) -> ToolCatalog:
+    entries = {t: _make_entry(t) for t in (tools or ("test.tool",))}
+    return ToolCatalog(entries=entries, catalog_hash="sha256:" + "1" * 64)
+
+
+def _make_evaluator(allow: bool = True) -> PolicyEvaluator:
+    evaluator = MagicMock(spec=PolicyEvaluator)
+    if allow:
+        evaluator.evaluate.return_value = PolicyDecision(
+            allowed=True,
+            enforcement_mode=EnforcementMode.ENFORCING,
+            rule_matched=None,
+            advice={},
+            evaluation_ms=0.1,
+            would_have_denied=False,
+        )
+    else:
+        evaluator.evaluate.side_effect = PolicyDeny("denied by Cedar")
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+    return evaluator
+
+
+def _make_proxy(catalog=None, evaluator=None, call_log=None):
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    cat = catalog or _make_catalog()
+    ev = evaluator or _make_evaluator()
+    session = SessionState(session_id="sess-001")
+    chain = AuditChain("sess-001")
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(cat, ev, session, chain, cfg, call_log=call_log)
+        proxy._mcp_gateway = MagicMock()
+        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+            sensitivity_tags=[], injection_detected=False
+        ))
+    return proxy, session, chain
+
+
+# ── proxy records call after each tool call ───────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_proxy_records_call_after_allow():
+    log = CallLog(session_id="sess-001")
+    proxy, _, _ = _make_proxy(call_log=log)
+    await proxy.call_tool("c1", "test.tool", {})
+    assert len(log.records) == 1
+    assert log.records[0].tool_name == "test.tool"
+    assert log.records[0].allowed is True
+
+
+@pytest.mark.asyncio
+async def test_proxy_records_call_on_catalog_deny():
+    log = CallLog(session_id="sess-001")
+    proxy, _, _ = _make_proxy(call_log=log)
+    await proxy.call_tool("c1", "nonexistent.tool", {})
+    assert len(log.records) == 1
+    assert log.records[0].allowed is False
+
+
+@pytest.mark.asyncio
+async def test_proxy_records_call_on_policy_deny():
+    log = CallLog(session_id="sess-001")
+    ev = _make_evaluator(allow=False)
+    proxy, _, _ = _make_proxy(evaluator=ev, call_log=log)
+    await proxy.call_tool("c1", "test.tool", {})
+    assert len(log.records) == 1
+    assert log.records[0].allowed is False
+
+
+@pytest.mark.asyncio
+async def test_proxy_accumulates_multiple_calls():
+    log = CallLog(session_id="sess-001")
+    proxy, _, _ = _make_proxy(call_log=log)
+    await proxy.call_tool("c1", "test.tool", {})
+    await proxy.call_tool("c2", "test.tool", {})
+    await proxy.call_tool("c3", "test.tool", {})
+    assert len(log.records) == 3
+
+
+# ── suspicious sequence detection increments session.suspicious_sequences ─────
+
+@pytest.mark.asyncio
+async def test_suspicious_sequence_increments_session_counter():
+    log = CallLog(session_id="sess-001")
+    proxy, session, _ = _make_proxy(call_log=log)
+    # Call the same tool 4 times (threshold=3 → suspicious after 4th)
+    for i in range(4):
+        await proxy.call_tool(f"c{i}", "test.tool", {})
+    assert session.suspicious_sequences >= 1
+
+
+# ── audit entry appended on suspicious detection ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_suspicious_sequence_writes_audit_entry():
+    log = CallLog(session_id="sess-001")
+    proxy, _, chain = _make_proxy(call_log=log)
+    for i in range(4):
+        await proxy.call_tool(f"c{i}", "test.tool", {})
+    suspicious_entries = [
+        e for e in chain.entries if e.entry_type == "suspicious_call_sequence"
+    ]
+    assert len(suspicious_entries) >= 1
+    assert suspicious_entries[0].tool_name == "test.tool"
+    assert suspicious_entries[0].detail is not None
+    assert suspicious_entries[0].detail["repeated_tool"] == "test.tool"
+
+
+@pytest.mark.asyncio
+async def test_no_suspicious_entry_when_below_threshold():
+    log = CallLog(session_id="sess-001")
+    proxy, session, chain = _make_proxy(call_log=log)
+    # 3 calls: at threshold but not over — not suspicious
+    for i in range(3):
+        await proxy.call_tool(f"c{i}", "test.tool", {})
+    suspicious_entries = [
+        e for e in chain.entries if e.entry_type == "suspicious_call_sequence"
+    ]
+    assert len(suspicious_entries) == 0
+    assert session.suspicious_sequences == 0
+
+
+# ── default call_log created when none provided ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_proxy_creates_default_call_log():
+    proxy, _, _ = _make_proxy()
+    assert proxy._call_log is not None
+    assert proxy._call_log.session_id == "sess-001"
+    await proxy.call_tool("c1", "test.tool", {})
+    assert len(proxy._call_log.records) == 1


### PR DESCRIPTION
## Summary

- Adds `CallLog` and `CallRecord` in `src/cmcp_gateway/session/call_log.py`: per-session log with `adjacent_pairs()` and `suspicious_sequence(threshold=3)` for injection/replay detection
- `CMCPProxy` records every tool call into a `CallLog`; when the same tool repeats more than 3× consecutively, appends a `suspicious_call_sequence` audit entry and increments `session.suspicious_sequences`
- `SessionState` gains `suspicious_sequences: int = 0` (cleared on `reset()`)
- `GatewayAddenda` gains `call_log_summary` with `total_calls`, `tools_called`, and `suspicious_sequences_detected`; `SessionManager.close_session()` passes the `CallLog` through to populate this

## Test plan

- [ ] `tests/unit/test_call_log.py` — 13 unit tests covering CallLog behaviors
- [ ] `tests/unit/test_call_log_integration.py` — 8 integration tests covering proxy wiring, detection, audit entries
- [ ] All existing tests pass

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)