### PR TITLE
fix(proxy,server): audit Cedar exceptions; add global 500 handler (POLICY-003, NET-004)

### DIFF
--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -245,6 +245,24 @@ class CMCPProxy:
                 latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
+        except Exception as exc:
+            # POLICY-003: Cedar backend raised an unexpected exception (e.g. malformed
+            # policy). Write a fault audit entry so the incident is traceable, then
+            # re-raise so server.py can return a generic 500.
+            logger.error("CEDAR_FAULT: tool=%s error=%s", tool_name, exc, exc_info=True)
+            self._audit.append(
+                "fault",
+                call_id=call_id,
+                tool_name=tool_name,
+                server_identity=entry.server.url,
+                policy_decision="fault",
+                policy_rule_matched=f"cedar_exception:{type(exc).__name__}",
+                request_payload_hash=request_payload_hash,
+                session_sensitivity_before=sensitivity_before,
+                session_sensitivity_after=self._session.max_sensitivity,
+                detail={"exception_type": type(exc).__name__},
+            )
+            raise
 
         # Step 3: AGT MCPGateway enforcement
         # AGT handles per-agent rate limiting, parameter sanitization, and

--- a/src/cmcp_gateway/mcp/server.py
+++ b/src/cmcp_gateway/mcp/server.py
@@ -37,6 +37,21 @@ logger = logging.getLogger(__name__)
 _AUTH_EXEMPT_PATHS = {"/health"}
 
 
+async def _unhandled_error_handler(request: Request, exc: Exception) -> Response:
+    """NET-004: return generic 500 without leaking exception class or message."""
+    logger.error(
+        "UNHANDLED_EXCEPTION: method=%s path=%s error=%s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
+    return JSONResponse(
+        {"error": "Internal server error", "error_code": "INTERNAL_ERROR"},
+        status_code=500,
+    )
+
+
 class _BearerAuthMiddleware(BaseHTTPMiddleware):
     """AUTH-001 (CRITICAL): validate Authorization: Bearer <token> on all protected endpoints."""
 
@@ -114,6 +129,7 @@ class MCPServer:
                 ),
             ],
             middleware=middleware,
+            exception_handlers={Exception: _unhandled_error_handler},
         )
 
     async def _handle_mcp(self, request: Request) -> Response:

--- a/tests/conformance/test_gateway_conformance.py
+++ b/tests/conformance/test_gateway_conformance.py
@@ -91,7 +91,7 @@ def _make_proxy(*, allowed: bool = True) -> MagicMock:
 
     if allowed:
         # Return allowed for known tools; denied for unknown tools (catalog miss).
-        def _call_side_effect(call_id: str, tool_name: str, arguments: dict) -> CallResult:  # type: ignore[type-arg]
+        def _call_side_effect(call_id: str, tool_name: str, arguments: dict, **kwargs) -> CallResult:  # type: ignore[type-arg]
             if tool_name in catalog.entries:
                 return _make_allowed_result(call_id, tool_name)
             return _make_denied_result(call_id, tool_name)
@@ -99,7 +99,7 @@ def _make_proxy(*, allowed: bool = True) -> MagicMock:
         proxy.call_tool = AsyncMock(side_effect=_call_side_effect)
     else:
         proxy.call_tool = AsyncMock(
-            side_effect=lambda call_id, tool_name, arguments: _make_denied_result(call_id, tool_name)
+            side_effect=lambda call_id, tool_name, arguments, **kwargs: _make_denied_result(call_id, tool_name)
         )
     return proxy
 

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -253,3 +253,26 @@ async def test_audit_payload_hash_is_canonical_sha256():
     expected_bytes = json.dumps(args, sort_keys=True, separators=(",", ":")).encode()
     expected = f"sha256:{hashlib.sha256(expected_bytes).hexdigest()}"
     assert entry.request_payload_hash == expected
+
+
+# ── POLICY-003: Cedar exception writes fault audit entry ──────────────────────
+
+@pytest.mark.asyncio
+async def test_cedar_exception_writes_fault_audit_entry():
+    """POLICY-003 — Cedar backend exception must emit a fault audit entry before re-raising."""
+    evaluator = MagicMock(spec=_make_evaluator().__class__)
+    evaluator.evaluate.side_effect = RuntimeError("malformed Cedar policy")
+    evaluator.authorize_egress.return_value = MagicMock(would_have_denied=False)
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+
+    proxy, _, chain = _make_proxy(evaluator=evaluator)
+
+    with pytest.raises(RuntimeError):
+        await proxy.call_tool("c1", "test.tool", {"x": 1})
+
+    fault_entries = [e for e in chain.entries if e.entry_type == "fault"]
+    assert len(fault_entries) == 1
+    assert fault_entries[0].policy_decision == "fault"
+    assert "RuntimeError" in (fault_entries[0].policy_rule_matched or "")
+    assert fault_entries[0].request_payload_hash is not None

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -156,6 +156,28 @@ def test_unknown_method_truncated_at_64_chars():
 
 # ── INJECT-003: deny_reason not reflected to caller ──────────────────────────
 
+# ── NET-004: unhandled exceptions return generic 500 ─────────────────────────
+
+def test_unhandled_exception_returns_generic_500():
+    """NET-004 — truly unhandled exception must not leak class or message to caller.
+
+    Uses /tools/list which has no try/except — an exception from catalog.entries.items()
+    propagates out of the handler and must be caught by the global exception handler.
+    """
+    proxy = MagicMock()
+    proxy._catalog = MagicMock()
+    proxy._catalog.entries.items.side_effect = RuntimeError("secret internal detail")
+    with patch("cmcp_gateway.mcp.server.StatelessKernel"):
+        server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.get("/tools/list")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "secret internal detail" not in str(body)
+    assert "RuntimeError" not in str(body)
+    assert body.get("error_code") == "INTERNAL_ERROR"
+
+
 def test_deny_response_does_not_include_internal_reason():
     """INJECT-003 — internal deny_reason must not appear in 403 response body."""
     proxy = MagicMock()


### PR DESCRIPTION
## Summary

- **POLICY-003** (#160): Cedar backend exceptions (malformed policy, encoding errors) now emit a `fault` audit entry with `policy_decision="fault"` and `exception_type` detail before re-raising. Previously these escaped silently with no audit trail.
- **NET-004** (#180): Added `_unhandled_error_handler` as a global Starlette `exception_handlers={Exception: ...}` handler. Truly unhandled exceptions now return `{"error_code": "INTERNAL_ERROR"}` (HTTP 500) without leaking exception class names or messages.

## Test plan

- [ ] `test_cedar_exception_writes_fault_audit_entry` — RuntimeError from Cedar backend produces one fault entry with correct policy_decision and exception_type
- [ ] `test_unhandled_exception_returns_generic_500` — unhandled exception in /tools/list returns 500 without leaking detail
- [ ] Full suite: 330 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)