### PR TITLE
fix(session): add upgrade_attestation() to rotate session token on attestation upgrade (AUTH-001)

### DIFF
--- a/src/cmcp_gateway/session/state.py
+++ b/src/cmcp_gateway/session/state.py
@@ -104,3 +104,19 @@ class SessionState:
         self.catalog_drift = False
         # reason and authorized_by are logged by the caller in the audit chain
         return previous_session_id, self.session_id
+
+    def upgrade_attestation(self) -> tuple[str, str]:
+        """
+        Rotate the session token when attestation upgrades (e.g. software-only → hardware TEE).
+
+        Unlike reset(), session sensitivity state is preserved — the ongoing session
+        continues at its current sensitivity level. Only the session_id is rotated so
+        that any trust assertions cached against the old ID are invalidated.
+
+        Returns (previous_session_id, new_session_id). The caller is responsible for
+        writing an attestation_refresh audit entry.
+        """
+        previous_session_id = self.session_id
+        self.session_id = str(uuid4())
+        self.attestation_stale = False
+        return previous_session_id, self.session_id

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -139,3 +139,42 @@ async def test_concurrent_update_and_reset_do_not_corrupt_state():
     tasks = [_update() for _ in range(5)] + [_reset() for _ in range(5)]
     await asyncio.gather(*tasks)
     assert state.max_sensitivity in SENSITIVITY_ORDER
+
+
+# ── AUTH-001: attestation upgrade rotates session token ───────────────────────
+
+def test_upgrade_attestation_rotates_session_id():
+    """AUTH-001: session token (session_id) must be rotated on attestation upgrade."""
+    state = SessionState(session_id="s1")
+    old_id, new_id = state.upgrade_attestation()
+    assert old_id == "s1"
+    assert new_id != "s1"
+    assert state.session_id == new_id
+
+
+def test_upgrade_attestation_clears_stale_flag():
+    state = SessionState(session_id="s1", attestation_stale=True)
+    state.upgrade_attestation()
+    assert state.attestation_stale is False
+
+
+def test_upgrade_attestation_preserves_sensitivity():
+    """Unlike reset(), upgrade_attestation() preserves accumulated session sensitivity."""
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["hipaa_phi"], False, True)
+    assert state.max_sensitivity == "hipaa_phi"
+    state.upgrade_attestation()
+    assert state.max_sensitivity == "hipaa_phi"
+
+
+def test_upgrade_attestation_preserves_injection_events():
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", [], injection_detected=True, response_allowed=False)
+    state.upgrade_attestation()
+    assert len(state.injection_events) == 1
+
+
+def test_upgrade_attestation_does_not_increment_reset_count():
+    state = SessionState(session_id="s1")
+    state.upgrade_attestation()
+    assert state.reset_count == 0


### PR DESCRIPTION
## Summary

- When attestation upgrades (software-only → hardware TEE), the session_id (session "token") was never rotated, leaving old trust assertions valid at the lower attestation level
- Added `SessionState.upgrade_attestation()` that rotates `session_id` and clears `attestation_stale`, while preserving accumulated sensitivity state and injection events (contrast with `reset()` which clears everything)
- Returns `(old_session_id, new_session_id)` for the caller to write an `attestation_refresh` audit entry

Fixes #163.

## Test plan

- [ ] `pytest tests/unit/test_session.py` — all 20 pass including 5 new AUTH-001 tests
- [ ] `pytest` full suite — no regressions