### PR TITLE
fix(policy): add attestation_platform to Cedar context at evaluation time (POLICY-005)

### DIFF
--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -71,6 +71,7 @@ class CMCPProxy:
         attestation_generated_at: datetime | None = None,
         attestation_validity_seconds: int = 86400,
         catalog_hash: str | None = None,
+        attestation_platform: str = "unknown",
     ) -> None:
         self._catalog = catalog
         self._policy = policy_evaluator
@@ -82,6 +83,7 @@ class CMCPProxy:
         self._attestation_generated_at = attestation_generated_at
         self._attestation_validity_seconds = attestation_validity_seconds
         self._catalog_hash = catalog_hash or catalog.catalog_hash
+        self._attestation_platform = attestation_platform
 
         # Build AGT GovernancePolicy from cMCP catalog
         allowed_tools = list(catalog.entries.keys())
@@ -158,6 +160,7 @@ class CMCPProxy:
             "baa_covered": (not entry.requires_baa) if entry else False,
             "destination_class": "external",
             "session_max_sensitivity": self._session.max_sensitivity,
+            "attestation_platform": self._attestation_platform,
         }
         if workflow_id is not None:
             ctx["workflow_id"] = workflow_id

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -207,6 +207,46 @@ async def test_cedar_context_includes_arguments():
     assert ctx["arguments"] == args
 
 
+# ── POLICY-005 (issue #162): attestation_platform in Cedar context ────────────
+
+@pytest.mark.asyncio
+async def test_cedar_context_includes_attestation_platform():
+    """POLICY-005 (issue #162) — attestation_platform must be in Cedar context so
+    policies can restrict calls to hardware-attested callers only."""
+    from cmcp_gateway.mcp.proxy import CMCPProxy
+
+    evaluator = _make_evaluator()
+    cfg = Config()
+    cfg.attestation = AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING)
+    session = SessionState(session_id="sess-001")
+    chain = AuditChain("sess-001")
+
+    with patch("cmcp_gateway.mcp.proxy.MCPGateway"), \
+         patch("cmcp_gateway.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            _make_catalog(), evaluator, session, chain, cfg,
+            attestation_platform="amd-sev-snp",
+        )
+        proxy._mcp_gateway = MagicMock()
+        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+            sensitivity_tags=[], injection_detected=False
+        ))
+
+    await proxy.call_tool("c1", "test.tool", {})
+    ctx = evaluator.evaluate.call_args[0][0]
+    assert ctx["attestation_platform"] == "amd-sev-snp"
+
+
+@pytest.mark.asyncio
+async def test_cedar_context_attestation_platform_default_is_unknown():
+    """POLICY-005 — default attestation_platform is 'unknown' when not specified."""
+    evaluator = _make_evaluator()
+    proxy, _, _ = _make_proxy(evaluator=evaluator)
+    await proxy.call_tool("c1", "test.tool", {})
+    ctx = evaluator.evaluate.call_args[0][0]
+    assert ctx["attestation_platform"] == "unknown"
+
+
 # ── POLICY-005: request_payload_hash in all audit entries ────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Cedar policy evaluation did not include `attestation_platform` in the context, so policies couldn't restrict `amd-sev-snp`-only access — a software-only attestation would satisfy any platform-scoped policy
- Added `attestation_platform: str = "unknown"` parameter to `CMCPProxy.__init__()` and included it in `_build_cedar_context()` return dict
- Default is `"unknown"` to ensure policies that check `context.attestation_platform == "amd-sev-snp"` fail closed by default

Fixes #162.

## Test plan

- [ ] `pytest tests/unit/test_mcp_proxy.py` — all 19 pass including 2 new POLICY-005 tests
- [ ] `pytest` full suite — no regressions