### PR TITLE
fix(startup): reject unknown TEE provider names at startup (HW-001)

### DIFF
--- a/src/cmcp_gateway/startup.py
+++ b/src/cmcp_gateway/startup.py
@@ -25,6 +25,17 @@ from cmcp_gateway.tee.spiffe import SpiffeClientResult, fetch_svid
 
 logger = logging.getLogger(__name__)
 
+# HW-001: allowlist of canonical TEE provider names that may appear in
+# AttestationReport.provider.  Mirrors the keys of _PROVIDER_MAP in
+# audit/trace_claim.py — kept as a local constant to avoid a circular import.
+_VALID_PROVIDERS: frozenset[str] = frozenset({
+    "sev-snp",
+    "tdx",
+    "opaque",
+    "tpm",
+    "software-only",
+})
+
 
 @dataclass
 class GatewayContext:
@@ -109,6 +120,20 @@ def run_startup(config_path: str) -> GatewayContext:
         attestation_report.provider,
         attestation_report.measurement[:16],
     )
+
+    # HW-001: reject unknown provider strings before they can propagate into
+    # TRACE Claims or Cedar policy context.  A custom or misconfigured provider
+    # could set an arbitrary value in provider_name(); validate here at the
+    # boundary rather than relying on downstream consumers to handle it.
+    if attestation_report.provider not in _VALID_PROVIDERS:
+        _fatal(
+            "ATTESTATION_PROVIDER_INVALID",
+            f"TEE provider returned unknown platform string '{attestation_report.provider}'. "
+            f"Allowed values: {sorted(_VALID_PROVIDERS)}.",
+            provider=attestation_report.provider,
+            action="startup_aborted",
+        )
+        sys.exit(1)
 
     # AUTH-001 (CRITICAL): require a bearer token in production to authenticate
     # inbound MCP calls. Without it, any network client can invoke any tool.

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -161,4 +161,24 @@ def test_startup_fails_when_catalog_hash_unset_and_not_dev_mode(tmp_path, monkey
     env = {"CMCP_DEV_MODE": "0", "CMCP_POLICY_HASH": policy_hash}
     with patch.dict(os.environ, env, clear=True), pytest.raises(SystemExit) as exc_info:
         run_startup(str(config_path))
+    assert exc_info.value.code == 1
+
+
+def test_startup_fails_on_unknown_tee_provider_name(complete_setup):
+    """HW-001: a provider that returns an unknown platform string must cause exit 1.
+
+    The mock bypasses AttestationReport.__post_init__ by returning a plain
+    MagicMock, simulating a custom or misconfigured provider that injects an
+    arbitrary string before the startup boundary check can catch it.
+    """
+    fake_report = MagicMock()
+    fake_report.provider = "evil-custom-tee"
+    fake_report.measurement = "aabbcc" * 8
+
+    with patch(
+        "cmcp_gateway.tee.base.SoftwareOnlyProvider.get_attestation_report",
+        return_value=fake_report,
+    ), pytest.raises(SystemExit) as exc_info:
+        run_startup(complete_setup)
+
     assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

- Closes #171 (HW-001: TEE platform string not validated before use in attestation report)
- Adds `_VALID_PROVIDERS: frozenset[str]` constant to `startup.py` with the five canonical provider names (`sev-snp`, `tdx`, `opaque`, `tpm`, `software-only`), mirroring the keys of `_PROVIDER_MAP` in `audit/trace_claim.py` without creating a circular import
- Validates `attestation_report.provider` against that allowlist immediately after attestation succeeds; calls `_fatal("ATTESTATION_PROVIDER_INVALID", ...)` and `sys.exit(1)` on any unknown value, preventing the string from propagating into TRACE Claims or Cedar policy context

## Test plan

- [ ] `test_startup_fails_on_unknown_tee_provider_name`: mocks `SoftwareOnlyProvider.get_attestation_report` to return a report with `provider="evil-custom-tee"` and asserts `sys.exit(1)`
- [ ] All 9 existing startup tests continue to pass
- [ ] Run `pytest tests/unit/test_startup.py -v` locally — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)