### PR TITLE
fix(tee): validate SNP measurement against expected value (HW-002)

### DIFF
--- a/src/cmcp_gateway/config.py
+++ b/src/cmcp_gateway/config.py
@@ -39,6 +39,7 @@ class AttestationConfig:
     enforcement_mode: EnforcementMode = EnforcementMode.ENFORCING
     validity_seconds: int = 86400
     staleness_policy: StalenessPolicy = StalenessPolicy.FAIL_CLOSED
+    expected_measurement: str | None = None
 
 
 @dataclass
@@ -54,7 +55,7 @@ class Config:
 
 
 _KNOWN_TOP_KEYS = {"attestation", "policy_bundle_path", "catalog_path", "listen_addr", "max_response_size_bytes", "policy_reload_interval_seconds"}
-_KNOWN_ATTEST_KEYS = {"provider", "enforcement_mode", "validity_seconds", "staleness_policy"}
+_KNOWN_ATTEST_KEYS = {"provider", "enforcement_mode", "validity_seconds", "staleness_policy", "expected_measurement"}
 
 
 def _check_no_traversal(field_name: str, path_str: str) -> None:
@@ -123,6 +124,10 @@ def load_config(path: str) -> Config:
     if not isinstance(validity_seconds, int) or validity_seconds <= 0:
         raise ConfigError("attestation.validity_seconds must be a positive integer")
 
+    expected_measurement = attest_raw.get("expected_measurement", None)
+    if expected_measurement is not None and not isinstance(expected_measurement, str):
+        raise ConfigError("attestation.expected_measurement must be a string")
+
     max_bytes = raw.get("max_response_size_bytes", 2 * 1024 * 1024)
     if not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ConfigError("max_response_size_bytes must be a positive integer")
@@ -145,6 +150,7 @@ def load_config(path: str) -> Config:
             enforcement_mode=enforcement_mode,
             validity_seconds=validity_seconds,
             staleness_policy=staleness_policy,
+            expected_measurement=expected_measurement,
         ),
         policy_bundle_path=policy_bundle_path,
         catalog_path=catalog_path,

--- a/src/cmcp_gateway/tee/detect.py
+++ b/src/cmcp_gateway/tee/detect.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 _PROBE_ORDER: list[str] = ["tpm", "sev-snp", "tdx", "opaque"]
 
 
-def _get_provider_impl(name: str) -> TEEProvider | None:
+def _get_provider_impl(name: str, config: Config | None = None) -> TEEProvider | None:
     """Import and return a provider implementation by name, or None if not found."""
     if name == "tpm":
         try:
@@ -26,7 +26,8 @@ def _get_provider_impl(name: str) -> TEEProvider | None:
     if name == "sev-snp":
         try:
             from cmcp_gateway.tee.sev_snp import SEVSNPProvider
-            return SEVSNPProvider()
+            expected = config.attestation.expected_measurement if config else None
+            return SEVSNPProvider(expected_measurement=expected)
         except ImportError:
             return None
     if name == "tdx":
@@ -72,7 +73,7 @@ def detect_provider(config: Config) -> TEEProvider:
                 "TRACE Claims produced here must not be used for compliance purposes."
             )
             return SoftwareOnlyProvider()
-        impl = _get_provider_impl(name)
+        impl = _get_provider_impl(name, config)
         if impl is None or not impl.detect():
             raise AttestationProviderUnsupported(
                 f"Requested provider '{name}' not available on this host",
@@ -83,7 +84,7 @@ def detect_provider(config: Config) -> TEEProvider:
 
     # Auto-detection
     for name in _PROBE_ORDER:
-        impl = _get_provider_impl(name)
+        impl = _get_provider_impl(name, config)
         if impl is not None and impl.detect():
             logger.info("TEE provider: %s (auto-detected)", name)
             return impl

--- a/src/cmcp_gateway/tee/sev_snp.py
+++ b/src/cmcp_gateway/tee/sev_snp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import struct
 import sys
 from datetime import UTC, datetime
@@ -34,6 +35,9 @@ _SNP_MEASUREMENT_END = 0x90  # 48 bytes = SHA-384
 
 class SEVSNPProvider(TEEProvider):
     """AMD SEV-SNP attestation provider using the /dev/sev-guest ioctl interface."""
+
+    def __init__(self, expected_measurement: str | None = None) -> None:
+        self._expected_measurement = expected_measurement
 
     def provider_name(self) -> str:
         return "sev-snp"
@@ -89,6 +93,16 @@ class SEVSNPProvider(TEEProvider):
         # Measurement = SHA-384 of the measurement field within the SNP report
         measurement_bytes = raw_evidence[_SNP_MEASUREMENT_OFFSET:_SNP_MEASUREMENT_END]
         measurement = "sha384:" + hashlib.sha384(measurement_bytes).hexdigest()
+
+        # HW-002: reject reports whose measurement doesn't match the expected binary hash.
+        # This prevents replay of a valid attestation report for a different binary.
+        if self._expected_measurement is not None:
+            if not hmac.compare_digest(measurement, self._expected_measurement):
+                raise RuntimeError(
+                    "SEV-SNP measurement mismatch: the report measurement does not match "
+                    "attestation.expected_measurement from config. "
+                    "This report may be replayed from a different binary or build."
+                )
 
         return AttestationReport(
             provider=self.provider_name(),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -156,3 +156,27 @@ def test_policy_reload_interval_non_integer_rejected(config_file):
     path = config_file("policy_reload_interval_seconds: 30.5\n")
     with pytest.raises(ConfigError, match="policy_reload_interval_seconds"):
         load_config(path)
+
+
+# ── HW-002: expected_measurement config field ─────────────────────────────────
+
+def test_expected_measurement_loaded_from_config(config_file):
+    """HW-002: attestation.expected_measurement is parsed and stored."""
+    em = "sha384:" + "a" * 96
+    path = config_file(f"attestation:\n  expected_measurement: {em}\n")
+    cfg = load_config(path)
+    assert cfg.attestation.expected_measurement == em
+
+
+def test_expected_measurement_defaults_to_none(config_file):
+    """HW-002: omitting expected_measurement leaves it as None."""
+    path = config_file("attestation:\n  provider: auto\n")
+    cfg = load_config(path)
+    assert cfg.attestation.expected_measurement is None
+
+
+def test_expected_measurement_non_string_rejected(config_file):
+    """HW-002: a non-string expected_measurement is a config error."""
+    path = config_file("attestation:\n  expected_measurement: 12345\n")
+    with pytest.raises(ConfigError, match="expected_measurement"):
+        load_config(path)

--- a/tests/unit/test_tee.py
+++ b/tests/unit/test_tee.py
@@ -108,7 +108,7 @@ def test_detect_uses_first_available_provider(dev_config):
     """detect_provider picks the first provider whose detect() returns True."""
     mock_provider = SoftwareOnlyProvider()  # reuse as a stand-in
 
-    def _mock_get(name: str):
+    def _mock_get(name, config=None):
         if name == "sev-snp":
             return mock_provider
         return None
@@ -163,3 +163,131 @@ def test_attestation_report_known_providers_accepted():
             attestation_generated_at=datetime.now(tz=timezone.utc),
             attestation_validity_seconds=86400,
         )
+
+
+# ── HW-002: SEVSNPProvider expected_measurement validation ───────────────────
+
+def test_sevsnp_no_expected_measurement_skips_check():
+    """HW-002: when expected_measurement is None, attribute is None (check skipped)."""
+    from cmcp_gateway.tee.sev_snp import SEVSNPProvider
+    provider = SEVSNPProvider(expected_measurement=None)
+    assert provider._expected_measurement is None
+
+
+def test_sevsnp_stores_expected_measurement():
+    """HW-002: SEVSNPProvider stores the configured expected_measurement."""
+    from cmcp_gateway.tee.sev_snp import SEVSNPProvider
+    em = "sha384:" + "a" * 96
+    provider = SEVSNPProvider(expected_measurement=em)
+    assert provider._expected_measurement == em
+
+
+def test_sevsnp_rejects_mismatched_expected_measurement(monkeypatch):
+    """HW-002: measurement mismatch raises RuntimeError before returning the report."""
+    import hashlib
+    import struct
+    import sys
+    from unittest.mock import MagicMock
+
+    from cmcp_gateway.tee.sev_snp import (
+        SEVSNPProvider,
+        _SNP_MEASUREMENT_END,
+        _SNP_MEASUREMENT_OFFSET,
+        _SNP_REPORT_SIZE,
+        _SNP_RESP_HEADER_SIZE,
+    )
+
+    # Build a fake ioctl response with a known measurement
+    measurement_bytes = b"\xab" * (_SNP_MEASUREMENT_END - _SNP_MEASUREMENT_OFFSET)
+    raw_evidence = bytearray(_SNP_REPORT_SIZE)
+    raw_evidence[_SNP_MEASUREMENT_OFFSET:_SNP_MEASUREMENT_END] = measurement_bytes
+
+    resp_buf = bytearray(_SNP_RESP_HEADER_SIZE + _SNP_REPORT_SIZE)
+    struct.pack_into("<I", resp_buf, 0, 0)  # status = 0
+    resp_buf[_SNP_RESP_HEADER_SIZE:] = raw_evidence
+
+    def fake_ioctl(fd, req, buf):
+        buf[:] = resp_buf
+
+    mock_fcntl = MagicMock()
+    mock_fcntl.ioctl.side_effect = fake_ioctl
+    monkeypatch.setitem(sys.modules, "fcntl", mock_fcntl)
+    monkeypatch.setattr("cmcp_gateway.tee.sev_snp.sys.platform", "linux")
+
+    wrong_expected = "sha384:" + "0" * 96
+    provider = SEVSNPProvider(expected_measurement=wrong_expected)
+
+    with patch("builtins.open", MagicMock(
+        return_value=MagicMock(__enter__=lambda s: MagicMock(), __exit__=lambda s, *a: False)
+    )), pytest.raises(RuntimeError, match="measurement mismatch"):
+        provider.get_attestation_report(b"\x00" * 32)
+
+
+def test_sevsnp_accepts_matching_expected_measurement(monkeypatch):
+    """HW-002: when expected_measurement matches, report is returned without error."""
+    import hashlib
+    import struct
+    import sys
+    from unittest.mock import MagicMock
+
+    from cmcp_gateway.tee.sev_snp import (
+        SEVSNPProvider,
+        _SNP_MEASUREMENT_END,
+        _SNP_MEASUREMENT_OFFSET,
+        _SNP_REPORT_SIZE,
+        _SNP_RESP_HEADER_SIZE,
+    )
+
+    measurement_bytes = b"\xcd" * (_SNP_MEASUREMENT_END - _SNP_MEASUREMENT_OFFSET)
+    expected = "sha384:" + hashlib.sha384(measurement_bytes).hexdigest()
+
+    raw_evidence = bytearray(_SNP_REPORT_SIZE)
+    raw_evidence[_SNP_MEASUREMENT_OFFSET:_SNP_MEASUREMENT_END] = measurement_bytes
+
+    resp_buf = bytearray(_SNP_RESP_HEADER_SIZE + _SNP_REPORT_SIZE)
+    struct.pack_into("<I", resp_buf, 0, 0)
+    resp_buf[_SNP_RESP_HEADER_SIZE:] = raw_evidence
+
+    def fake_ioctl(fd, req, buf):
+        buf[:] = resp_buf
+
+    mock_fcntl = MagicMock()
+    mock_fcntl.ioctl.side_effect = fake_ioctl
+    monkeypatch.setitem(sys.modules, "fcntl", mock_fcntl)
+    monkeypatch.setattr("cmcp_gateway.tee.sev_snp.sys.platform", "linux")
+
+    provider = SEVSNPProvider(expected_measurement=expected)
+
+    with patch("builtins.open", MagicMock(
+        return_value=MagicMock(__enter__=lambda s: MagicMock(), __exit__=lambda s, *a: False)
+    )):
+        report = provider.get_attestation_report(b"\x00" * 32)
+
+    assert report.measurement == expected
+
+
+def test_detect_provider_passes_expected_measurement_to_snp(dev_config):
+    """HW-002: detect_provider threads attestation.expected_measurement into SEVSNPProvider."""
+    from cmcp_gateway.tee.sev_snp import SEVSNPProvider
+
+    dev_config.attestation.expected_measurement = "sha384:" + "f" * 96
+    dev_config.attestation.provider = TEEProviderEnum.SEV_SNP
+
+    created = []
+
+    original_get = __import__(
+        "cmcp_gateway.tee.detect", fromlist=["_get_provider_impl"]
+    )._get_provider_impl
+
+    def spy_get(name, config=None):
+        impl = original_get(name, config)
+        if isinstance(impl, SEVSNPProvider):
+            created.append(impl)
+        return impl
+
+    with patch("cmcp_gateway.tee.detect._get_provider_impl", side_effect=spy_get), \
+         patch.object(SEVSNPProvider, "detect", return_value=True):
+        detect_provider(dev_config)
+
+    assert created, "SEVSNPProvider was not instantiated"
+    assert created[0]._expected_measurement == "sha384:" + "f" * 96


### PR DESCRIPTION
## Summary

- Adds `expected_measurement` field to `AttestationConfig` (optional, defaults to `None`)
- `SEVSNPProvider.__init__` accepts the value and stores it as `_expected_measurement`
- On each `get_attestation_report` call, if configured, computes `sha384` of the raw firmware measurement bytes and uses `hmac.compare_digest` for constant-time comparison — raises `RuntimeError("measurement mismatch")` on failure
- `detect_provider` / `_get_provider_impl` now thread the config through so `SEVSNPProvider` receives `expected_measurement` at construction

Closes #172

## Test plan

- [ ] `test_expected_measurement_loaded_from_config` — field parsed from YAML
- [ ] `test_expected_measurement_defaults_to_none` — omitting field leaves it `None`
- [ ] `test_expected_measurement_non_string_rejected` — non-string value raises `ConfigError`
- [ ] `test_sevsnp_no_expected_measurement_skips_check` — `None` value skips comparison
- [ ] `test_sevsnp_stores_expected_measurement` — value stored on instance
- [ ] `test_sevsnp_rejects_mismatched_expected_measurement` — mismatch raises `RuntimeError`
- [ ] `test_sevsnp_accepts_matching_expected_measurement` — match returns report cleanly
- [ ] `test_detect_provider_passes_expected_measurement_to_snp` — wired end-to-end