### PR TITLE
fix(proxy): include injection scanner and pattern in audit chain detail (INJECT-003)

### DIFF
--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -409,6 +409,11 @@ class CMCPProxy:
         # AUTH-002: lock protects against race with concurrent session reset requests.
         response_sensitivity = getattr(agt_result, "sensitivity_tags", [])
         injection_detected = getattr(agt_result, "injection_detected", False)
+        # INJECT-003: capture scanner attribution and matched pattern for audit chain detail
+        injection_scanner = getattr(agt_result, "injection_scanner", None)
+        injection_pattern = getattr(agt_result, "matched_pattern", None) or getattr(
+            agt_result, "injection_pattern", None
+        )
         async with self._session.mutation_lock:
             self._session.update_from_inspection(
                 call_id=call_id,
@@ -462,6 +467,15 @@ class CMCPProxy:
         # Step 6: audit chain write
         policy_decision: Any = "advisory_deny" if would_have_denied else "allow"
         latency_us = int((time.perf_counter() - t0) * 1_000_000)
+        # INJECT-003: include injection scanner and pattern in audit detail when detected
+        injection_detail: dict[str, str | int] | None = (
+            {
+                "injection_scanner": str(injection_scanner or "unknown")[:128],
+                "matched_pattern": str(injection_pattern or "unknown")[:256],
+            }
+            if injection_detected
+            else None
+        )
         self._audit.append(
             "tool_call",
             call_id=call_id,
@@ -474,6 +488,7 @@ class CMCPProxy:
             session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
             workflow_id=workflow_id,
+            detail=injection_detail,
         )
 
         # Step 6: call log record + suspicious-sequence check

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -316,3 +316,61 @@ async def test_cedar_exception_writes_fault_audit_entry():
     assert fault_entries[0].policy_decision == "fault"
     assert "RuntimeError" in (fault_entries[0].policy_rule_matched or "")
     assert fault_entries[0].request_payload_hash is not None
+
+
+# ── INJECT-003: injection detail included in audit entry ─────────────────────
+
+@pytest.mark.asyncio
+async def test_audit_entry_detail_includes_injection_scanner_and_pattern():
+    """INJECT-003 (closes #170) — when injection is detected, the audit entry detail must
+    include injection_scanner and matched_pattern so a verifier can reconstruct why
+    the request was denied."""
+    proxy, _, chain = _make_proxy()
+    proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
+        sensitivity_tags=[],
+        injection_detected=True,
+        injection_scanner="agt_mcp",
+        matched_pattern="test_pattern",
+        injection_pattern=None,
+    ))
+
+    await proxy.call_tool("c1", "test.tool", {"q": "hello"})
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    entry = tool_entries[-1]
+    assert entry.detail is not None, "detail must be set when injection is detected"
+    assert entry.detail["injection_scanner"] == "agt_mcp"
+    assert entry.detail["matched_pattern"] == "test_pattern"
+
+
+@pytest.mark.asyncio
+async def test_audit_entry_detail_is_none_when_no_injection():
+    """INJECT-003 — when no injection is detected, detail must not be set
+    (so clean calls do not carry spurious injection keys)."""
+    proxy, _, chain = _make_proxy()
+
+    await proxy.call_tool("c1", "test.tool", {"q": "safe"})
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    entry = tool_entries[-1]
+    assert entry.detail is None
+
+
+@pytest.mark.asyncio
+async def test_audit_entry_detail_falls_back_to_unknown_when_fields_absent():
+    """INJECT-003 — when injection_detected=True but scanner/pattern attrs are absent,
+    detail values must fall back to 'unknown' rather than crashing."""
+    proxy, _, chain = _make_proxy()
+    agt_mock = MagicMock(spec=[])  # no attributes beyond spec
+    agt_mock.sensitivity_tags = []
+    agt_mock.injection_detected = True
+    # injection_scanner and matched_pattern intentionally absent
+    proxy._mcp_gateway.call_tool = AsyncMock(return_value=agt_mock)
+
+    await proxy.call_tool("c1", "test.tool", {})
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    entry = tool_entries[-1]
+    assert entry.detail is not None
+    assert entry.detail["injection_scanner"] == "unknown"
+    assert entry.detail["matched_pattern"] == "unknown"


### PR DESCRIPTION
## Summary

- When `injection_detected=True` from `agt_result`, `proxy.py` now captures `injection_scanner` and `matched_pattern` (with fallback to `injection_pattern`) via `getattr` from the AGT result object.
- The `detail` dict `{"injection_scanner": ..., "matched_pattern": ...}` is written to the `tool_call` audit entry when injection is detected; `detail` remains `None` for clean calls.
- String values are truncated to 128/256 chars and fallback to `"unknown"` if the attributes are absent, satisfying `dict[str, str | int]` type constraints and preventing crashes on sparse AGT result objects.

closes #170

## Test plan

- [x] `test_audit_entry_detail_includes_injection_scanner_and_pattern` — verifies `detail` has correct values when `injection_detected=True`
- [x] `test_audit_entry_detail_is_none_when_no_injection` — verifies `detail` is `None` for clean calls
- [x] `test_audit_entry_detail_falls_back_to_unknown_when_fields_absent` — verifies `"unknown"` fallback when AGT result lacks the fields
- [x] All 22 existing proxy unit tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)