### PR TITLE
fix: opt into node.js 24 across all workflows before june 16 deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: ""
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze (python)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   id-token: write  # for OIDC trusted publishing
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   draft-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   scorecard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Opts into Node.js 24 via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 at workflow level before the June 16 forced cutover. After June 16, GitHub forces Node.js 24 anyway — this makes it explicit now so any incompatibilities surface on our timeline.