### PR TITLE
feat: add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,30 @@
+name: SBOM
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sbom.yml` using `anchore/sbom-action@v0`
- Generates an SPDX-JSON SBOM on push to main and on every release publish
- Uploaded as a workflow artifact; can be attached to releases via a follow-up

Required `permissions: contents: write, id-token: write` for OIDC-based signing (forward-compatible when Sigstore attestation is added).

## Test plan

- [ ] CI passes on GitHub
- [ ] SBOM artifact appears in the run's artifact list

🤖 Generated with [Claude Code](https://claude.com/claude-code)