### PR TITLE
fix(policy): pin agent_os_version in manifest; warn on mismatch (POLICY-007)

### DIFF
--- a/src/cmcp_gateway/policy/bundle.py
+++ b/src/cmcp_gateway/policy/bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
 import logging
 import threading
@@ -12,6 +13,13 @@ from pathlib import Path
 from typing import Any
 
 from cmcp_gateway.errors import ConfigError, PolicyHashMismatch
+
+# POLICY-007: version of the Cedar evaluation library bundled in agent-os-kernel.
+# Pinned in manifest.json as agent_os_version; mismatch is logged as a warning.
+try:
+    _AGENT_OS_VERSION: str = importlib.metadata.version("agent-os-kernel")
+except importlib.metadata.PackageNotFoundError:
+    _AGENT_OS_VERSION = "unknown"
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +33,7 @@ class PolicyManifest:
     author_identity: str
     commit_sha: str
     approval_chain: list[dict[str, str]] = field(default_factory=list)
+    agent_os_version: str | None = None  # POLICY-007: expected agent-os-kernel version
 
 
 @dataclass
@@ -105,12 +114,25 @@ def load_policy_bundle(bundle_path: str, expected_hash: str | None = None) -> Po
     if missing:
         raise ConfigError(f"manifest.json missing required fields: {missing}")
 
+    pinned_agent_os = raw_manifest.get("agent_os_version")
+    if pinned_agent_os is not None and pinned_agent_os != _AGENT_OS_VERSION:
+        # POLICY-007: mismatch is a warning, not a hard failure, because the
+        # gateway cannot know in advance whether a newer agent_os is semantically
+        # compatible. Operators must review changelogs and re-pin after upgrade.
+        logger.warning(
+            "POLICY-007: agent_os_version mismatch — bundle pinned %s, installed %s. "
+            "Cedar policy semantics may have changed; review the agent-os-kernel changelog.",
+            pinned_agent_os,
+            _AGENT_OS_VERSION,
+        )
+
     manifest = PolicyManifest(
         version=raw_manifest["version"],
         authored_at=raw_manifest["authored_at"],
         author_identity=raw_manifest["author_identity"],
         commit_sha=raw_manifest["commit_sha"],
         approval_chain=raw_manifest.get("approval_chain", []),
+        agent_os_version=pinned_agent_os,
     )
 
     # Load Cedar policy files

--- a/tests/unit/test_policy_bundle.py
+++ b/tests/unit/test_policy_bundle.py
@@ -205,3 +205,44 @@ def test_policy_store_keeps_current_on_reload_failure():
     # Should return False (failure path) and preserve the original bundle.
     assert result is False
     assert store.bundle.bundle_hash == bundle.bundle_hash
+
+
+# ── POLICY-007: agent_os_version pinning ─────────────────────────────────────
+
+def test_load_bundle_accepts_manifest_without_agent_os_version(bundle_dir):
+    """POLICY-007: agent_os_version is optional — bundles without it still load."""
+    bundle = load_policy_bundle(str(bundle_dir))
+    assert bundle.manifest.agent_os_version is None
+
+
+def test_load_bundle_records_pinned_agent_os_version(bundle_dir):
+    """POLICY-007: agent_os_version from manifest is stored in PolicyManifest."""
+    manifest_with_version = dict(MANIFEST)
+    manifest_with_version["agent_os_version"] = "3.7.0"
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest_with_version))
+    bundle = load_policy_bundle(str(bundle_dir))
+    assert bundle.manifest.agent_os_version == "3.7.0"
+
+
+def test_load_bundle_warns_on_agent_os_version_mismatch(bundle_dir, caplog):
+    """POLICY-007: version mismatch emits a WARNING but does not raise."""
+    import logging
+    manifest_with_old = dict(MANIFEST)
+    manifest_with_old["agent_os_version"] = "0.0.0-definitely-not-installed"
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest_with_old))
+    with caplog.at_level(logging.WARNING):
+        bundle = load_policy_bundle(str(bundle_dir))
+    assert bundle is not None
+    assert any("POLICY-007" in r.message for r in caplog.records)
+
+
+def test_load_bundle_no_warning_when_versions_match(bundle_dir, caplog):
+    """POLICY-007: no warning when pinned version matches installed version."""
+    import logging
+    from cmcp_gateway.policy.bundle import _AGENT_OS_VERSION
+    manifest_with_match = dict(MANIFEST)
+    manifest_with_match["agent_os_version"] = _AGENT_OS_VERSION
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest_with_match))
+    with caplog.at_level(logging.WARNING):
+        load_policy_bundle(str(bundle_dir))
+    assert not any("POLICY-007" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

**POLICY-007 (closes #185):** Cedar policy documents had no way to declare which version of the evaluation library they were authored against. If `agent-os-kernel` is upgraded and Cedar semantics change (operator precedence, new built-ins, etc.), existing policies could evaluate differently without any signal to operators.

`PolicyManifest` gains an optional `agent_os_version` field. When set in `manifest.json`, `load_policy_bundle` compares it against `importlib.metadata.version("agent-os-kernel")` and emits a `POLICY-007 WARNING` if they differ.

A mismatch is non-fatal by design — the gateway can't know in advance whether a newer library is semantically compatible. Operators get the warning, review the changelog, update the pin, and recompute the bundle hash.

Example `manifest.json`:
```json
{
  "version": "1.0.0",
  "authored_at": "2026-06-07T00:00:00Z",
  "author_identity": "security@example.com",
  "commit_sha": "abc123",
  "agent_os_version": "3.7.0"
}
```

## Test plan

- [x] `test_load_bundle_accepts_manifest_without_agent_os_version` — field optional, no breakage for existing bundles
- [x] `test_load_bundle_records_pinned_agent_os_version` — field stored in `PolicyManifest`
- [x] `test_load_bundle_warns_on_agent_os_version_mismatch` — POLICY-007 in log when versions differ
- [x] `test_load_bundle_no_warning_when_versions_match` — no warning when pinned == installed
- [x] All 21 tests in test_policy_bundle.py pass; 450 unit tests pass total

🤖 Generated with [Claude Code](https://claude.com/claude-code)