### PR TITLE
feat(session): per-session call log with compliance-domain tracking

### DIFF
--- a/src/cmcp_gateway/audit/trace_claim.py
+++ b/src/cmcp_gateway/audit/trace_claim.py
@@ -36,7 +36,9 @@ _SW_ONLY_FIRMWARE = "software-only-dev-mode"
 @dataclass
 class CallGraphSummary:
     compliance_domains_touched: list[str]
-    cross_boundary_events: list[dict[str, str]]
+    cross_boundary_events: list[dict[str, Any]]
+    #: Clarifies that edges are temporal adjacency, not data provenance (issue #94).
+    edges_represent: str | None = None
 
 
 @dataclass
@@ -81,7 +83,9 @@ class CallGraphOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     compliance_domains_touched: list[str]
-    cross_boundary_events: list[dict[str, str]]
+    cross_boundary_events: list[dict[str, Any]]
+    #: Clarifies that edges are temporal adjacency, not data provenance (issue #94).
+    edges_represent: str | None = None
 
 
 class CallSummaryOut(BaseModel):
@@ -316,6 +320,7 @@ def generate_trace_claim(
             call_graph_summary=CallGraphOut(
                 compliance_domains_touched=call_summary.call_graph_summary.compliance_domains_touched,
                 cross_boundary_events=call_summary.call_graph_summary.cross_boundary_events,
+                edges_represent=call_summary.call_graph_summary.edges_represent,
             ),
         ),
         catalog=CatalogSummary(

--- a/src/cmcp_gateway/mcp/proxy.py
+++ b/src/cmcp_gateway/mcp/proxy.py
@@ -28,7 +28,7 @@ from cmcp_gateway.catalog.loader import ToolCatalog
 from cmcp_gateway.config import Config
 from cmcp_gateway.errors import PolicyDeny
 from cmcp_gateway.policy.evaluator import PolicyEvaluator
-from cmcp_gateway.session.call_log import CallLog, CallRecord
+from cmcp_gateway.session.call_log import CallLog, CallRecord, SessionCallLog
 from cmcp_gateway.session.state import SessionState
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,7 @@ class CMCPProxy:
         audit_chain: AuditChain,
         config: Config,
         call_log: CallLog | None = None,
+        session_call_log: SessionCallLog | None = None,
         attestation_generated_at: datetime | None = None,
         attestation_validity_seconds: int = 86400,
         catalog_hash: str | None = None,
@@ -80,6 +81,10 @@ class CMCPProxy:
         self._config = config
         self._enforcement = config.attestation.enforcement_mode
         self._call_log: CallLog = call_log if call_log is not None else CallLog(session_id=session.session_id)
+        self._session_call_log: SessionCallLog = (
+            session_call_log if session_call_log is not None
+            else SessionCallLog(session_id=session.session_id)
+        )
         self._attestation_generated_at = attestation_generated_at
         self._attestation_validity_seconds = attestation_validity_seconds
         self._catalog_hash = catalog_hash or catalog.catalog_hash
@@ -174,11 +179,18 @@ class CMCPProxy:
         allowed: bool,
         sensitivity_before: str,
         stage_results: dict[str, str],
+        *,
+        call_id: str | None = None,
+        catalog_entry: Any | None = None,
+        policy_decision: str = "n/a",
+        response_sensitivity_tags: list[str] | None = None,
     ) -> None:
         """
         Append a CallRecord to the session call log and check for suspicious
         sequences. On detection: write a suspicious_call_sequence audit entry
         and increment session.suspicious_sequences.
+
+        Also records to the SessionCallLog for TRACE Claim call_graph_summary.
         """
         sensitivity_raised = self._session.max_sensitivity != sensitivity_before
         self._call_log.record(
@@ -191,6 +203,14 @@ class CMCPProxy:
                 stage_results=stage_results,
             )
         )
+        # SessionCallLog: record with richer fields for call_graph_summary.
+        if call_id is not None:
+            self._session_call_log.record_call(
+                call_id=call_id,
+                catalog_entry=catalog_entry,
+                policy_decision=policy_decision,
+                response_sensitivity_tags=response_sensitivity_tags,
+            )
         if self._call_log.suspicious_sequence():
             consecutive = self._call_log.consecutive_count(tool_name)
             self._audit.append(
@@ -272,6 +292,9 @@ class CMCPProxy:
                 allowed=False,
                 sensitivity_before=sensitivity_before,
                 stage_results={"catalog": "deny"},
+                call_id=call_id,
+                catalog_entry=None,
+                policy_decision="deny",
             )
             return CallResult(
                 call_id=call_id,
@@ -331,6 +354,9 @@ class CMCPProxy:
                 allowed=False,
                 sensitivity_before=sensitivity_before,
                 stage_results={"policy": "deny"},
+                call_id=call_id,
+                catalog_entry=entry,
+                policy_decision="deny",
             )
             return CallResult(
                 call_id=call_id,
@@ -393,6 +419,9 @@ class CMCPProxy:
                 allowed=False,
                 sensitivity_before=sensitivity_before,
                 stage_results={"agt_gateway": "deny"},
+                call_id=call_id,
+                catalog_entry=entry,
+                policy_decision="deny",
             )
             return CallResult(
                 call_id=call_id,
@@ -500,6 +529,10 @@ class CMCPProxy:
             allowed=True,
             sensitivity_before=sensitivity_before,
             stage_results={"policy": str(policy_decision)},
+            call_id=call_id,
+            catalog_entry=entry,
+            policy_decision=str(policy_decision),
+            response_sensitivity_tags=list(response_sensitivity or []),
         )
 
         return CallResult(

--- a/src/cmcp_gateway/session/call_log.py
+++ b/src/cmcp_gateway/session/call_log.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
 
 @dataclass
@@ -71,4 +72,161 @@ class CallLog:
         return count
 
 
-__all__ = ["CallLog", "CallRecord"]
+# ---------------------------------------------------------------------------
+# SessionCallLog and CallLogEntry — richer per-call tracking for TRACE Claims
+# ---------------------------------------------------------------------------
+
+#: Sentinel for the compliance_domain of calls where no catalog entry exists.
+_UNKNOWN_DOMAIN = "unknown"
+
+#: High-sensitivity compliance domains that trigger cross-boundary event recording
+#: when a call transitions away from them.
+_HIGH_SENSITIVITY_DOMAINS: frozenset[str] = frozenset({"pii", "phi", "pci", "restricted"})
+
+
+@dataclass
+class CallLogEntry:
+    """One entry in the per-session call log (issue #94 spec).
+
+    Tracks temporal adjacency only — not data provenance.  Edges in the
+    call graph represent "B was called immediately after A", not "B consumed
+    A's output".
+    """
+
+    call_id: str
+    sequence_number: int
+    tool_name: str
+    server_identity: str | None
+    compliance_domain: str
+    timestamp: datetime
+    policy_decision: str
+    response_sensitivity_tags: list[str]
+
+
+class SessionCallLog:
+    """
+    Per-session call log with compliance-domain tracking and cross-boundary
+    event detection for the TRACE Claim call_graph_summary (issue #94).
+
+    Edges represent temporal adjacency (call order), NOT data provenance.
+    This distinction is surfaced explicitly in get_call_graph_summary() via
+    the 'edges_represent' metadata field so consumers do not misinterpret
+    temporal edges as data-flow edges.
+    """
+
+    #: Metadata note embedded in every call_graph_summary dict.  Do not remove.
+    _ADJACENCY_NOTE = (
+        "Edges represent temporal adjacency (call order), not data provenance. "
+        "A -> B means B was called immediately after A within this session."
+    )
+
+    def __init__(self, session_id: str) -> None:
+        self._session_id = session_id
+        self._entries: list[CallLogEntry] = []
+
+    @property
+    def entries(self) -> list[CallLogEntry]:
+        return list(self._entries)
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def record_call(
+        self,
+        call_id: str,
+        catalog_entry: Any | None,
+        policy_decision: str,
+        *,
+        response_sensitivity_tags: list[str] | None = None,
+    ) -> CallLogEntry:
+        """
+        Append a CallLogEntry derived from the catalog entry and policy decision.
+
+        compliance_domain is taken from catalog_entry.compliance_domain when
+        a catalog entry is available; falls back to "unknown" for catalog misses.
+        server_identity is taken from catalog_entry.server.url.
+        tool_name is taken from catalog_entry.tool_name.
+
+        Returns the appended entry.
+        """
+        if catalog_entry is not None:
+            tool_name: str = catalog_entry.tool_name
+            server_identity: str | None = getattr(
+                getattr(catalog_entry, "server", None), "url", None
+            )
+            compliance_domain: str = getattr(catalog_entry, "compliance_domain", _UNKNOWN_DOMAIN)
+        else:
+            tool_name = "unknown"
+            server_identity = None
+            compliance_domain = _UNKNOWN_DOMAIN
+
+        entry = CallLogEntry(
+            call_id=call_id,
+            sequence_number=len(self._entries),
+            tool_name=tool_name,
+            server_identity=server_identity,
+            compliance_domain=compliance_domain,
+            timestamp=datetime.now(UTC),
+            policy_decision=policy_decision,
+            response_sensitivity_tags=list(response_sensitivity_tags or []),
+        )
+        self._entries.append(entry)
+        return entry
+
+    def get_call_graph_summary(self) -> dict[str, Any]:
+        """
+        Build the call_graph_summary dict for inclusion in the TRACE Claim.
+
+        Returns:
+            {
+                "compliance_domains_touched": [sorted list of unique domains],
+                "cross_boundary_events": [
+                    {
+                        "from_domain": str,
+                        "to_domain": str,
+                        "call_id": str,
+                        "tool_name": str,
+                        "sequence_number": int,
+                    },
+                    ...
+                ],
+                "edges_represent": "<adjacency note>",
+            }
+
+        Cross-boundary events are recorded when a call follows a call in a
+        high-sensitivity compliance domain (pii, phi, pci, restricted) and
+        the new call is in a different domain.  This captures data-sensitivity
+        boundary crossings, not arbitrary domain transitions.
+        """
+        domains: set[str] = set()
+        cross_boundary: list[dict[str, Any]] = []
+
+        for entry in self._entries:
+            domains.add(entry.compliance_domain)
+
+        for i in range(1, len(self._entries)):
+            prev = self._entries[i - 1]
+            curr = self._entries[i]
+            if (
+                prev.compliance_domain in _HIGH_SENSITIVITY_DOMAINS
+                and curr.compliance_domain != prev.compliance_domain
+            ):
+                cross_boundary.append(
+                    {
+                        "from_domain": prev.compliance_domain,
+                        "to_domain": curr.compliance_domain,
+                        "call_id": curr.call_id,
+                        "tool_name": curr.tool_name,
+                        "sequence_number": curr.sequence_number,
+                    }
+                )
+
+        return {
+            "compliance_domains_touched": sorted(domains),
+            "cross_boundary_events": cross_boundary,
+            "edges_represent": self._ADJACENCY_NOTE,
+        }
+
+
+__all__ = ["CallLog", "CallRecord", "SessionCallLog", "CallLogEntry"]

--- a/src/cmcp_gateway/session/manager.py
+++ b/src/cmcp_gateway/session/manager.py
@@ -25,7 +25,7 @@ from cmcp_gateway.audit.trace_claim import (
     ToolCatalogInfo,
     generate_trace_claim,
 )
-from cmcp_gateway.session.call_log import CallLog
+from cmcp_gateway.session.call_log import CallLog, SessionCallLog
 from cmcp_gateway.session.state import SessionState
 from cmcp_gateway.startup import GatewayContext
 
@@ -55,6 +55,7 @@ class SessionManager:
         state: SessionState,
         chain: AuditChain,
         call_log: CallLog | None = None,
+        session_call_log: SessionCallLog | None = None,
     ) -> dict[str, Any]:
         """
         Close a session:
@@ -134,14 +135,27 @@ class SessionManager:
             {e.tool_name for e in tool_calls if e.tool_name is not None}
         )
 
-        # Identify compliance domains from catalog entries touched.
-        compliance_domains_touched = sorted(
-            {
-                catalog.entries[name].compliance_domain
-                for name in tools_invoked
-                if name in catalog.entries
-            }
-        )
+        # Build call graph summary: prefer SessionCallLog (richer, with adjacency
+        # tracking) and fall back to deriving domains from the audit chain entries.
+        if session_call_log is not None:
+            cg = session_call_log.get_call_graph_summary()
+            call_graph_summary = CallGraphSummary(
+                compliance_domains_touched=cg["compliance_domains_touched"],
+                cross_boundary_events=cg["cross_boundary_events"],
+                edges_represent=cg["edges_represent"],
+            )
+        else:
+            compliance_domains_touched = sorted(
+                {
+                    catalog.entries[name].compliance_domain
+                    for name in tools_invoked
+                    if name in catalog.entries
+                }
+            )
+            call_graph_summary = CallGraphSummary(
+                compliance_domains_touched=compliance_domains_touched,
+                cross_boundary_events=[],
+            )
 
         call_summary = CallSummary(
             tool_calls_total=tool_calls_total,
@@ -150,10 +164,7 @@ class SessionManager:
             tool_calls_faulted=tool_calls_faulted,
             tools_invoked=tools_invoked,
             session_max_sensitivity=state.max_sensitivity,
-            call_graph_summary=CallGraphSummary(
-                compliance_domains_touched=compliance_domains_touched,
-                cross_boundary_events=[],
-            ),
+            call_graph_summary=call_graph_summary,
         )
 
         call_log_summary: CallLogSummary | None = None

--- a/tests/unit/test_session_call_log.py
+++ b/tests/unit/test_session_call_log.py
@@ -1,0 +1,324 @@
+"""Unit tests for SessionCallLog and CallLogEntry (issue #94).
+
+Tests:
+- domain tracking across calls
+- cross-boundary event detection when transitioning from high-sensitivity domains
+- get_call_graph_summary structure and edges_represent note
+- summary with no cross-boundary events
+- TRACE Claim call_graph_summary populated from SessionCallLog
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from cmcp_gateway.session.call_log import CallLogEntry, SessionCallLog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _entry(tool_name: str, compliance_domain: str = "external", server_url: str = "https://test.example.com/mcp") -> MagicMock:
+    """Build a minimal catalog entry mock."""
+    e = MagicMock()
+    e.tool_name = tool_name
+    e.compliance_domain = compliance_domain
+    e.server = MagicMock()
+    e.server.url = server_url
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Basic record_call
+# ---------------------------------------------------------------------------
+
+
+def test_record_call_appends_entry():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("tool.a"), "allow")
+    assert len(log.entries) == 1
+
+
+def test_record_call_sequence_numbers_contiguous():
+    log = SessionCallLog("sess-001")
+    for i in range(5):
+        log.record_call(f"c{i}", _entry(f"tool.{i}"), "allow")
+    for i, entry in enumerate(log.entries):
+        assert entry.sequence_number == i
+
+
+def test_record_call_sets_tool_name_from_catalog():
+    log = SessionCallLog("sess-001")
+    e = _entry("crm.query", "pii")
+    log.record_call("c1", e, "allow")
+    assert log.entries[0].tool_name == "crm.query"
+
+
+def test_record_call_sets_compliance_domain_from_catalog():
+    log = SessionCallLog("sess-001")
+    e = _entry("phi.lookup", "phi")
+    log.record_call("c1", e, "allow")
+    assert log.entries[0].compliance_domain == "phi"
+
+
+def test_record_call_sets_server_identity_from_catalog():
+    log = SessionCallLog("sess-001")
+    e = _entry("tool.a", server_url="https://server.example.com/mcp")
+    log.record_call("c1", e, "allow")
+    assert log.entries[0].server_identity == "https://server.example.com/mcp"
+
+
+def test_record_call_stores_policy_decision():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t"), "deny")
+    assert log.entries[0].policy_decision == "deny"
+
+
+def test_record_call_stores_call_id():
+    log = SessionCallLog("sess-001")
+    log.record_call("abc-123", _entry("t"), "allow")
+    assert log.entries[0].call_id == "abc-123"
+
+
+def test_record_call_timestamp_is_timezone_aware():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t"), "allow")
+    ts = log.entries[0].timestamp
+    assert ts.tzinfo is not None
+
+
+def test_record_call_catalog_none_uses_unknown_domain():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", None, "deny")
+    entry = log.entries[0]
+    assert entry.compliance_domain == "unknown"
+    assert entry.tool_name == "unknown"
+    assert entry.server_identity is None
+
+
+def test_record_call_stores_response_sensitivity_tags():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t"), "allow", response_sensitivity_tags=["pii", "restricted"])
+    assert log.entries[0].response_sensitivity_tags == ["pii", "restricted"]
+
+
+def test_record_call_empty_response_sensitivity_tags_by_default():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t"), "allow")
+    assert log.entries[0].response_sensitivity_tags == []
+
+
+# ---------------------------------------------------------------------------
+# get_call_graph_summary — compliance_domains_touched
+# ---------------------------------------------------------------------------
+
+
+def test_summary_empty_log():
+    log = SessionCallLog("sess-001")
+    s = log.get_call_graph_summary()
+    assert s["compliance_domains_touched"] == []
+    assert s["cross_boundary_events"] == []
+    assert "edges_represent" in s
+
+
+def test_summary_single_domain():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t", "external"), "allow")
+    s = log.get_call_graph_summary()
+    assert s["compliance_domains_touched"] == ["external"]
+
+
+def test_summary_multiple_domains_sorted():
+    log = SessionCallLog("sess-001")
+    for domain in ["pii", "external", "phi", "external"]:
+        log.record_call("c1", _entry("t", domain), "allow")
+    s = log.get_call_graph_summary()
+    assert s["compliance_domains_touched"] == ["external", "phi", "pii"]
+
+
+def test_summary_domains_deduplicated():
+    log = SessionCallLog("sess-001")
+    for _ in range(5):
+        log.record_call("c1", _entry("t", "pii"), "allow")
+    s = log.get_call_graph_summary()
+    assert s["compliance_domains_touched"] == ["pii"]
+
+
+# ---------------------------------------------------------------------------
+# get_call_graph_summary — cross_boundary_events
+# ---------------------------------------------------------------------------
+
+
+def test_no_cross_boundary_all_same_domain():
+    log = SessionCallLog("sess-001")
+    for i in range(3):
+        log.record_call(f"c{i}", _entry(f"t{i}", "external"), "allow")
+    s = log.get_call_graph_summary()
+    assert s["cross_boundary_events"] == []
+
+
+def test_no_cross_boundary_only_low_sensitivity():
+    """Transitions between non-high-sensitivity domains are not events."""
+    log = SessionCallLog("sess-001")
+    for domain in ["external", "internal", "external", "public"]:
+        log.record_call("c1", _entry("t", domain), "allow")
+    s = log.get_call_graph_summary()
+    assert s["cross_boundary_events"] == []
+
+
+def test_cross_boundary_after_pii():
+    """pii -> external triggers a cross-boundary event."""
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "pii"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+    s = log.get_call_graph_summary()
+    assert len(s["cross_boundary_events"]) == 1
+    ev = s["cross_boundary_events"][0]
+    assert ev["from_domain"] == "pii"
+    assert ev["to_domain"] == "external"
+    assert ev["call_id"] == "c2"
+    assert ev["tool_name"] == "t2"
+    assert ev["sequence_number"] == 1
+
+
+def test_cross_boundary_after_phi():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "phi"), "allow")
+    log.record_call("c2", _entry("t2", "public"), "allow")
+    s = log.get_call_graph_summary()
+    assert len(s["cross_boundary_events"]) == 1
+    assert s["cross_boundary_events"][0]["from_domain"] == "phi"
+
+
+def test_cross_boundary_after_pci():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "pci"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+    s = log.get_call_graph_summary()
+    assert len(s["cross_boundary_events"]) == 1
+
+
+def test_cross_boundary_after_restricted():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "restricted"), "allow")
+    log.record_call("c2", _entry("t2", "internal"), "allow")
+    s = log.get_call_graph_summary()
+    assert len(s["cross_boundary_events"]) == 1
+
+
+def test_no_cross_boundary_pii_to_pii():
+    """Same domain after pii does not trigger a cross-boundary event."""
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "pii"), "allow")
+    log.record_call("c2", _entry("t2", "pii"), "allow")
+    s = log.get_call_graph_summary()
+    assert s["cross_boundary_events"] == []
+
+
+def test_multiple_cross_boundary_events():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "pii"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+    log.record_call("c3", _entry("t3", "phi"), "allow")
+    log.record_call("c4", _entry("t4", "public"), "allow")
+    s = log.get_call_graph_summary()
+    assert len(s["cross_boundary_events"]) == 2
+
+
+def test_cross_boundary_event_has_required_keys():
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", "pii"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+    ev = log.get_call_graph_summary()["cross_boundary_events"][0]
+    assert set(ev.keys()) == {"from_domain", "to_domain", "call_id", "tool_name", "sequence_number"}
+
+
+# ---------------------------------------------------------------------------
+# edges_represent note
+# ---------------------------------------------------------------------------
+
+
+def test_summary_includes_edges_represent_note():
+    log = SessionCallLog("sess-001")
+    s = log.get_call_graph_summary()
+    assert "edges_represent" in s
+    note = s["edges_represent"]
+    assert isinstance(note, str)
+    assert "temporal adjacency" in note.lower()
+    assert "not data provenance" in note.lower()
+
+
+# ---------------------------------------------------------------------------
+# TRACE Claim call_graph_summary populated from SessionCallLog
+# ---------------------------------------------------------------------------
+
+
+def test_trace_claim_call_graph_summary_from_session_call_log():
+    """Integration: close_session with a SessionCallLog uses its call_graph_summary."""
+    from cmcp_gateway.audit.chain import AuditChain
+    from cmcp_gateway.audit.keys import SigningKey
+    from cmcp_gateway.session.manager import SessionManager
+    from cmcp_gateway.session.state import SessionState
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock
+
+    # Build a minimal GatewayContext mock
+    key = SigningKey()
+    policy_bundle = MagicMock()
+    policy_bundle.bundle_hash = "sha256:" + "a" * 64
+    policy_bundle.manifest.version = "1.0.0"
+
+    catalog = MagicMock()
+    catalog.catalog_hash = "sha256:" + "b" * 64
+    catalog.entries = {}
+    catalog.exceptions = []
+
+    config = MagicMock()
+    config.attestation.enforcement_mode = "enforcing"
+
+    report = MagicMock()
+    report.provider = "software-only"
+    report.measurement = "DEVELOPMENT_ONLY_NOT_FOR_PRODUCTION"
+    report.report_data = "aa" * 32
+    report.raw_evidence = None
+    report.measurement_note = None
+    report.attestation_validity_seconds = 86400
+    report.attestation_generated_at = datetime.now(UTC)
+
+    tee_provider = MagicMock()
+    tee_provider.get_attestation_report.return_value = MagicMock()
+
+    ctx = MagicMock()
+    ctx.signing_key = key
+    ctx.attestation_report = report
+    ctx.policy_bundle = policy_bundle
+    ctx.catalog = catalog
+    ctx.config = config
+    ctx.tee_provider = tee_provider
+
+    mgr = SessionManager(ctx)
+    state, chain = mgr.create_session()
+    session_id = state.session_id
+
+    # Build a SessionCallLog with a pii -> external cross-boundary event
+    scl = SessionCallLog(session_id)
+    e_pii = _entry("pii.tool", "pii")
+    e_ext = _entry("ext.tool", "external")
+    scl.record_call("c1", e_pii, "allow")
+    scl.record_call("c2", e_ext, "allow")
+
+    claim_dict = mgr.close_session(
+        session_id, state, chain, session_call_log=scl
+    )
+
+    cg = claim_dict["gateway"]["call_summary"]["call_graph_summary"]
+    assert "pii" in cg["compliance_domains_touched"]
+    assert "external" in cg["compliance_domains_touched"]
+    assert len(cg["cross_boundary_events"]) == 1
+    assert cg["cross_boundary_events"][0]["from_domain"] == "pii"
+    # Temporal adjacency note must appear
+    assert "edges_represent" in cg
+    assert "temporal adjacency" in cg["edges_represent"].lower()


### PR DESCRIPTION
## Summary

- Adds `SessionCallLog` + `CallLogEntry` dataclass to `session/call_log.py` with all spec fields from #94 (call_id, sequence_number, tool_name, server_identity, compliance_domain, timestamp, policy_decision, response_sensitivity_tags)
- `record_call(call_id, catalog_entry, policy_decision)` derives compliance_domain and server_identity from the catalog entry; falls back to "unknown" on catalog misses
- `get_call_graph_summary()` returns compliance_domains_touched (sorted, deduplicated), cross_boundary_events (transitions away from pii/phi/pci/restricted), and an `edges_represent` note clarifying that edges are temporal adjacency, not data provenance
- Wired into `CMCPProxy._record_call` at all four call sites (catalog miss, Cedar deny, AGT deny, allow path)
- `SessionManager.close_session` accepts optional `session_call_log` and uses its summary to populate the TRACE Claim `call_graph_summary`; `CallGraphOut` and `CallGraphSummary` updated to carry `edges_represent`
- 26 unit tests in `tests/unit/test_session_call_log.py`

Closes #94.

## Test plan

- [ ] `pytest tests/unit/test_session_call_log.py` — 26 passed
- [ ] `pytest tests/unit/test_call_log.py tests/unit/test_call_log_integration.py tests/unit/test_trace_claim.py tests/unit/test_session_manager.py` — all pass, no regressions
- [ ] Full unit + conformance suite: 534 passed, 2 pre-existing benchmark failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)