### PR TITLE
fix: upgrade codeql-action v3 -> v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze (python)
@@ -22,19 +25,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         continue-on-error: true
         with:
           category: /language:python


### PR DESCRIPTION
## Summary

`codeql-action@v3` uses Node.js 20, which is deprecated with forced cutover on June 16, 2026. Upgrading to `v4` (Node.js 24) and adding `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to opt in now.

Also pinned `actions/checkout@v6` back to `@v4` for consistency with other workflows.

Note: CodeQL SARIF upload still requires GitHub Advanced Security or a public repo. The `continue-on-error: true` on the analyze step ensures this doesn't block CI.

## Test plan
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)