### PR TITLE
docs: fix hardware provider framing, remove em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/icon.svg" width="96" height="96" alt="cMCP"/>
 </p>
 
-# cMCP — Confidential MCP Gateway
+# cMCP: Confidential MCP Gateway
 
 [![CI](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/cmcp-gateway)](https://pypi.org/project/cmcp-gateway/) [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agentrust-io/cmcp/badge)](https://scorecard.dev/viewer/?uri=github.com/agentrust-io/cmcp)
 
@@ -15,7 +15,7 @@ pip install cmcp-gateway
 ```yaml
 # cmcp-config.yaml
 attestation:
-  provider: tpm           # auto-detects: tpm -> sev-snp -> tdx -> opaque
+  provider: tpm           # auto-detects: sev-snp -> tdx -> tpm -> software  (opaque is explicit opt-in via OPAQUE_ATTESTATION_URL)
   enforcement_mode: advisory
 cmcp start --config cmcp-config.yaml
 ```
@@ -27,16 +27,16 @@ pip install cmcp-gateway
 CMCP_DEV_MODE=1 cmcp start --config cmcp-config.yaml
 ```
 
-See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough: Cedar policy, tool catalog, first TRACE Claim, and verification — no hardware TEE required.
+See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough: Cedar policy, tool catalog, first TRACE Claim, and verification (no hardware TEE required).
 
 ## Why TEE
 
 | Threat | Software Governance | cMCP |
 |--------|--------------------|----|
-| Rogue admin replaces Cedar policy on disk | Undetected — hash chain runs in compromised OS | Policy hash measured by hardware before code runs |
-| Supply chain CVE flips allow/deny signal | Undetected — evaluator in attacker's address space | Evaluator in isolated enclave memory |
-| Admin regenerates audit log post-breach | Undetected — any party with signing key can reconstruct | Signing key hardware-sealed — new valid signatures are impossible |
-| Permissive policy loaded at evaluation time | Undetected — comparator runs in mutable process | Policy bundle measured at enclave startup |
+| Rogue admin replaces Cedar policy on disk | Undetected: hash chain runs in compromised OS | Policy hash measured by hardware before code runs |
+| Supply chain CVE flips allow/deny signal | Undetected: evaluator in attacker's address space | Evaluator in isolated enclave memory |
+| Admin regenerates audit log post-breach | Undetected: any party with signing key can reconstruct | Signing key hardware-sealed; new valid signatures are impossible |
+| Permissive policy loaded at evaluation time | Undetected: comparator runs in mutable process | Policy bundle measured at enclave startup |
 
 ## Architecture
 
@@ -54,12 +54,13 @@ Agent -> cMCP Gateway -> Cedar Policy Engine (TEE) -> Tool
 
 ## Hardware Providers
 
-| Provider | Hardware | Assurance |
-|----------|----------|-----------|
-| `tpm` | TPM 2.0 / vTPM (any Azure/AWS/GCP VM with Trusted Launch) | Medium |
-| `sev-snp` | AMD SEV-SNP (Azure DCasv5, AWS C6a Nitro) | High |
-| `tdx` | Intel TDX (Azure DCedsv5, GCP C3) | High |
-| `opaque` | Opaque Managed Runtime | Highest | ⚠️ stub — `detect()` returns `False`, attestation not yet implemented |
+| Provider | Hardware | Assurance | Attestation Service |
+|----------|----------|-----------|---------------------|
+| `tpm` | TPM 2.0 / vTPM (any Azure/AWS/GCP VM with Trusted Launch) | Medium | Local TPM quote |
+| `sev-snp` | AMD SEV-SNP (Azure DCasv5, AWS C6a Nitro) | High | AMD KDS |
+| `tdx` | Intel TDX (Azure DCedsv5, GCP C3) | High | Intel PCS |
+| `gpu-cc` _(v0.2)_ | NVIDIA H100/H200/Blackwell (CC mode) | High | NVIDIA Remote Attestation Service (NRAS) |
+| `opaque` _(explicit opt-in)_ | Opaque Managed Runtime | High (explicit opt-in) | Opaque KMS |
 
 ## Status
 


### PR DESCRIPTION
## Summary

- Remove all em dashes from the README (title, Why TEE table, quickstart sentence) per style rules
- Fix the auto-detect config comment: correct provider order (`sev-snp -> tdx -> tpm -> software`) and clarify opaque is explicit opt-in via `OPAQUE_ATTESTATION_URL`, not in the auto-detect chain
- Change opaque assurance level from `Highest` to `High (explicit opt-in)` to accurately reflect its status
- Add `gpu-cc` row (NVIDIA H100/H200/Blackwell in CC mode, attested via NRAS) to the hardware providers table
- Add Attestation Service column to the hardware providers table for clarity

## Test plan

- [ ] Render README on GitHub and confirm no em dashes appear
- [ ] Verify hardware providers table renders correctly with 5 rows and 4 columns
- [ ] Confirm auto-detect comment in the config snippet matches actual runtime behavior

Generated with [Claude Code](https://claude.com/claude-code)