### PR TITLE
docs: fix CoC routing, stray file, pyproject urls, vote threshold, phantom doc links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,6 +12,6 @@ Unacceptable behavior: sexualized language or imagery, trolling, insulting comme
 
 ## Enforcement
 
-Report instances of abusive behavior via [GitHub Security Advisories](https://github.com/agentrust-io/cmcp/security/advisories/new).
+Report instances of abusive behavior by opening a GitHub issue labeled `code of conduct`, or by posting in [GitHub Discussions](https://github.com/orgs/agentrust-io/discussions). Security vulnerabilities belong in SECURITY.md, not here.
 
 Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -27,7 +27,7 @@ To be considered for maintainer status you must:
 - Have held reviewer status for at least 60 days
 - Have reviewed 10 or more pull requests
 - Be nominated by an existing maintainer
-- Be approved by a majority vote of the current maintainers
+- Be approved by a 2/3 vote of the current maintainers
 
 ## Emeritus
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,13 +50,6 @@ Issues in this repo track spec decisions, not implementation bugs. Each issue co
 | docs/spec/phase2-server.md | Provider-side attestation, 5 unique properties, streaming proxy, multi-tenant | 2 | Draft v0.1 | #17, #28, #29, #32, #42 |
 | docs/testing/benchmarks.md | Latency targets and benchmark methodology | 1 | Draft v0.1 | #27 |
 | docs/testing/soak-test.md | 72-hour soak test plan | 1 | Draft v0.1 | #31 |
-| docs/research/rq1-interview-guide.md | MCP-specific payload leakage validation | — | Draft v0.1 | #10 |
-| docs/research/rq4-interview-guide.md | Escalation trigger research (what makes the proof gap blocking) | — | Draft v0.1 | #9 |
-| docs/research/rq6-interview-guide.md | Phase 2 demand validation (SaaS vendor questionnaires) | — | Draft v0.1 | #19 |
-| docs/research/qualifying-question-validation.md | Qualifying question test protocol | — | Draft v0.1 | #11 |
-| docs/gtm/regulated-buyer-playbook.md | Regulated buyer entry point script and objection handling | — | Draft v0.1 | #15 |
-| docs/gtm/launch-checklist.md | CC Summit launch checklist | — | Draft v0.1 | #16 |
-| docs/partners/design-partner-template.md | Design partner engagement template | — | Draft v0.1 | #12, #13, #14 |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ cmcp = "cmcp_gateway.cli:main"
 [project.urls]
 Homepage = "https://github.com/agentrust-io/cmcp"
 Repository = "https://github.com/agentrust-io/cmcp"
-Documentation = "https://github.com/agentrust-io/cmcp#readme"
+Documentation = "https://github.com/agentrust-io/cmcp/tree/main/docs"
 "Bug Tracker" = "https://github.com/agentrust-io/cmcp/issues"
 
 [tool.hatch.build.targets.wheel]

--- a/tests/conformance/test_audit_conformance.py
+++ b/tests/conformance/test_audit_conformance.py
@@ -3,13 +3,16 @@ Conformance tests: audit chain entry format and SHA-256 hash chaining (issue #47
 Covers AUDIT-001 through AUDIT-005.
 """
 from __future__ import annotations
+
 import hashlib
 import json
 import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from unittest.mock import patch
+
 import pytest
+
 from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.audit.trace_claim import (
@@ -20,7 +23,6 @@ from cmcp_gateway.audit.trace_claim import (
     ToolCatalogInfo,
     generate_trace_claim,
 )
-
 
 # ---- helpers ----------------------------------------------------------------
 

--- a/tests/conformance/test_audit_conformance.py
+++ b/tests/conformance/test_audit_conformance.py
@@ -1,0 +1,315 @@
+"""
+Conformance tests: audit chain entry format and SHA-256 hash chaining (issue #47).
+Covers AUDIT-001 through AUDIT-005.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from unittest.mock import patch
+import pytest
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.audit.keys import SigningKey
+from cmcp_gateway.audit.trace_claim import (
+    AttestationReportInfo,
+    CallGraphSummary,
+    CallSummary,
+    PolicyBundleInfo,
+    ToolCatalogInfo,
+    generate_trace_claim,
+)
+
+
+# ---- helpers ----------------------------------------------------------------
+
+def _report():
+    return AttestationReportInfo(
+        provider="software-only",
+        measurement="DEVELOPMENT_ONLY_NOT_FOR_PRODUCTION",
+        report_data="aa" * 32,
+        attestation_generated_at="2026-06-04T00:00:00+00:00",
+        attestation_validity_seconds=86400,
+    )
+
+
+def _summary():
+    return CallSummary(
+        tool_calls_total=1,
+        tool_calls_allowed=1,
+        tool_calls_denied=0,
+        tool_calls_faulted=0,
+        tools_invoked=["tool.a"],
+        session_max_sensitivity="public",
+        call_graph_summary=CallGraphSummary(
+            compliance_domains_touched=["external"],
+            cross_boundary_events=[],
+        ),
+    )
+
+
+def _claim_dict(chain, key, seq=1, prev=None):
+    c = generate_trace_claim(
+        session_id=chain._session_id,
+        signing_key=key,
+        attestation_report=_report(),
+        policy_bundle=PolicyBundleInfo(
+            hash="sha256:" + "0" * 64,
+            enforcement_mode="enforcing",
+            policy_version="1.0.0",
+        ),
+        tool_catalog=ToolCatalogInfo(hash="sha256:" + "1" * 64),
+        call_summary=_summary(),
+        audit_chain_root=chain.chain_root,
+        audit_chain_tip=chain.chain_tip,
+        audit_chain_length=chain.length,
+        sequence_number=seq,
+        prev_claim_hash=prev,
+        do_sign=False,
+    )
+    return c.model_dump(exclude_none=True)
+
+
+def _sha256t(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+# ---- AUDIT-001: Monotonic timestamp guard -----------------------------------
+
+
+class TestAudit001MonotonicTimestamps:
+    """AUDIT-001: timestamps must be monotonically non-decreasing."""
+
+    def test_clock_regression_clamped(self):
+        chain = AuditChain("sess-a001-a")
+        first_ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        backward = first_ts - timedelta(seconds=5)
+        with patch("cmcp_gateway.audit.chain.datetime") as m:
+            m.now.return_value = backward
+            m.fromisoformat = datetime.fromisoformat
+            entry = chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert datetime.fromisoformat(entry.timestamp_utc) >= first_ts
+
+    def test_forward_clock_preserved(self):
+        chain = AuditChain("sess-a001-b")
+        first_ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        forward = first_ts + timedelta(seconds=10)
+        with patch("cmcp_gateway.audit.chain.datetime") as m:
+            m.now.return_value = forward
+            m.fromisoformat = datetime.fromisoformat
+            entry = chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert datetime.fromisoformat(entry.timestamp_utc) == forward
+
+    def test_all_timestamps_monotonic(self):
+        chain = AuditChain("sess-a001-c")
+        for i in range(5):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        ts = [datetime.fromisoformat(e.timestamp_utc) for e in chain.entries]
+        for i in range(1, len(ts)):
+            assert ts[i] >= ts[i - 1]
+
+    def test_first_entry_timestamp_timezone_aware(self):
+        chain = AuditChain("sess-a001-d")
+        ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        assert ts.tzinfo is not None
+
+
+# ---- AUDIT-002: TEE anchor --------------------------------------------------
+
+
+class TestAudit002TeeAnchor:
+    """AUDIT-002: chain root must be committed to an external TEE anchor."""
+
+    def test_set_anchor_accepts_current_root(self):
+        chain = AuditChain("sess-a002-a")
+        chain.set_tee_anchor(chain.chain_root)
+        assert chain.tee_anchor == chain.chain_root
+
+    def test_set_anchor_rejects_wrong_value(self):
+        chain = AuditChain("sess-a002-b")
+        with pytest.raises(ValueError, match="does not match current chain_root"):
+            chain.set_tee_anchor("0" * 64)
+
+    def test_anchor_none_before_set(self):
+        chain = AuditChain("sess-a002-c")
+        assert chain.tee_anchor is None
+
+    def test_verify_passes_with_anchor(self):
+        chain = AuditChain("sess-a002-d")
+        chain.set_tee_anchor(chain.chain_root)
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain() is True
+
+    def test_chain_substitution_detected(self):
+        real = AuditChain("sess-a002-e")
+        real.set_tee_anchor(real.chain_root)
+        real.append("tool_call", call_id="c1", tool_name="legit", policy_decision="allow")
+        fake = AuditChain("sess-a002-e")
+        fake.append("tool_call", call_id="c1", tool_name="evil", policy_decision="allow")
+        real._entries = fake._entries
+        assert real.verify_chain() is False
+
+    def test_verify_warns_when_no_anchor(self, caplog):
+        chain = AuditChain("sess-a002-f")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        with caplog.at_level(logging.WARNING, logger="cmcp_gateway.audit.chain"):
+            result = chain.verify_chain()
+        assert result is True
+        assert "AUDIT-002" in caplog.text
+
+
+# ---- AUDIT-003: Canonical entry format and entry_hash -----------------------
+
+
+class TestAudit003EntryFormat:
+    """AUDIT-003: entry_hash = SHA-256(canonical JSON of entry minus entry_hash)."""
+
+    def test_session_start_required_fields(self):
+        chain = AuditChain("sess-a003-a")
+        e = chain.entries[0]
+        assert e.entry_type == "session_start"
+        assert e.prev_entry_hash == "genesis"
+        assert e.sequence_number == 0
+        assert len(e.entry_id) > 0
+        assert len(e.entry_hash) == 64
+
+    def test_entry_hash_sha256_of_body_minus_entry_hash(self):
+        chain = AuditChain("sess-a003-b")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        for entry in chain.entries:
+            d = asdict(entry)
+            d.pop("entry_hash")
+            expected = hashlib.sha256(
+                json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+            ).hexdigest()
+            assert entry.entry_hash == expected
+
+    def test_payload_hash_sha256_prefixed_not_raw(self):
+        chain = AuditChain("sess-a003-c")
+        raw = json.dumps({"arg": "secret"}, sort_keys=True, separators=(",", ":")).encode()
+        phash = "sha256:" + hashlib.sha256(raw).hexdigest()
+        entry = chain.append("tool_call", call_id="c1", tool_name="t",
+                              policy_decision="allow", request_payload_hash=phash)
+        assert entry.request_payload_hash.startswith("sha256:")
+        assert "secret" not in str(asdict(entry))
+
+    def test_field_modification_changes_hash(self):
+        chain = AuditChain("sess-a003-d")
+        entry = chain.append("tool_call", call_id="c1", tool_name="original", policy_decision="allow")
+        orig = entry.entry_hash
+        entry.tool_name = "tampered"
+        assert entry.compute_hash() != orig
+
+    def test_session_id_in_all_entries(self):
+        sid = "sess-a003-e"
+        chain = AuditChain(sid)
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        for e in chain.entries:
+            assert e.session_id == sid
+
+
+# ---- AUDIT-004: Hash chain integrity ----------------------------------------
+
+
+class TestAudit004HashChaining:
+    """AUDIT-004: prev_entry_hash links every entry back to the previous one."""
+
+    def test_first_entry_prev_hash_is_genesis(self):
+        chain = AuditChain("sess-a004-a")
+        assert chain.entries[0].prev_entry_hash == "genesis"
+
+    def test_prev_hash_links_contiguous(self):
+        chain = AuditChain("sess-a004-b")
+        for i in range(4):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        for i in range(1, chain.length):
+            assert chain.entries[i].prev_entry_hash == chain.entries[i - 1].entry_hash
+
+    def test_chain_root_equals_first_entry_hash(self):
+        chain = AuditChain("sess-a004-c")
+        assert chain.chain_root == chain.entries[0].entry_hash
+
+    def test_chain_tip_equals_last_entry_hash(self):
+        chain = AuditChain("sess-a004-d")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.append("tool_call", call_id="c2", tool_name="t", policy_decision="deny")
+        assert chain.chain_tip == chain.entries[-1].entry_hash
+
+    def test_chain_tip_changes_on_each_append(self):
+        chain = AuditChain("sess-a004-e")
+        tips = [chain.chain_tip]
+        for i in range(3):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+            tips.append(chain.chain_tip)
+        assert len(set(tips)) == len(tips)
+
+    def test_verify_passes_on_unmodified_chain(self):
+        chain = AuditChain("sess-a004-f")
+        for i in range(3):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain() is True
+
+    def test_verify_detects_field_tampering(self):
+        chain = AuditChain("sess-a004-g")
+        chain.append("tool_call", call_id="c1", tool_name="legit", policy_decision="allow")
+        chain.entries[1].tool_name = "injected"
+        assert chain.verify_chain() is False
+
+    def test_verify_detects_hash_tampering(self):
+        chain = AuditChain("sess-a004-h")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.entries[0].entry_hash = "0" * 64
+        assert chain.verify_chain() is False
+
+    def test_sequence_numbers_contiguous_from_zero(self):
+        chain = AuditChain("sess-a004-i")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.append("fault", call_id="c2")
+        for i, entry in enumerate(chain.entries):
+            assert entry.sequence_number == i
+
+
+# ---- AUDIT-005: TRACE Claim sequence and chaining ---------------------------
+
+
+class TestAudit005ClaimSequence:
+    """AUDIT-005: TRACE Claims carry sequence_number and prev_claim_hash."""
+
+    def test_sequence_number_in_claim(self):
+        chain = AuditChain("sess-a005-a")
+        key = SigningKey()
+        d = _claim_dict(chain, key, seq=1)
+        assert d["gateway"]["sequence_number"] == 1
+
+    def test_sequence_number_reflects_caller_value(self):
+        chain = AuditChain("sess-a005-b")
+        key = SigningKey()
+        for seq in [1, 2, 3, 10, 100]:
+            d = _claim_dict(chain, key, seq=seq)
+            assert d["gateway"]["sequence_number"] == seq
+
+    def test_prev_claim_hash_absent_for_first_claim(self):
+        chain = AuditChain("sess-a005-c")
+        key = SigningKey()
+        d = _claim_dict(chain, key, seq=1, prev=None)
+        assert "prev_claim_hash" not in d["gateway"]
+
+    def test_prev_claim_hash_links_successive_claims(self):
+        chain = AuditChain("sess-a005-d")
+        key = SigningKey()
+        c1 = _claim_dict(chain, key, seq=1)
+        c1_hash = _sha256t(
+            json.dumps(c1, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        )
+        c2 = _claim_dict(chain, key, seq=2, prev=c1_hash)
+        assert c2["gateway"]["prev_claim_hash"] == c1_hash
+
+    def test_sequence_numbers_strictly_increasing(self):
+        chain = AuditChain("sess-a005-e")
+        key = SigningKey()
+        seqs = [1, 2, 3, 4, 5]
+        for s in seqs:
+            d = _claim_dict(chain, key, seq=s)
+            assert d["gateway"]["sequence_number"] == s
+        assert seqs == sorted(set(seqs))

--- a/tests/unit/test_audit_chain_anchor.py
+++ b/tests/unit/test_audit_chain_anchor.py
@@ -12,7 +12,6 @@ from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.session.manager import SessionManager
 
-
 # ── AuditChain.set_tee_anchor ─────────────────────────────────────────────────
 
 

--- a/tests/unit/test_audit_chain_anchor.py
+++ b/tests/unit/test_audit_chain_anchor.py
@@ -12,6 +12,7 @@ from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.session.manager import SessionManager
 
+
 # ── AuditChain.set_tee_anchor ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Delete untracked `=0.3.0,` artifact in repo root (zero-byte pip install remnant)
- Fix `CODE_OF_CONDUCT.md`: replace GitHub Security Advisories reporting path with GitHub Issues (`code of conduct` label) and GitHub Discussions; add note that vulnerabilities go to SECURITY.md
- Fix `pyproject.toml`: update `[project.urls]` Documentation entry from `#readme` anchor to `tree/main/docs`
- Fix `MAINTAINERS.md`: change "majority vote" to "2/3 vote" for Maintainer elevation, matching GOVERNANCE.md
- Fix `docs/README.md`: remove seven rows referencing `docs/research/`, `docs/gtm/`, and `docs/partners/` directories that do not exist in this repo

## Test plan

- [ ] Verify `=0.3.0,` no longer appears in repo root
- [ ] Verify CODE_OF_CONDUCT.md has no link to security/advisories
- [ ] Verify pyproject.toml Documentation URL resolves to the docs directory
- [ ] Verify MAINTAINERS.md and GOVERNANCE.md both say 2/3 for Maintainer elevation
- [ ] Verify docs/README.md table contains no references to research/, gtm/, or partners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)