### PR TITLE
docs: add LIMITATIONS.md and configuration reference

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,77 @@
+# Limitations
+
+This document describes what cMCP does not prevent, where its guarantees end, and what operators and verifiers must address through separate controls.
+
+## What cMCP does not prevent
+
+**Prompt injection into Cedar policy**
+Cedar policy evaluation is only as correct as the policy the operator wrote and approved. cMCP measures the policy bundle hash into the TEE attestation report, which proves the policy that ran is the policy that was approved. It does not evaluate whether that policy achieves the intended security outcome. A policy that contains `permit(principal, action, resource);` without conditions permits every tool call. Policy correctness is the operator's responsibility; policy review is a separate control.
+
+**Compromised TEE firmware or microcode**
+Hardware attestation proves the workload hash was measured in silicon. It does not protect against vulnerabilities in the TEE firmware or CPU microcode itself (Spectre-class side channels, cache timing, power analysis, fault injection targeting the TEE boundary). Protection at this level is the responsibility of the hardware vendor. Operators must keep TEE firmware and microcode up to date; see [Compensating Controls](docs/spec/threat-model.md#compensating-controls-operator-responsibilities) in the threat model.
+
+**Operator-controlled key material**
+The TEE-sealed signing key is generated inside the enclave and cannot be extracted by a privileged operator under normal circumstances. However, if the operator can substitute the TEE firmware, modify the enclave startup measurement, or compromise the SPIRE infrastructure that issues SVIDs, they can effectively control what key material is used. The trust root is the hardware platform vendor (AMD, Intel, or the TPM manufacturer), not cMCP. Deployments that do not independently verify the attestation report before routing traffic treat attestation as post-hoc audit evidence only.
+
+**Phase 2 completeness: server-side attestation**
+Phase 1 attests the gateway boundary. It does not attest what happens on the other side of that boundary. The `tool_transcript.hash` field in the TRACE Claim records a hash of the audit chain tip, but the tool transcript binding that ties a specific tool execution to a specific response is Phase 2 work. Phase 1 partially addresses P1.4 (transitive trust into upstream dependencies) and P4.1 (typosquatted packages added to catalog) -- both are fully closed by Phase 2. Any compliance claim that relies on server-side proof must wait for Phase 2.
+
+**LLM inference and model output**
+cMCP intercepts tool calls at the MCP protocol boundary. It does not observe or modify LLM inference, the contents of the agent's context window, or model outputs that do not produce a tool call. A model could hallucinate a response, leak sensitive context in a chat reply, or receive a poisoned tool response that influences subsequent reasoning -- none of these are visible to the gateway. cMCP controls the tool boundary, not the model boundary.
+
+**Response injection evasion via novel patterns**
+The response inspector uses pattern-based detection for prompt injection in tool responses. Pattern-based detection has false negatives. A sufficiently sophisticated injection may evade the current pattern list. The pattern list must be maintained and updated by the operator as new injection techniques emerge; see [Compensating Controls](docs/spec/threat-model.md#compensating-controls-operator-responsibilities).
+
+**APM and telemetry payload capture**
+The TEE prevents plaintext from leaving the enclave to any destination not covered by the egress policy. This protection is structural only when the egress policy explicitly denies APM and telemetry endpoints. If the operator allowlists those endpoints in the Cedar policy, the TEE boundary does not prevent payload capture by the APM agent. A TRACE Claim with an egress policy that permits APM or SDK telemetry endpoints does not provide this protection. Verifiers must inspect the policy bundle hash and confirm the policy excludes those endpoints.
+
+**Tool name collision via malicious catalog entries**
+The catalog binds each tool name to a specific upstream server identity, which prevents routing ambiguity for approved servers. It does not prevent a typosquatted or look-alike package from being added to the catalog in the first place. Catalog approval is human-gated. The gateway trusts the catalog; it cannot detect that a catalog entry was added via a compromised reviewer or a social engineering attack.
+
+## What Level 0 (CMCP_DEV_MODE) does not provide
+
+`CMCP_DEV_MODE=1` uses a software-only TEE provider. It is suitable for development, testing, and demo scenarios. It does not satisfy production governance requirements because:
+
+- **No hardware root of trust.** The signing key is held in software and is accessible to any process running as the same user. A privileged operator can extract it.
+- **No verifiable measurement.** The `trace.runtime.measurement` field is all zeros in dev mode. There is no hardware-measured enclave identity, so a verifier cannot confirm which binary ran.
+- **Threat classes T1 through T4 are not covered.** These are the rogue administrator, host OS compromise, post-incident audit log reconstruction, and policy substitution threats described in the [threat model](docs/spec/threat-model.md). All four require a hardware TEE to close. In software-only mode, all four remain open.
+- **TRACE Claims are partially verified only.** The `cmcp_verify` library returns `status: partially_verified` and reports `hardware_attestation: software-only mode -- not hardware-backed`. Claims produced in dev mode must not be presented as hardware-attested proof to auditors or regulators.
+
+## What cMCP does not do
+
+- **cMCP is not a WAF.** It does not inspect HTTP traffic for SQL injection, XSS, or other web application attack patterns. It operates at the MCP tool call layer, not the HTTP layer.
+- **cMCP is not a content filter.** It does not classify or filter free-text content for harmful material, bias, or policy violations in the LLM inference path. Response inspection is scoped to tool response payloads at the gateway boundary.
+- **cMCP is not a network proxy.** It does not perform general-purpose HTTP proxying, TLS termination for arbitrary traffic, or routing outside the MCP protocol. It proxies MCP tool calls only.
+- **cMCP is not responsible for MCP server bugs.** The gateway enforces policy and records what happened. Bugs in upstream MCP servers -- memory corruption, logic errors, incorrect data handling -- are outside the gateway's control and are not attested by the TRACE Claim.
+
+## Performance
+
+Attestation is a startup cost, not a per-call cost. Per-call gateway overhead covers Cedar policy evaluation, audit entry creation, and routing. Upstream tool execution time is excluded.
+
+### Attestation handshake (one-time, at startup)
+
+| Provider | Typical latency |
+|----------|----------------|
+| TPM | less than 500ms (hardware I/O bound) |
+| SEV-SNP | less than 100ms (Azure DCasv5, AWS C6a Nitro) |
+| TDX | less than 100ms (Azure DCedsv5, GCP C3) |
+| Opaque Managed | less than 50ms |
+| software-only | negligible |
+
+### Per-call gateway overhead
+
+| Percentile | Target |
+|------------|--------|
+| p50 | less than 1ms |
+| p95 | less than 3ms |
+| p99 | less than 5ms |
+
+Expected component breakdown for a 10-rule policy bundle:
+
+| Component | Estimated cost |
+|-----------|---------------|
+| Cedar evaluation (10 rules) | 0.2 to 0.5ms |
+| Audit entry hash computation | approximately 0.1ms |
+| Network routing overhead | 0.5 to 2ms |
+
+These are targets from [docs/testing/benchmarks.md](docs/testing/benchmarks.md). Actual results on real TEE hardware will vary by provider and payload size; benchmark results are committed per provider to `benchmarks/` in CI.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,128 @@
+# Configuration Reference
+
+`cmcp-config.yaml` controls the gateway's attestation provider, policy enforcement behavior, network settings, and file paths. Environment variables override specific fields and control secrets that must not appear in config files.
+
+## Full example
+
+```yaml
+# cmcp-config.yaml — annotated full example
+
+attestation:
+  # TEE provider. auto detects in order: tpm -> sev-snp -> tdx.
+  # opaque requires explicit opt-in via OPAQUE_ATTESTATION_URL env var.
+  # Use software-only only with CMCP_DEV_MODE=1.
+  provider: auto
+
+  # enforcing: policy denies block the tool call and return HTTP 403.
+  # advisory: policy denies are logged but the call is forwarded.
+  # silent: evaluates policy but takes no action and does not log denies.
+  enforcement_mode: enforcing
+
+  # How long (in seconds) an attestation report is considered fresh.
+  # Default is 24 hours. When validity expires, the default behavior is
+  # fail_closed: active sessions are terminated until re-attestation.
+  validity_seconds: 86400
+
+  # fail_closed (default): terminate sessions when attestation expires.
+  # warn_only: allow sessions to continue; marks TRACE Claims as stale.
+  staleness_policy: fail_closed
+
+  # Optional. If set, the gateway verifies the TEE measurement matches
+  # this value at startup and refuses to start if it does not.
+  # Format: provider-specific (e.g., hex PCR values for TPM,
+  # AMD measurement register hex for SEV-SNP).
+  # expected_measurement: "sha256:..."
+
+# Path to the directory containing .cedar policy files and manifest.json.
+# Must not contain '..' components. Relative paths are resolved from the
+# working directory at startup.
+policy_bundle_path: policy/
+
+# Path to the JSON tool catalog file.
+# Must not contain '..' components.
+catalog_path: catalog.json
+
+# Address and port the gateway listens on.
+listen_addr: "0.0.0.0:8443"
+
+# Maximum size of a tool response payload in bytes. Responses larger than
+# this are rejected before entering the response inspector (FM-5 size check).
+# Default is 2MB (2097152 bytes).
+max_response_size_bytes: 2097152
+
+# Interval in seconds between automatic policy bundle reloads.
+# 0 (default) disables automatic reload. Changing the policy bundle
+# without restarting the gateway invalidates the attestation measurement.
+# This field exists for advisory/silent deployments only; do not use in
+# enforcing mode without a full enclave restart.
+policy_reload_interval_seconds: 0
+```
+
+## Field reference
+
+### attestation
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | `auto` | TEE provider. Valid values: `auto`, `tpm`, `sev-snp`, `tdx`, `opaque`, `software-only`. `auto` detects in order: tpm then sev-snp then tdx. `opaque` requires `OPAQUE_ATTESTATION_URL` to be set. `software-only` requires `CMCP_DEV_MODE=1`. |
+| `enforcement_mode` | string | `enforcing` | Policy enforcement mode. Valid values: `enforcing`, `advisory`, `silent`. |
+| `validity_seconds` | integer | `86400` | Attestation report validity period in seconds. Must be a positive integer. At expiry, behavior is controlled by `staleness_policy`. |
+| `staleness_policy` | string | `fail_closed` | Action when attestation validity expires. Valid values: `fail_closed` (terminate sessions), `warn_only` (allow sessions, mark claims as stale). |
+| `expected_measurement` | string | none | Optional. Expected TEE measurement value. If set, the gateway verifies the hardware measurement matches this string at startup and exits with a non-zero status if it does not. |
+
+### top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `policy_bundle_path` | string | `policy/` | Path to the Cedar policy bundle directory. Must contain `.cedar` files and a `manifest.json`. Path traversal (`..` components) is rejected. |
+| `catalog_path` | string | `catalog.json` | Path to the JSON tool catalog. Path traversal (`..` components) is rejected. |
+| `listen_addr` | string | `0.0.0.0:8443` | Address and port the gateway binds to. |
+| `max_response_size_bytes` | integer | `2097152` | Maximum tool response size in bytes (2MB). Must be a positive integer. Responses exceeding this limit are rejected before inspection. |
+| `policy_reload_interval_seconds` | integer | `0` | Interval in seconds between automatic Cedar bundle reloads. `0` disables automatic reload. See note in the full example above. |
+
+## Environment variables
+
+Environment variables control secrets and mode flags that must not appear in config files. They are read once at process startup; they cannot be changed at runtime.
+
+| Variable | Description | Overrides |
+|----------|-------------|-----------|
+| `CMCP_DEV_MODE=1` | Enables software-only attestation. No hardware TEE required. TRACE Claims will show `partially_verified` status. Required when `provider` is `software-only`. | `attestation.provider` (forces software-only) |
+| `CMCP_BEARER_TOKEN` | Optional bearer token for gateway HTTP auth. If set, all requests to the gateway must include `Authorization: Bearer <token>`. If unset, no bearer auth is enforced. | none |
+| `OPAQUE_ATTESTATION_URL` | Enables the Opaque Managed Runtime provider. Must be set to the Opaque attestation service URL. Required when `provider` is `opaque` or `auto` on Opaque infrastructure. | enables `opaque` provider detection |
+| `CMCP_CATALOG_HASH` | SHA-256 hash of the approved `catalog.json`. Required in non-dev mode. The gateway fails closed at startup if this is unset and `CMCP_DEV_MODE` is not `1`. Format: `sha256:<hex>`. | none (additional startup check) |
+
+## Enforcement modes
+
+| Mode | Behavior | Use case |
+|------|----------|----------|
+| `enforcing` | Policy denies block the tool call. The gateway returns HTTP 403 and a structured error to the agent. The call is not forwarded to the upstream server. | Production. Default for new deployments. |
+| `advisory` | Policy denies are logged in the audit chain but the call is forwarded. The TRACE Claim records the deny. No tool call is blocked. | Policy testing, migration from existing gateway. Safe for first run with an untuned policy. |
+| `silent` | Policy is evaluated but the result is not acted on and denies are not logged. Observability-only mode. | Measuring policy impact before rollout. Not suitable for any compliance scenario. |
+
+## Minimal working config
+
+```yaml
+attestation:
+  provider: auto
+  enforcement_mode: enforcing
+policy_bundle_path: policy/
+catalog_path: catalog.json
+```
+
+With `CMCP_DEV_MODE=1` for local development:
+
+```yaml
+attestation:
+  provider: auto
+  enforcement_mode: advisory
+policy_bundle_path: ./policies/
+catalog_path: ./catalog.json
+```
+
+## Production hardening checklist
+
+- Set `attestation.enforcement_mode` to `enforcing`. Advisory mode provides no blocking protection against policy violations.
+- Set `CMCP_CATALOG_HASH` to the SHA-256 of the approved `catalog.json`. The gateway fails closed at startup if this is unset in non-dev mode, but setting it explicitly pins the approved catalog hash and prevents silent substitution.
+- Set `attestation.expected_measurement` to the expected TEE measurement for your deployment. Without this, a different binary could be deployed and would still produce valid attestation reports.
+- Use a real TEE provider (`tpm`, `sev-snp`, `tdx`, or `opaque`), not `software-only`. Software-only mode does not provide a hardware root of trust and leaves threat classes T1 through T4 open.
+- Rotate the TEE signing key by performing a full enclave restart on a regular schedule. The signing key is hardware-sealed per enclave instance; rotation requires restart.

--- a/tests/conformance/test_audit_conformance.py
+++ b/tests/conformance/test_audit_conformance.py
@@ -3,13 +3,16 @@ Conformance tests: audit chain entry format and SHA-256 hash chaining (issue #47
 Covers AUDIT-001 through AUDIT-005.
 """
 from __future__ import annotations
+
 import hashlib
 import json
 import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from unittest.mock import patch
+
 import pytest
+
 from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.audit.trace_claim import (
@@ -20,7 +23,6 @@ from cmcp_gateway.audit.trace_claim import (
     ToolCatalogInfo,
     generate_trace_claim,
 )
-
 
 # ---- helpers ----------------------------------------------------------------
 

--- a/tests/conformance/test_audit_conformance.py
+++ b/tests/conformance/test_audit_conformance.py
@@ -1,0 +1,315 @@
+"""
+Conformance tests: audit chain entry format and SHA-256 hash chaining (issue #47).
+Covers AUDIT-001 through AUDIT-005.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from unittest.mock import patch
+import pytest
+from cmcp_gateway.audit.chain import AuditChain
+from cmcp_gateway.audit.keys import SigningKey
+from cmcp_gateway.audit.trace_claim import (
+    AttestationReportInfo,
+    CallGraphSummary,
+    CallSummary,
+    PolicyBundleInfo,
+    ToolCatalogInfo,
+    generate_trace_claim,
+)
+
+
+# ---- helpers ----------------------------------------------------------------
+
+def _report():
+    return AttestationReportInfo(
+        provider="software-only",
+        measurement="DEVELOPMENT_ONLY_NOT_FOR_PRODUCTION",
+        report_data="aa" * 32,
+        attestation_generated_at="2026-06-04T00:00:00+00:00",
+        attestation_validity_seconds=86400,
+    )
+
+
+def _summary():
+    return CallSummary(
+        tool_calls_total=1,
+        tool_calls_allowed=1,
+        tool_calls_denied=0,
+        tool_calls_faulted=0,
+        tools_invoked=["tool.a"],
+        session_max_sensitivity="public",
+        call_graph_summary=CallGraphSummary(
+            compliance_domains_touched=["external"],
+            cross_boundary_events=[],
+        ),
+    )
+
+
+def _claim_dict(chain, key, seq=1, prev=None):
+    c = generate_trace_claim(
+        session_id=chain._session_id,
+        signing_key=key,
+        attestation_report=_report(),
+        policy_bundle=PolicyBundleInfo(
+            hash="sha256:" + "0" * 64,
+            enforcement_mode="enforcing",
+            policy_version="1.0.0",
+        ),
+        tool_catalog=ToolCatalogInfo(hash="sha256:" + "1" * 64),
+        call_summary=_summary(),
+        audit_chain_root=chain.chain_root,
+        audit_chain_tip=chain.chain_tip,
+        audit_chain_length=chain.length,
+        sequence_number=seq,
+        prev_claim_hash=prev,
+        do_sign=False,
+    )
+    return c.model_dump(exclude_none=True)
+
+
+def _sha256t(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+# ---- AUDIT-001: Monotonic timestamp guard -----------------------------------
+
+
+class TestAudit001MonotonicTimestamps:
+    """AUDIT-001: timestamps must be monotonically non-decreasing."""
+
+    def test_clock_regression_clamped(self):
+        chain = AuditChain("sess-a001-a")
+        first_ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        backward = first_ts - timedelta(seconds=5)
+        with patch("cmcp_gateway.audit.chain.datetime") as m:
+            m.now.return_value = backward
+            m.fromisoformat = datetime.fromisoformat
+            entry = chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert datetime.fromisoformat(entry.timestamp_utc) >= first_ts
+
+    def test_forward_clock_preserved(self):
+        chain = AuditChain("sess-a001-b")
+        first_ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        forward = first_ts + timedelta(seconds=10)
+        with patch("cmcp_gateway.audit.chain.datetime") as m:
+            m.now.return_value = forward
+            m.fromisoformat = datetime.fromisoformat
+            entry = chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert datetime.fromisoformat(entry.timestamp_utc) == forward
+
+    def test_all_timestamps_monotonic(self):
+        chain = AuditChain("sess-a001-c")
+        for i in range(5):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        ts = [datetime.fromisoformat(e.timestamp_utc) for e in chain.entries]
+        for i in range(1, len(ts)):
+            assert ts[i] >= ts[i - 1]
+
+    def test_first_entry_timestamp_timezone_aware(self):
+        chain = AuditChain("sess-a001-d")
+        ts = datetime.fromisoformat(chain.entries[0].timestamp_utc)
+        assert ts.tzinfo is not None
+
+
+# ---- AUDIT-002: TEE anchor --------------------------------------------------
+
+
+class TestAudit002TeeAnchor:
+    """AUDIT-002: chain root must be committed to an external TEE anchor."""
+
+    def test_set_anchor_accepts_current_root(self):
+        chain = AuditChain("sess-a002-a")
+        chain.set_tee_anchor(chain.chain_root)
+        assert chain.tee_anchor == chain.chain_root
+
+    def test_set_anchor_rejects_wrong_value(self):
+        chain = AuditChain("sess-a002-b")
+        with pytest.raises(ValueError, match="does not match current chain_root"):
+            chain.set_tee_anchor("0" * 64)
+
+    def test_anchor_none_before_set(self):
+        chain = AuditChain("sess-a002-c")
+        assert chain.tee_anchor is None
+
+    def test_verify_passes_with_anchor(self):
+        chain = AuditChain("sess-a002-d")
+        chain.set_tee_anchor(chain.chain_root)
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain() is True
+
+    def test_chain_substitution_detected(self):
+        real = AuditChain("sess-a002-e")
+        real.set_tee_anchor(real.chain_root)
+        real.append("tool_call", call_id="c1", tool_name="legit", policy_decision="allow")
+        fake = AuditChain("sess-a002-e")
+        fake.append("tool_call", call_id="c1", tool_name="evil", policy_decision="allow")
+        real._entries = fake._entries
+        assert real.verify_chain() is False
+
+    def test_verify_warns_when_no_anchor(self, caplog):
+        chain = AuditChain("sess-a002-f")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        with caplog.at_level(logging.WARNING, logger="cmcp_gateway.audit.chain"):
+            result = chain.verify_chain()
+        assert result is True
+        assert "AUDIT-002" in caplog.text
+
+
+# ---- AUDIT-003: Canonical entry format and entry_hash -----------------------
+
+
+class TestAudit003EntryFormat:
+    """AUDIT-003: entry_hash = SHA-256(canonical JSON of entry minus entry_hash)."""
+
+    def test_session_start_required_fields(self):
+        chain = AuditChain("sess-a003-a")
+        e = chain.entries[0]
+        assert e.entry_type == "session_start"
+        assert e.prev_entry_hash == "genesis"
+        assert e.sequence_number == 0
+        assert len(e.entry_id) > 0
+        assert len(e.entry_hash) == 64
+
+    def test_entry_hash_sha256_of_body_minus_entry_hash(self):
+        chain = AuditChain("sess-a003-b")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        for entry in chain.entries:
+            d = asdict(entry)
+            d.pop("entry_hash")
+            expected = hashlib.sha256(
+                json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+            ).hexdigest()
+            assert entry.entry_hash == expected
+
+    def test_payload_hash_sha256_prefixed_not_raw(self):
+        chain = AuditChain("sess-a003-c")
+        raw = json.dumps({"arg": "secret"}, sort_keys=True, separators=(",", ":")).encode()
+        phash = "sha256:" + hashlib.sha256(raw).hexdigest()
+        entry = chain.append("tool_call", call_id="c1", tool_name="t",
+                              policy_decision="allow", request_payload_hash=phash)
+        assert entry.request_payload_hash.startswith("sha256:")
+        assert "secret" not in str(asdict(entry))
+
+    def test_field_modification_changes_hash(self):
+        chain = AuditChain("sess-a003-d")
+        entry = chain.append("tool_call", call_id="c1", tool_name="original", policy_decision="allow")
+        orig = entry.entry_hash
+        entry.tool_name = "tampered"
+        assert entry.compute_hash() != orig
+
+    def test_session_id_in_all_entries(self):
+        sid = "sess-a003-e"
+        chain = AuditChain(sid)
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        for e in chain.entries:
+            assert e.session_id == sid
+
+
+# ---- AUDIT-004: Hash chain integrity ----------------------------------------
+
+
+class TestAudit004HashChaining:
+    """AUDIT-004: prev_entry_hash links every entry back to the previous one."""
+
+    def test_first_entry_prev_hash_is_genesis(self):
+        chain = AuditChain("sess-a004-a")
+        assert chain.entries[0].prev_entry_hash == "genesis"
+
+    def test_prev_hash_links_contiguous(self):
+        chain = AuditChain("sess-a004-b")
+        for i in range(4):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        for i in range(1, chain.length):
+            assert chain.entries[i].prev_entry_hash == chain.entries[i - 1].entry_hash
+
+    def test_chain_root_equals_first_entry_hash(self):
+        chain = AuditChain("sess-a004-c")
+        assert chain.chain_root == chain.entries[0].entry_hash
+
+    def test_chain_tip_equals_last_entry_hash(self):
+        chain = AuditChain("sess-a004-d")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.append("tool_call", call_id="c2", tool_name="t", policy_decision="deny")
+        assert chain.chain_tip == chain.entries[-1].entry_hash
+
+    def test_chain_tip_changes_on_each_append(self):
+        chain = AuditChain("sess-a004-e")
+        tips = [chain.chain_tip]
+        for i in range(3):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+            tips.append(chain.chain_tip)
+        assert len(set(tips)) == len(tips)
+
+    def test_verify_passes_on_unmodified_chain(self):
+        chain = AuditChain("sess-a004-f")
+        for i in range(3):
+            chain.append("tool_call", call_id=f"c{i}", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain() is True
+
+    def test_verify_detects_field_tampering(self):
+        chain = AuditChain("sess-a004-g")
+        chain.append("tool_call", call_id="c1", tool_name="legit", policy_decision="allow")
+        chain.entries[1].tool_name = "injected"
+        assert chain.verify_chain() is False
+
+    def test_verify_detects_hash_tampering(self):
+        chain = AuditChain("sess-a004-h")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.entries[0].entry_hash = "0" * 64
+        assert chain.verify_chain() is False
+
+    def test_sequence_numbers_contiguous_from_zero(self):
+        chain = AuditChain("sess-a004-i")
+        chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+        chain.append("fault", call_id="c2")
+        for i, entry in enumerate(chain.entries):
+            assert entry.sequence_number == i
+
+
+# ---- AUDIT-005: TRACE Claim sequence and chaining ---------------------------
+
+
+class TestAudit005ClaimSequence:
+    """AUDIT-005: TRACE Claims carry sequence_number and prev_claim_hash."""
+
+    def test_sequence_number_in_claim(self):
+        chain = AuditChain("sess-a005-a")
+        key = SigningKey()
+        d = _claim_dict(chain, key, seq=1)
+        assert d["gateway"]["sequence_number"] == 1
+
+    def test_sequence_number_reflects_caller_value(self):
+        chain = AuditChain("sess-a005-b")
+        key = SigningKey()
+        for seq in [1, 2, 3, 10, 100]:
+            d = _claim_dict(chain, key, seq=seq)
+            assert d["gateway"]["sequence_number"] == seq
+
+    def test_prev_claim_hash_absent_for_first_claim(self):
+        chain = AuditChain("sess-a005-c")
+        key = SigningKey()
+        d = _claim_dict(chain, key, seq=1, prev=None)
+        assert "prev_claim_hash" not in d["gateway"]
+
+    def test_prev_claim_hash_links_successive_claims(self):
+        chain = AuditChain("sess-a005-d")
+        key = SigningKey()
+        c1 = _claim_dict(chain, key, seq=1)
+        c1_hash = _sha256t(
+            json.dumps(c1, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        )
+        c2 = _claim_dict(chain, key, seq=2, prev=c1_hash)
+        assert c2["gateway"]["prev_claim_hash"] == c1_hash
+
+    def test_sequence_numbers_strictly_increasing(self):
+        chain = AuditChain("sess-a005-e")
+        key = SigningKey()
+        seqs = [1, 2, 3, 4, 5]
+        for s in seqs:
+            d = _claim_dict(chain, key, seq=s)
+            assert d["gateway"]["sequence_number"] == s
+        assert seqs == sorted(set(seqs))

--- a/tests/unit/test_audit_chain_anchor.py
+++ b/tests/unit/test_audit_chain_anchor.py
@@ -12,7 +12,6 @@ from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.session.manager import SessionManager
 
-
 # ── AuditChain.set_tee_anchor ─────────────────────────────────────────────────
 
 

--- a/tests/unit/test_audit_chain_anchor.py
+++ b/tests/unit/test_audit_chain_anchor.py
@@ -12,6 +12,7 @@ from cmcp_gateway.audit.chain import AuditChain
 from cmcp_gateway.audit.keys import SigningKey
 from cmcp_gateway.session.manager import SessionManager
 
+
 # ── AuditChain.set_tee_anchor ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Adds `LIMITATIONS.md` at repo root: honest, specific scope boundaries covering Cedar policy correctness, TEE firmware trust, operator key control, Phase 1 vs Phase 2 completeness, model output vs tool boundary, pattern injection evasion, APM telemetry gaps, and catalog approval limits. Includes Level 0 threat class coverage (T1-T4), the four things cMCP explicitly is not, and a performance table with attestation and per-call latency targets from `docs/testing/benchmarks.md`.
- Adds `docs/configuration.md`: complete configuration reference for `cmcp-config.yaml`. Every field, type, default, and validation rule sourced directly from `src/cmcp_gateway/config.py`. Includes annotated full YAML example, field reference tables, environment variable table, enforcement mode table, minimal working config, and a 5-item production hardening checklist.

## Test plan

- [ ] Read both files and verify all field names, defaults, and enum values match `src/cmcp_gateway/config.py` exactly
- [ ] Verify latency numbers in LIMITATIONS.md match `docs/testing/benchmarks.md`
- [ ] Verify threat class references (T1-T4) match `docs/spec/threat-model.md`
- [ ] Verify Phase 1/Phase 2 residuals (P1.4, P4.1) match `docs/SPEC.md` section 8

Generated with [Claude Code](https://claude.com/claude-code)