### PR TITLE
chore: migrate agent-os-kernel dep to agent-governance-toolkit-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.29",
     "click>=8.1",
-    "agent-os-kernel>=3.7",
+    "agent-governance-toolkit-core>=4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Changes `agent-os-kernel>=3.7` to `agent-governance-toolkit-core>=4.0` in `pyproject.toml`
- No import changes: `agent_os.*` paths are identical in both packages
- Silences the `DeprecationWarning` that fires on every import of `agent_os.policies.backends`

`agent-os-kernel` was consolidated into `agent-governance-toolkit-core` as of v4.0.0. The migration guide at `docs/package-consolidation/MIGRATION.md` lists this as a stub redirect; the stub emits a warning and delegates. This PR upgrades to the canonical package directly.

## Test plan

- [ ] CI passes (import paths unchanged, no code changes)
- [ ] `python -c "from agent_os.policies.backends import CedarBackend; print(CedarBackend)"` -- no DeprecationWarning
- [ ] `pip install -e ".[dev]"` resolves cleanly with the new dep name

🤖 Generated with [Claude Code](https://claude.com/claude-code)