### PR TITLE
feat(server): POST /sessions/{id}/close issues the TRACE Claim and rotates the session

### DIFF
--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -110,6 +110,18 @@ class CMCPProxy:
         # proxy construction stays sync and tests need no event loop.
         self._http: httpx.AsyncClient | None = None
 
+    def rebind_session(self, session: SessionState, audit_chain: AuditChain) -> None:
+        """
+        Point the proxy at a fresh session after the previous one was closed.
+
+        Call logs are recreated for the new session id; catalog, policy
+        evaluator, and gateway are unchanged.
+        """
+        self._session = session
+        self._audit = audit_chain
+        self._call_log = CallLog(session_id=session.session_id)
+        self._session_call_log = SessionCallLog(session_id=session.session_id)
+
     async def _forward_to_upstream(
         self,
         call_id: str,

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -52,6 +52,26 @@ class CallResult:
     advice: dict[str, str] | None = None
 
 
+def _cedar_safe(value: Any) -> Any:
+    """
+    Coerce a JSON value into types Cedar can ingest.
+
+    Cedar has no float or null type: a single float anywhere in the request
+    context makes cedarpy reject the whole request, which fails closed and
+    denies the call. Floats are preserved as strings; None values are dropped
+    (policies use `has` checks, so absence is the correct representation).
+    """
+    if isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _cedar_safe(v) for k, v in value.items() if v is not None}
+    if isinstance(value, (list, tuple)):
+        return [_cedar_safe(v) for v in value if v is not None]
+    return str(value)
+
+
 class CMCPProxy:
     """
     Wraps AGT's MCPGateway so every tool call is:
@@ -238,7 +258,7 @@ class CMCPProxy:
         entry = self._catalog.lookup(tool_name)
         ctx: dict[str, Any] = {
             "tool_name": tool_name,
-            "arguments": arguments,
+            "arguments": _cedar_safe(arguments),
             "server_identity": entry.server.url if entry else "",
             "compliance_domain": entry.compliance_domain if entry else "external",
             "baa_covered": (not entry.requires_baa) if entry else False,

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -153,6 +153,9 @@ class MCPServer:
         self._session = session
         self._max_request_bytes = max_request_bytes
         self._audit = audit_chain
+        # Chains of closed sessions, kept so /audit/export still serves them
+        # after the live session rotates.
+        self._closed_chains: dict[str, AuditChain] = {}
         self._kernel = StatelessKernel()
         # NET-002: rate-limit unauthenticated /health before auth middleware runs.
         # Starlette applies middleware outermost-first (first in list = first to run).
@@ -186,6 +189,11 @@ class MCPServer:
                 Route(
                     "/sessions/{session_id}/reset",
                     self._session_reset,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/sessions/{session_id}/close",
+                    self._session_close,
                     methods=["POST"],
                 ),
                 Route("/catalog/exception", self._catalog_exception, methods=["POST"]),
@@ -372,6 +380,8 @@ class MCPServer:
             "would_have_denied": result.would_have_denied,
             "latency_us": result.latency_us,
         }
+        if self._session is not None:
+            cmcp_meta["session_id"] = self._session.session_id
         if result.would_have_denied and result.advice:
             cmcp_meta["advice"] = result.advice
         if workflow_id is not None:
@@ -472,10 +482,10 @@ class MCPServer:
                 {"error": "query parameter 'session_id' is required"},
                 status_code=400,
             )
+        # Closed sessions keep their chain available for export after rotation.
+        chain = self._closed_chains.get(session_id, self._audit_chain)
         try:
-            bundle = self._session_manager.get_audit_bundle(
-                session_id, self._audit_chain
-            )
+            bundle = self._session_manager.get_audit_bundle(session_id, chain)
         except ValueError as exc:
             logger.error(
                 "Audit chain integrity failure: session_id=%s error=%s",
@@ -486,6 +496,50 @@ class MCPServer:
                 {"error": "audit chain integrity check failed"}, status_code=500
             )
         return JSONResponse(bundle)
+
+    async def _session_close(self, request: Request) -> Response:
+        """POST /sessions/{session_id}/close — close the session, return its signed TRACE Claim.
+
+        Appends the session_end audit entry, signs the claim, then rotates the
+        gateway onto a fresh session so subsequent tool calls keep working.
+        The closed session's claim stays available at
+        GET /sessions/{session_id}/trace-claim and its audit bundle at
+        GET /audit/export?session_id=<id>.
+        """
+        if (
+            self._session_manager is None
+            or self._session is None
+            or self._audit_chain is None
+        ):
+            return JSONResponse(
+                {"error": "session management not available"}, status_code=501
+            )
+        session_id: str = request.path_params["session_id"]
+        if session_id != self._session.session_id:
+            return JSONResponse(
+                {"error": f"unknown or already closed session_id={session_id}"},
+                status_code=404,
+            )
+
+        claim = self._session_manager.close_session(
+            session_id,
+            self._session,
+            self._audit_chain,
+            call_log=getattr(self._proxy, "_call_log", None),
+            session_call_log=getattr(self._proxy, "_session_call_log", None),
+        )
+        self._closed_chains[session_id] = self._audit_chain
+
+        # Rotate onto a fresh session so the gateway keeps serving.
+        new_session, new_chain = self._session_manager.create_session()
+        self._session = new_session
+        self._audit_chain = new_chain
+        self._audit = new_chain
+        self._proxy.rebind_session(new_session, new_chain)
+        logger.info(
+            "Session closed via API: closed=%s new=%s", session_id, new_session.session_id
+        )
+        return JSONResponse(claim)
 
     async def _catalog_exception(self, request: Request) -> Response:
         """POST /catalog/exception — add a break-glass catalog exception at runtime.

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -380,3 +380,42 @@ async def test_audit_entry_detail_falls_back_to_unknown_when_fields_absent():
     assert entry.detail is not None
     assert entry.detail["injection_scanner"] == "agt_response_scanner"
     assert entry.detail["matched_pattern"] == "unknown"
+
+
+# ── Cedar-safe context coercion ────────────────────────────────────────────────
+
+
+def test_cedar_safe_coerces_floats_and_drops_none():
+    from cmcp_runtime.mcp.proxy import _cedar_safe
+
+    out = _cedar_safe({
+        "score": 72.3,
+        "labs": {"glucose": 9.2, "note": None},
+        "tags": ["a", 1, 2.5, None],
+        "count": 3,
+        "active": True,
+    })
+    assert out == {
+        "score": "72.3",
+        "labs": {"glucose": "9.2"},
+        "tags": ["a", 1, "2.5"],
+        "count": 3,
+        "active": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_float_arguments_do_not_fail_policy_evaluation():
+    """A float in tool arguments must not crash Cedar and deny the call."""
+    proxy, _, _ = _make_proxy()
+    captured = {}
+    original = proxy._policy.evaluate
+
+    def capture(ctx):
+        captured.update(ctx)
+        return original(ctx)
+
+    proxy._policy.evaluate = capture
+    result = await proxy.call_tool("c1", "test.tool", {"risk_score": 72.3})
+    assert result.allowed is True
+    assert captured["arguments"] == {"risk_score": "72.3"}

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -1,0 +1,105 @@
+"""Tests for POST /sessions/{id}/close — claim issuance and session rotation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.cli import build_server
+from cmcp_runtime.config import AttestationConfig, Config
+from cmcp_runtime.policy.bundle import PolicyStore
+from cmcp_runtime.startup import RuntimeContext
+
+
+@pytest.fixture
+def server():
+    config = Config(attestation=AttestationConfig(), dev_mode=True)
+
+    attestation_report = MagicMock()
+    attestation_report.provider = "software-only"
+    attestation_report.attestation_generated_at = datetime.now(UTC)
+    attestation_report.attestation_validity_seconds = 86400
+    attestation_report.measurement = "0" * 64
+    attestation_report.report_data = "0" * 64
+    attestation_report.measurement_note = None
+    attestation_report.raw_evidence = None
+
+    bundle = MagicMock()
+    bundle.bundle_hash = "sha256:" + "0" * 64
+    bundle.policy_files = {"allow.cedar": "permit (principal, action, resource);"}
+    bundle.manifest = MagicMock()
+    bundle.manifest.version = "test-v1"
+    policy_store = MagicMock(spec=PolicyStore)
+    policy_store.bundle = bundle
+
+    catalog = MagicMock()
+    catalog.entries = {}
+    catalog.catalog_hash = "sha256:" + "1" * 64
+    catalog.exceptions = []
+
+    ctx = RuntimeContext(
+        config=config,
+        tee_provider=MagicMock(),
+        attestation_report=attestation_report,
+        signing_key=SigningKey(),
+        policy_bundle=policy_store,
+        catalog=catalog,
+    )
+    return build_server(ctx)
+
+
+def test_close_returns_signed_claim_and_rotates(server):
+    client = TestClient(server.app)
+    old_session_id = server._session.session_id
+
+    resp = client.post(f"/sessions/{old_session_id}/close")
+    assert resp.status_code == 200
+    claim = resp.json()
+    assert claim["gateway"]["session_id"] == old_session_id
+    assert claim["signature"]  # signed claim
+
+    # Session rotated: new id, proxy rebound.
+    assert server._session.session_id != old_session_id
+    assert server._proxy._session.session_id == server._session.session_id
+    assert server._audit_chain is server._proxy._audit
+
+
+def test_closed_claim_retrievable_via_trace_claim_endpoint(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    client.post(f"/sessions/{session_id}/close")
+
+    resp = client.get(f"/sessions/{session_id}/trace-claim")
+    assert resp.status_code == 200
+    assert resp.json()["gateway"]["session_id"] == session_id
+
+
+def test_close_unknown_session_404(server):
+    client = TestClient(server.app)
+    resp = client.post("/sessions/not-a-real-session/close")
+    assert resp.status_code == 404
+
+
+def test_close_twice_404_on_second(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    assert client.post(f"/sessions/{session_id}/close").status_code == 200
+    assert client.post(f"/sessions/{session_id}/close").status_code == 404
+
+
+def test_audit_export_serves_closed_session(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    client.post(f"/sessions/{session_id}/close")
+
+    resp = client.get(f"/audit/export?session_id={session_id}")
+    assert resp.status_code == 200
+    bundle = resp.json()
+    assert bundle["session_id"] == session_id
+    entry_types = [e["entry_type"] for e in bundle["entries"]]
+    assert "session_start" in entry_types
+    assert "session_end" in entry_types


### PR DESCRIPTION
## Summary

Final piece of the demo-critical call path (#277): TRACE Claims are generated only on session close, but no endpoint could close a session, and clients never learned their session id -- so a running gateway could never produce a retrievable TRACE Claim.

- **`POST /sessions/{session_id}/close`** -- appends the `session_end` audit entry, signs and returns the `RuntimeClaim`, then rotates the gateway onto a fresh session (`SessionManager.create_session()` + new `CMCPProxy.rebind_session()`). Closed chains are retained so `GET /sessions/{id}/trace-claim` and `GET /audit/export?session_id=` keep serving closed sessions.
- **`_cmcp.session_id`** in every tools/call response so clients can address the session endpoints.

Demo flow this enables: N tool calls -> read `_cmcp.session_id` -> `POST /sessions/{id}/close` -> signed TRACE Claim in the response.

## Test plan

- [x] 5 new tests: claim issuance + rotation, claim retrievable after close, 404 on unknown/double close, audit export of closed session (session_start + session_end present)
- [x] Full suite: 666 passed, 1 skipped

Stacked on #280.

Generated with [Claude Code](https://claude.ai/code)