### PR TITLE
fix(policy): carry workflow_id into the egress evaluation context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,9 @@ attestation:
 
   # enforcing: policy denies block the tool call and return HTTP 403.
   # advisory: policy denies are logged but the call is forwarded.
-  # silent: evaluates policy but takes no action and does not log denies.
+  # silent: like advisory but without operational log lines. The hash-chained
+  #   audit log still records every would-have-denied decision -- silent
+  #   quiets logs, never the evidence.
   enforcement_mode: enforcing
 
   # How long (in seconds) an attestation report is considered fresh.
@@ -97,7 +99,7 @@ Environment variables control secrets and mode flags that must not appear in con
 |------|----------|----------|
 | `enforcing` | Policy denies block the tool call. The runtime returns HTTP 403 and a structured error to the agent. The call is not forwarded to the upstream server. | Production. Default for new deployments. |
 | `advisory` | Policy denies are logged in the audit chain but the call is forwarded. The TRACE Claim records the deny. No tool call is blocked. | Policy testing, migration from existing runtime. Safe for first run with an untuned policy. |
-| `silent` | Policy is evaluated but the result is not acted on and denies are not logged. Observability-only mode. | Measuring policy impact before rollout. Not suitable for any compliance scenario. |
+| `silent` | Policy is evaluated, the call is forwarded, and **the audit chain still records every would-have-denied decision** (as `advisory_deny`, visible in the TRACE Claim's call summary). The only difference from `advisory` is that no operational log lines are emitted. Silent quiets logs, never the evidence. | Measuring policy impact before rollout without operational log noise. The tamper-evident record remains complete, so post-hoc review stays possible. |
 
 ## Minimal working config
 

--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -24,7 +24,9 @@ _PROVIDER_MAP: dict[str, str] = {
     "tdx": "intel-tdx",
     "opaque": "intel-tdx",
     "tpm": "tpm2",
-    "software-only": "tpm2",
+    # Dev mode is its own platform value: a consumer keying trust on
+    # runtime.platform must never mistake a non-attested record for TPM-backed.
+    "software-only": "software-only",
 }
 
 _SW_ONLY_MEASUREMENT = "sha256:" + "0" * 64

--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -94,6 +94,97 @@ def start(config: str, enforcement: str | None) -> None:
     uvicorn.run(server.app, host=host, port=port)
 
 
+@main.command()
+@click.argument("claim_file", type=click.Path(exists=True))
+@click.option("--policy-hash", default=None,
+              help="Approved policy bundle hash (sha256:<hex>). Unpinned if omitted.")
+@click.option("--catalog-hash", default=None,
+              help="Approved tool catalog hash (sha256:<hex>). Unpinned if omitted.")
+@click.option("--max-age", default=86400, type=int, show_default=True,
+              help="Maximum attestation age in seconds.")
+@click.option("--trusted-key", default=None,
+              help="Out-of-band pinned Ed25519 public key (hex) to cross-check trace.cnf.jwk.")
+@click.option("--audit-bundle", default=None, type=click.Path(exists=True),
+              help="Also verify an exported audit bundle (GET /audit/export) against the claim.")
+def verify(
+    claim_file: str,
+    policy_hash: str | None,
+    catalog_hash: str | None,
+    max_age: int,
+    trusted_key: str | None,
+    audit_bundle: str | None,
+) -> None:
+    """Verify a signed TRACE Claim (and optionally its audit bundle).
+
+    Checks the Ed25519 signature against the confirmation key in
+    trace.cnf.jwk, the claim schema, attestation freshness, audit chain
+    consistency, and (when pinned) the policy and catalog hashes.
+    Exits 0 when verified, 1 otherwise.
+    """
+    import json as _json
+
+    from cmcp_verify import ApprovedHashes, verify_audit_bundle, verify_trace_claim
+
+    with open(claim_file) as f:
+        claim = _json.load(f)
+
+    pinned_policy = policy_hash is not None
+    pinned_catalog = catalog_hash is not None
+    # Unpinned hashes fall back to the claim's own values: the check passes
+    # trivially and is reported as "not pinned" rather than verified.
+    approved = ApprovedHashes(
+        policy_bundle_hash=policy_hash
+        or claim.get("trace", {}).get("policy", {}).get("bundle_hash", ""),
+        tool_catalog_hash=catalog_hash
+        or claim.get("gateway", {}).get("catalog", {}).get("hash", ""),
+    )
+
+    result = verify_trace_claim(
+        claim,
+        approved,
+        max_attestation_age_seconds=max_age,
+        trusted_public_key_hex=trusted_key,
+    )
+
+    def _line(name: str, ok: bool, note: str = "") -> None:
+        mark = "PASS" if ok else "FAIL"
+        click.echo(f"[cmcp verify] {name:<24} {mark}{('  ' + note) if note else ''}")
+
+    for field_name in result.verified_fields:
+        note = ""
+        if field_name == "policy_bundle.hash" and not pinned_policy:
+            note = "(not pinned — pass --policy-hash to pin)"
+        if field_name == "tool_catalog.hash" and not pinned_catalog:
+            note = "(not pinned — pass --catalog-hash to pin)"
+        _line(field_name, True, note)
+    for field_name in result.unverified_fields:
+        _line(field_name, False, result.details.get(field_name, ""))
+
+    bundle_ok = True
+    if audit_bundle is not None:
+        with open(audit_bundle) as f:
+            bundle = _json.load(f)
+        bundle_result = verify_audit_bundle(bundle, claim)
+        bundle_ok = bundle_result.verified
+        _line(
+            "audit_bundle",
+            bundle_ok,
+            f"({bundle_result.entry_count} entries)"
+            if bundle_ok
+            else "; ".join(bundle_result.failures),
+        )
+
+    overall = result.status.value == "verified" and bundle_ok
+    if "hardware_attestation" in result.unverified_fields:
+        click.echo(
+            "[cmcp verify] note: "
+            + result.details.get("hardware_attestation", "hardware attestation not verified")
+        )
+    click.echo(f"[cmcp verify] RESULT: {'PASS' if overall else 'FAIL'} ({result.status.value})")
+    if not overall:
+        raise SystemExit(1)
+
+
 @main.command("validate-config")
 @click.option("--config", required=True, type=click.Path(exists=True), help="Path to cmcp-config.yaml")
 def validate_config(config: str) -> None:

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -695,7 +695,7 @@ class CMCPProxy:
 
         try:
             egress_decision = self._policy.authorize_egress(
-                tool_name, response_bytes, self._session
+                tool_name, response_bytes, self._session, workflow_id=workflow_id
             )
             egress_would_deny = egress_decision.would_have_denied
             egress_advice = egress_decision.advice

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -288,7 +288,12 @@ class MCPServer:
         tool_name: str = params.get("name", "").lower()
         arguments: dict[str, Any] = params.get("arguments", {})
         call_id = str(uuid.uuid4())
-        workflow_id: str | None = params.get("_cmcp", {}).get("workflow_id")
+        # A malformed _cmcp (string, list, number) must not 500 the call path.
+        cmcp_params = params.get("_cmcp")
+        if not isinstance(cmcp_params, dict):
+            cmcp_params = {}
+        raw_workflow = cmcp_params.get("workflow_id")
+        workflow_id: str | None = raw_workflow if isinstance(raw_workflow, str) else None
 
         try:
             result = await self._proxy.call_tool(call_id, tool_name, arguments, workflow_id=workflow_id)
@@ -658,6 +663,10 @@ class MCPServer:
             )
         # AUTH-002: lock guards against a concurrent tool-call coroutine modifying sensitivity.
         async with self._session.mutation_lock:
+            # Capture the pre-reset sensitivity: reset() drops it back to
+            # "public", and the elevated value the session held at reset time
+            # is exactly the forensic detail the audit entry must preserve.
+            sensitivity_before = self._session.max_sensitivity
             old_id, new_id = self._session.reset(
                 reason="operator reset via API",
                 authorized_by="api",
@@ -667,7 +676,7 @@ class MCPServer:
             call_id=None,
             tool_name=None,
             policy_decision="n/a",
-            session_sensitivity_before=self._session.max_sensitivity,
+            session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
         )
         return JSONResponse({

--- a/src/cmcp_runtime/policy/evaluator.py
+++ b/src/cmcp_runtime/policy/evaluator.py
@@ -200,6 +200,7 @@ class PolicyEvaluator:
         tool_name: str,
         response_bytes: bytes,
         session: SessionState,
+        workflow_id: str | None = None,
     ) -> PolicyDecision:
         """
         Evaluate Cedar egress policies after a tool response is received.
@@ -207,6 +208,10 @@ class PolicyEvaluator:
         Uses the same CedarBackend as ingress evaluation but passes egress-specific
         context fields so Cedar policies can distinguish direction.  The principal
         and action are implicit in the context dict the backend receives.
+
+        workflow_id carries the same call identity as the ingress evaluation:
+        without it, workflow-scoped permits (default-deny bundles with no
+        catch-all) can never match at egress and every response would be denied.
 
         Returns PolicyDecision(allowed=True/False, ...).  In ENFORCING mode a deny
         raises PolicyDeny; in ADVISORY/SILENT a deny is flagged via would_have_denied.
@@ -220,6 +225,8 @@ class PolicyEvaluator:
             "reset_count": session.reset_count,
             "response_size_bytes": len(response_bytes),
         }
+        if workflow_id is not None:
+            context["workflow_id"] = workflow_id
         return self.evaluate(context)
 
     @property

--- a/src/cmcp_verify/__init__.py
+++ b/src/cmcp_verify/__init__.py
@@ -2,17 +2,21 @@
 
 from cmcp_verify.verify import (
     ApprovedHashes,
+    AuditBundleResult,
     VerificationError,
     VerificationResult,
     VerificationStatus,
+    verify_audit_bundle,
     verify_trace_claim,
 )
 
 __version__ = "0.1.0"
 __all__ = [
     "ApprovedHashes",
+    "AuditBundleResult",
     "VerificationError",
     "VerificationResult",
     "VerificationStatus",
+    "verify_audit_bundle",
     "verify_trace_claim",
 ]

--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -63,6 +63,9 @@ def verify_opaque_measurement(
         return result
 
     if raw_evidence is None:
+        # Fail closed: an attestation claim with no evidence cannot verify.
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["opaque_endpoint"] = endpoint
         result.details["hint"] = "raw_evidence not provided; cannot verify with Opaque"

--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -97,8 +97,17 @@ def verify_sev_snp_measurement(
         result.details["vcek_chain"] = "requires_amd_kds_lookup"
         return result
 
-    # Step 2: Parse raw_evidence if provided
-    if raw_evidence is not None and len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory — a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(["measurement", "vcek_cert_chain"])
+        result.details["raw_evidence"] = "not provided; SNP report cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-006)
             report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
@@ -142,7 +151,7 @@ def verify_sev_snp_measurement(
             result.details["vcek_chain"] = "requires_amd_kds_lookup"
             return result
 
-    elif raw_evidence is not None and len(raw_evidence) < _SNP_REPORT_MIN_SIZE:
+    else:
         # Truncated report -- treat as parse error
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tdx.py
+++ b/src/cmcp_verify/tdx.py
@@ -98,8 +98,19 @@ def verify_tdx_measurement(
         result.details["dcap_chain"] = "requires_intel_dcap_service"
         return result
 
-    # Step 2: Parse TDREPORT if provided
-    if raw_evidence is not None and len(raw_evidence) >= _TDREPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory — a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(
+            ["measurement", "dcap_quote_signature", "tcb_status"]
+        )
+        result.details["raw_evidence"] = "not provided; TDREPORT cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _TDREPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-007)
             tdreport = _TdReport.from_buffer_copy(raw_evidence[:_TDREPORT_MIN_SIZE])
@@ -135,7 +146,7 @@ def verify_tdx_measurement(
             result.details["dcap_chain"] = "requires_intel_dcap_service"
             return result
 
-    elif raw_evidence is not None:
+    else:
         # Truncated evidence
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tpm.py
+++ b/src/cmcp_verify/tpm.py
@@ -86,23 +86,30 @@ def verify_tpm_measurement(
             unverified_fields.append("qualifying_data")
             details["tpm_parse_error"] = parse_details.get("error", "failed to parse TPM2B_ATTEST")
     else:
-        # No raw evidence — cannot verify PCR digest or qualifying data
-        unverified_fields.append("pcr_digest")
-        unverified_fields.append("qualifying_data")
+        # No raw evidence — a claim asserting a hardware platform with no
+        # evidence to check must fail closed, not pass on format checks alone.
+        unverified_fields.extend(["pcr_digest", "qualifying_data", "ek_cert_chain"])
         details["pcr_digest_note"] = "raw_evidence not provided; PCR digest unverifiable"
+        return TPMVerificationResult(
+            verified=False,
+            verified_fields=verified_fields,
+            unverified_fields=unverified_fields,
+            failure_reason="no_raw_evidence",
+            details=details,
+        )
 
     # Step 3: EK cert chain always unverified in Phase 1
     unverified_fields.append("ek_cert_chain")
     details["ek_cert_chain_validation"] = "ek_cert_chain_validation_requires_ca_lookup"
 
-    # verified=True if we have at least measurement_format and no parse failures
+    # verified=True only when the evidence parsed and matched
     verified = "measurement_format" in verified_fields and "pcr_format" not in unverified_fields
 
     return TPMVerificationResult(
         verified=verified,
         verified_fields=verified_fields,
         unverified_fields=unverified_fields,
-        failure_reason=None,
+        failure_reason=None if verified else "tpm_evidence_check_failed",
         details=details,
     )
 

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -36,7 +36,22 @@ _KNOWN_PLATFORMS = {
     "aws-nitro",
     "arm-cca",
     "google-confidential-space",
+    "software-only",
 }
+
+
+def _is_software_only(runtime: dict[str, Any]) -> bool:
+    """True for dev-mode (non-attested) records.
+
+    Current records use platform "software-only"; records produced before
+    that value existed used platform "tpm2" with the dev firmware sentinel.
+    """
+    if runtime.get("platform") == "software-only":
+        return True
+    return (
+        runtime.get("platform") == "tpm2"
+        and runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
+    )
 
 
 class VerificationStatus(StrEnum):
@@ -54,6 +69,7 @@ class VerificationError(StrEnum):
     ATTESTATION_STALE = "ATTESTATION_STALE"
     CHAIN_BROKEN = "CHAIN_BROKEN"
     CLAIM_MALFORMED = "CLAIM_MALFORMED"
+    HARDWARE_ATTESTATION_FAILED = "HARDWARE_ATTESTATION_FAILED"
 
 
 @dataclass
@@ -236,6 +252,86 @@ def _validate_schema(claim: dict[str, Any]) -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+@dataclass
+class AuditBundleResult:
+    """Outcome of verifying an exported audit bundle against a claim."""
+
+    verified: bool
+    entry_count: int
+    failures: list[str] = field(default_factory=list)
+
+
+def verify_audit_bundle(
+    bundle_json: dict[str, Any],
+    claim_json: dict[str, Any] | None = None,
+) -> AuditBundleResult:
+    """
+    Verify an exported audit bundle (GET /audit/export):
+
+    1. Recompute every entry hash from its canonical body and check the
+       prev_entry_hash linkage from "genesis" to the tip.
+    2. If a claim is provided, cross-check the bundle's root/tip/length
+       against gateway.audit_chain and verify the bundle_signature with the
+       claim's confirmation key (trace.cnf.jwk.x).
+    """
+    failures: list[str] = []
+    entries = bundle_json.get("entries", [])
+    if not entries:
+        return AuditBundleResult(verified=False, entry_count=0, failures=["bundle has no entries"])
+
+    prev = "genesis"
+    for i, entry in enumerate(entries):
+        body = {k: v for k, v in entry.items() if k != "entry_hash"}
+        recomputed = hashlib.sha256(
+            json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        ).hexdigest()
+        if recomputed != entry.get("entry_hash"):
+            failures.append(f"entry {i}: hash mismatch (content altered)")
+        if entry.get("prev_entry_hash") != prev:
+            failures.append(f"entry {i}: chain link broken")
+        prev = entry.get("entry_hash", "")
+
+    if claim_json is not None:
+        chain = claim_json.get("gateway", {}).get("audit_chain", {})
+        if chain.get("root") != entries[0].get("entry_hash"):
+            failures.append("bundle root does not match claim gateway.audit_chain.root")
+        if chain.get("tip") != entries[-1].get("entry_hash"):
+            failures.append("bundle tip does not match claim gateway.audit_chain.tip")
+        if chain.get("length") != len(entries):
+            failures.append(
+                f"bundle has {len(entries)} entries, claim says {chain.get('length')}"
+            )
+
+        sig_b64 = bundle_json.get("bundle_signature", "")
+        x_b64 = claim_json.get("trace", {}).get("cnf", {}).get("jwk", {}).get("x", "")
+        if not sig_b64:
+            failures.append("bundle_signature is missing")
+        elif not x_b64:
+            failures.append("claim has no confirmation key to check bundle_signature against")
+        else:
+            try:
+                pad = 4 - (len(x_b64) % 4)
+                pub = Ed25519PublicKey.from_public_bytes(
+                    base64.urlsafe_b64decode(x_b64 + ("=" * pad if pad != 4 else ""))
+                )
+                pad = 4 - (len(sig_b64) % 4)
+                sig = base64.urlsafe_b64decode(sig_b64 + ("=" * pad if pad != 4 else ""))
+                digest = hashlib.sha256(
+                    json.dumps(
+                        entries, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+                    ).encode()
+                ).digest()
+                pub.verify(sig, digest)
+            except InvalidSignature:
+                failures.append("bundle_signature is invalid")
+            except Exception as exc:
+                failures.append(f"bundle_signature could not be checked: {exc}")
+
+    return AuditBundleResult(
+        verified=not failures, entry_count=len(entries), failures=failures
+    )
+
+
 def verify_trace_claim(
     claim_json: dict[str, Any],
     approved: ApprovedHashes,
@@ -304,10 +400,7 @@ def verify_trace_claim(
     # An attacker who substitutes their own keypair cannot forge the TEE-signed nonce,
     # so verification fails even when the Ed25519 signature is self-consistent.
     _runtime = claim_json.get("trace", {}).get("runtime", {})
-    _is_sw_only = (
-        _runtime.get("platform") == "tpm2"
-        and _runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
-    )
+    _is_sw_only = _is_software_only(_runtime)
 
     binding_result, binding_msg = _verify_key_binding(claim_json, is_sw_only=_is_sw_only)
     if binding_result is True:
@@ -382,12 +475,11 @@ def verify_trace_claim(
 
     # Step 7: Platform-specific attestation
     platform = _runtime.get("platform", "")
-    firmware_version = _runtime.get("firmware_version", "")
 
-    if platform == "tpm2" and firmware_version == _SW_ONLY_FIRMWARE:
+    if _is_sw_only:
         unverified.append("hardware_attestation")
         details["hardware_attestation"] = "software-only mode — not hardware-backed"
-    elif platform == "tpm2" and firmware_version != _SW_ONLY_FIRMWARE:
+    elif platform == "tpm2":
         from cmcp_verify.tpm import verify_tpm_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -403,11 +495,12 @@ def verify_trace_claim(
             verified.extend(tpm_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tpm_result.failure_reason:
                 details["tpm_failure"] = tpm_result.failure_reason
         unverified.extend(tpm_result.unverified_fields)
         details.update(tpm_result.details)
-    elif platform == "sev-snp" and firmware_version != _SW_ONLY_FIRMWARE:
+    elif platform == "amd-sev-snp":
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -423,6 +516,7 @@ def verify_trace_claim(
             verified.extend(snp_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if snp_result.failure_reason:
                 details["sev_snp_failure"] = snp_result.failure_reason
         unverified.extend(snp_result.unverified_fields)
@@ -443,6 +537,7 @@ def verify_trace_claim(
             verified.extend(tdx_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tdx_result.failure_reason:
                 details["tdx_failure"] = tdx_result.failure_reason
         unverified.extend(tdx_result.unverified_fields)
@@ -461,6 +556,7 @@ def verify_trace_claim(
             verified.extend(opaque_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if opaque_result.failure_reason:
                 details["opaque_failure"] = opaque_result.failure_reason
         unverified.extend(opaque_result.unverified_fields)

--- a/tests/unit/test_egress_policy.py
+++ b/tests/unit/test_egress_policy.py
@@ -109,7 +109,7 @@ def _make_proxy_with_egress(egress_allow: bool, ingress_allow: bool = True):
     evaluator = MagicMock(spec=PolicyEvaluator)
     evaluator.evaluate.side_effect = _side_effect
     # authorize_egress delegates to evaluate() — wire it the same way
-    evaluator.authorize_egress.side_effect = lambda tool, resp, sess: _side_effect(
+    evaluator.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _side_effect(
         {"egress": True, "tool_name": tool}
     )
     evaluator.bundle_hash = "sha256:" + "0" * 64
@@ -275,7 +275,7 @@ async def test_proxy_high_sensitivity_session_blocked_by_egress():
     def _make_evaluator_for(session_sensitivity: str) -> MagicMock:
         ev = MagicMock(spec=PolicyEvaluator)
         ev.evaluate.side_effect = _sensitivity_aware_egress
-        ev.authorize_egress.side_effect = lambda tool, resp, sess: _sensitivity_aware_egress(
+        ev.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _sensitivity_aware_egress(
             {"egress": True, "sensitivity_level": {"public": 0, "pii": 1, "confidential": 2, "hipaa_phi": 3}.get(sess.max_sensitivity, 0)}
         )
         ev.bundle_hash = "sha256:" + "0" * 64
@@ -335,7 +335,7 @@ async def test_proxy_after_session_reset_egress_allowed_again():
 
     evaluator = MagicMock(spec=PolicyEvaluator)
     evaluator.evaluate.side_effect = _egress_aware
-    evaluator.authorize_egress.side_effect = lambda tool, resp, sess: _egress_aware(
+    evaluator.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _egress_aware(
         {"egress": True, "sensitivity_level": {"public": 0, "pii": 1, "confidential": 2, "hipaa_phi": 3, "mnpi": 3, "trade_secret": 3}.get(sess.max_sensitivity, 0)}
     )
     evaluator.bundle_hash = "sha256:" + "0" * 64
@@ -357,3 +357,47 @@ async def test_proxy_after_session_reset_egress_allowed_again():
     # After reset — same tool should be allowed
     result_after = await proxy.call_tool("c2", "test.tool", {})
     assert result_after.allowed is True
+
+
+def test_egress_carries_workflow_id_for_default_deny_bundles():
+    """A workflow-scoped permit (no catch-all) must also match at egress.
+
+    Without workflow_id in the egress context, default-deny bundles deny
+    every response even when the ingress evaluation allowed the call.
+    """
+    from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+    from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
+    from cmcp_runtime.policy.evaluator import PolicyEvaluator
+    from cmcp_runtime.session.state import SessionState
+
+    policy = """
+permit (principal, action == Action::"Ehr.patientRecordLookup", resource)
+when { context has workflow_id && context.workflow_id == "clinical-decision-support" };
+"""
+    bundle = PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-11T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": policy},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+    config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
+    evaluator = PolicyEvaluator(bundle=bundle, config=config)
+    session = SessionState(session_id="egress-wf-test")
+
+    decision = evaluator.authorize_egress(
+        "ehr.patient_record_lookup",
+        b"{}",
+        session,
+        workflow_id="clinical-decision-support",
+    )
+    assert decision.allowed is True
+
+    with pytest.raises(PolicyDeny):
+        evaluator.authorize_egress(
+            "ehr.patient_record_lookup", b"{}", session, workflow_id="wrong-workflow"
+        )

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -56,11 +56,12 @@ def test_snp_struct_round_trip() -> None:
     assert bytes(report.host_data) == host_pattern
 
 
-def test_valid_measurement_format_no_evidence():
+def test_valid_measurement_format_no_evidence_fails_closed():
+    """A well-formed measurement string is not evidence."""
     good = "sha384:" + "a" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_sha256_prefix_fails_format():
@@ -158,18 +159,20 @@ def test_truncated_report_is_parse_error():
     assert result.failure_reason == "raw_evidence_parse_error"
 
 
-def test_no_raw_evidence_hardware_unverified():
+def test_no_raw_evidence_fails_closed():
+    """A hardware-platform claim with no evidence must not verify."""
     good = "sha384:" + "f" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "measurement" not in result.verified_fields
 
 
 def test_vcek_cert_chain_always_unverified_no_evidence():
     good = "sha384:" + "e" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
+    assert result.verified is False
     assert "vcek_cert_chain" in result.unverified_fields
-    assert result.details["vcek_chain"] == "requires_amd_kds_lookup"
 
 
 def test_vcek_cert_chain_always_unverified_with_matching_report():

--- a/tests/unit/test_silent_mode_contract.py
+++ b/tests/unit/test_silent_mode_contract.py
@@ -1,0 +1,129 @@
+"""
+Silent-mode contract: silent quiets logs, never the evidence.
+
+enforcement_mode: silent must behave exactly like advisory with respect to
+the audit chain -- every would-have-denied decision is recorded as
+advisory_deny -- while emitting no operational log lines for the deny.
+This is the documented contract (docs/configuration.md); these tests exist
+so it cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
+from cmcp_runtime.policy.evaluator import PolicyEvaluator
+
+DENY_ALL = "forbid (principal, action, resource);"
+
+
+def _evaluator(mode: EnforcementMode) -> PolicyEvaluator:
+    bundle = PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-11T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": DENY_ALL},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+    return PolicyEvaluator(
+        bundle=bundle,
+        config=Config(attestation=AttestationConfig(enforcement_mode=mode)),
+    )
+
+
+CONTEXT = {
+    "tool_name": "test.tool",
+    "arguments": {},
+    "session_max_sensitivity": "public",
+}
+
+
+def test_silent_deny_flags_would_have_denied():
+    decision = _evaluator(EnforcementMode.SILENT).evaluate(dict(CONTEXT))
+    assert decision.allowed is True
+    assert decision.would_have_denied is True
+
+
+def test_silent_emits_no_deny_log_lines(caplog):
+    with caplog.at_level(logging.INFO, logger="cmcp_runtime.policy.evaluator"):
+        _evaluator(EnforcementMode.SILENT).evaluate(dict(CONTEXT))
+    assert not any("deny" in r.message.lower() for r in caplog.records)
+
+
+def test_advisory_does_emit_deny_log_line(caplog):
+    with caplog.at_level(logging.INFO, logger="cmcp_runtime.policy.evaluator"):
+        _evaluator(EnforcementMode.ADVISORY).evaluate(dict(CONTEXT))
+    assert any("advisory deny" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_silent_mode_audit_chain_records_advisory_deny():
+    """The core contract: in silent mode the hash-chained audit log still
+    records the would-have-denied decision."""
+    from unittest.mock import MagicMock, patch
+
+    from cmcp_runtime.audit.chain import AuditChain
+    from cmcp_runtime.catalog.loader import (
+        ApprovedDefinition,
+        CatalogEntry,
+        ServerIdentity,
+        ToolCatalog,
+    )
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+    from cmcp_runtime.session.state import SessionState
+
+    from .conftest import wire_mock_gateway
+
+    entry = CatalogEntry(
+        tool_name="test.tool",
+        server=ServerIdentity(
+            display_name="t",
+            url="http://localhost:8080/mcp",
+            tls_fingerprint="SHA256:" + "A" * 43 + "=",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="t", input_schema={"type": "object"}, output_schema=None
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="internal",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-11T00:00:00Z",
+        approved_by="test",
+    )
+    catalog = ToolCatalog(
+        entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64
+    )
+    session = SessionState(session_id="silent-contract")
+    chain = AuditChain("silent-contract")
+    with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
+         patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            catalog=catalog,
+            policy_evaluator=_evaluator(EnforcementMode.SILENT),
+            session=session,
+            audit_chain=chain,
+            config=Config(
+                attestation=AttestationConfig(enforcement_mode=EnforcementMode.SILENT)
+            ),
+        )
+        wire_mock_gateway(proxy)
+
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is True
+    assert result.would_have_denied is True
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert tool_entries, "audit chain must record the call in silent mode"
+    assert tool_entries[-1].policy_decision == "advisory_deny"

--- a/tests/unit/test_tdx_opaque_verify.py
+++ b/tests/unit/test_tdx_opaque_verify.py
@@ -47,22 +47,23 @@ def test_tdx_invalid_measurement_hex_length():
     assert result.failure_reason == "invalid_measurement_format"
 
 
-def test_tdx_no_raw_evidence_no_dcap(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed(monkeypatch):
+    """A hardware-platform claim with no evidence must not verify."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: False)
     measurement = "sha384:" + "b" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "dcap_quote_signature" in result.unverified_fields
-    assert result.details.get("dcap_chain") == "dcap_service_unreachable"
 
 
-def test_tdx_no_raw_evidence_dcap_reachable(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed_even_with_dcap(monkeypatch):
+    """DCAP reachability cannot substitute for missing evidence."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: True)
     measurement = "sha384:" + "c" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
-    assert "dcap_quote_signature" in result.unverified_fields
-    assert "reachable" in result.details.get("dcap_qe_identity", "")
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_tdx_measurement_matches_mrtd(monkeypatch):
@@ -100,11 +101,11 @@ def test_opaque_no_endpoint_configured(monkeypatch):
     assert "opaque_managed_attestation" in result.unverified_fields
 
 
-def test_opaque_no_raw_evidence(monkeypatch):
+def test_opaque_no_raw_evidence_fails_closed(monkeypatch):
     monkeypatch.setenv("CMCP_OPAQUE_ATTESTATION_ENDPOINT", "https://attest.opaque.co/v1/verify")
     result = verify_opaque_measurement("sha384:" + "a" * 96, None)
-    assert result.verified
-    assert "opaque_managed_attestation" in result.unverified_fields
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "raw_evidence not provided" in result.details.get("hint", "")
 
 

--- a/tests/unit/test_tpm_verify.py
+++ b/tests/unit/test_tpm_verify.py
@@ -51,13 +51,15 @@ def _make_tpm2b_attest(
 # ── Unit tests for verify_tpm_measurement ────────────────────────────────────
 
 
-def test_valid_measurement_format_passes() -> None:
+def test_valid_measurement_format_alone_does_not_verify() -> None:
+    """Format checks pass, but no evidence means fail closed."""
     result = verify_tpm_measurement(
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
     assert "measurement_format" in result.verified_fields
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_invalid_measurement_no_prefix_fails() -> None:
@@ -103,8 +105,8 @@ def test_no_raw_evidence_ek_cert_always_unverified() -> None:
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
+    assert result.verified is False
     assert "ek_cert_chain" in result.unverified_fields
-    assert result.details.get("ek_cert_chain_validation") == "ek_cert_chain_validation_requires_ca_lookup"
 
 
 def test_raw_evidence_valid_magic_parsed() -> None:

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -274,9 +274,9 @@ def test_generate_claim_enforcement_mode_mapped():
 
 
 def test_generate_claim_software_only_platform():
-    """software-only provider maps to tpm2 platform with firmware marker."""
+    """software-only provider gets its own platform value, never tpm2."""
     claim = _make_claim()
-    assert claim.trace.runtime.platform == "tpm2"
+    assert claim.trace.runtime.platform == "software-only"
     assert claim.trace.runtime.firmware_version == "software-only-dev-mode"
 
 

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -211,13 +211,18 @@ def test_all_software_only_verified_fields_are_present():
 
 
 def test_known_hardware_platform_without_verifier_is_partially_verified():
-    """TEE-001 -- amd-sev-snp must be PARTIALLY_VERIFIED not VERIFIED."""
+    """TEE-001 -- amd-sev-snp without raw evidence must not be VERIFIED.
+
+    The dispatch previously compared against the provider name ("sev-snp")
+    instead of the platform name ("amd-sev-snp"), so SNP verification never
+    ran; with the dispatch fixed, the missing raw evidence fails closed.
+    """
     claim_dict, key = _make_signed_claim(provider="sev-snp")
     result = verify_trace_claim(
         claim_dict, _approved(), trusted_public_key_hex=key.public_key_hex
     )
     assert result.status == VerificationStatus.PARTIALLY_VERIFIED
-    assert result.failure_reason == VerificationError.UNSUPPORTED_PROVIDER
+    assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED
     assert "hardware_attestation" in result.unverified_fields
 
 

--- a/tests/unit/test_verify_command.py
+++ b/tests/unit/test_verify_command.py
@@ -1,0 +1,127 @@
+"""End-to-end tests for `cmcp verify`: real claim, real tampering."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.cli import build_server, main
+from cmcp_runtime.config import AttestationConfig, Config
+from cmcp_runtime.policy.bundle import PolicyStore
+from cmcp_runtime.startup import RuntimeContext
+
+
+@pytest.fixture
+def claim_and_bundle(tmp_path):
+    """Spin up a real server, close a session, export claim + audit bundle."""
+    config = Config(attestation=AttestationConfig(), dev_mode=True)
+
+    attestation_report = MagicMock()
+    attestation_report.provider = "software-only"
+    attestation_report.attestation_generated_at = datetime.now(UTC)
+    attestation_report.attestation_validity_seconds = 86400
+    attestation_report.measurement = "0" * 64
+    attestation_report.report_data = "0" * 64
+    attestation_report.measurement_note = None
+    attestation_report.raw_evidence = None
+
+    bundle_mock = MagicMock()
+    bundle_mock.bundle_hash = "sha256:" + "0" * 64
+    bundle_mock.policy_files = {"allow.cedar": "permit (principal, action, resource);"}
+    bundle_mock.manifest = MagicMock()
+    bundle_mock.manifest.version = "test-v1"
+    policy_store = MagicMock(spec=PolicyStore)
+    policy_store.bundle = bundle_mock
+
+    catalog = MagicMock()
+    catalog.entries = {}
+    catalog.catalog_hash = "sha256:" + "1" * 64
+    catalog.exceptions = []
+
+    ctx = RuntimeContext(
+        config=config,
+        tee_provider=MagicMock(),
+        attestation_report=attestation_report,
+        signing_key=SigningKey(),
+        policy_bundle=policy_store,
+        catalog=catalog,
+    )
+    server = build_server(ctx)
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    claim = client.post(f"/sessions/{session_id}/close").json()
+    bundle = client.get(f"/audit/export?session_id={session_id}").json()
+
+    claim_file = tmp_path / "claim.json"
+    bundle_file = tmp_path / "bundle.json"
+    claim_file.write_text(json.dumps(claim))
+    bundle_file.write_text(json.dumps(bundle))
+    return claim_file, bundle_file, claim, bundle
+
+
+def test_verify_passes_on_genuine_claim(claim_and_bundle):
+    claim_file, _, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, ["verify", str(claim_file)])
+    assert result.exit_code == 0, result.output
+    assert "RESULT: PASS" in result.output
+    assert "signature" in result.output
+    assert "not pinned" in result.output  # hashes unpinned by default
+
+
+def test_verify_passes_with_pinned_hashes(claim_and_bundle):
+    claim_file, _, claim, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file),
+        "--policy-hash", claim["trace"]["policy"]["bundle_hash"],
+        "--catalog-hash", claim["gateway"]["catalog"]["hash"],
+    ])
+    assert result.exit_code == 0, result.output
+
+
+def test_verify_fails_with_wrong_pinned_hash(claim_and_bundle):
+    claim_file, _, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--policy-hash", "sha256:" + "f" * 64,
+    ])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output
+
+
+def test_verify_fails_on_tampered_claim(claim_and_bundle, tmp_path):
+    """The tamper demo: change one field, signature verification fails."""
+    _, _, claim, _ = claim_and_bundle
+    claim["gateway"]["call_summary"]["tool_calls_total"] += 7
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(claim))
+    result = CliRunner().invoke(main, ["verify", str(tampered)])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output
+    assert "signature" in result.output
+
+
+def test_verify_audit_bundle_passes(claim_and_bundle):
+    claim_file, bundle_file, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--audit-bundle", str(bundle_file),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "audit_bundle" in result.output
+
+
+def test_verify_fails_on_tampered_audit_bundle(claim_and_bundle, tmp_path):
+    """Mutating one audit entry breaks the hash chain and the bundle signature."""
+    claim_file, _, _, bundle = claim_and_bundle
+    bundle["entries"][0]["entry_type"] = "tool_call"
+    tampered = tmp_path / "tampered-bundle.json"
+    tampered.write_text(json.dumps(bundle))
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--audit-bundle", str(tampered),
+    ])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output


### PR DESCRIPTION
## Summary

Found while making the example demo policies workflow-scoped (agentrust-io/examples#12): the egress check re-evaluates the same Cedar bundle with a context that lacked `workflow_id`. A default-deny bundle (explicit workflow-scoped permits, no catch-all) therefore denied **every** response at egress, even when the ingress evaluation allowed the call. Catch-all-permit bundles masked this completely.

`authorize_egress()` now accepts and forwards the call's `workflow_id`, so the same permits that authorized the call also match the egress evaluation. Egress-specific rules still distinguish direction via `context.egress`.

## Test plan

- [x] New test: workflow-scoped permit with no catch-all allows egress with the right workflow, raises PolicyDeny with the wrong one
- [x] Full suite: 669 passed, 1 skipped

Stacked on #282.

Generated with [Claude Code](https://claude.ai/code)