### PR TITLE
fix(verify): dev-mode platform honesty + fail-closed hardware verification

### DIFF
--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -24,7 +24,9 @@ _PROVIDER_MAP: dict[str, str] = {
     "tdx": "intel-tdx",
     "opaque": "intel-tdx",
     "tpm": "tpm2",
-    "software-only": "tpm2",
+    # Dev mode is its own platform value: a consumer keying trust on
+    # runtime.platform must never mistake a non-attested record for TPM-backed.
+    "software-only": "software-only",
 }
 
 _SW_ONLY_MEASUREMENT = "sha256:" + "0" * 64

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -288,7 +288,12 @@ class MCPServer:
         tool_name: str = params.get("name", "").lower()
         arguments: dict[str, Any] = params.get("arguments", {})
         call_id = str(uuid.uuid4())
-        workflow_id: str | None = params.get("_cmcp", {}).get("workflow_id")
+        # A malformed _cmcp (string, list, number) must not 500 the call path.
+        cmcp_params = params.get("_cmcp")
+        if not isinstance(cmcp_params, dict):
+            cmcp_params = {}
+        raw_workflow = cmcp_params.get("workflow_id")
+        workflow_id: str | None = raw_workflow if isinstance(raw_workflow, str) else None
 
         try:
             result = await self._proxy.call_tool(call_id, tool_name, arguments, workflow_id=workflow_id)
@@ -658,6 +663,10 @@ class MCPServer:
             )
         # AUTH-002: lock guards against a concurrent tool-call coroutine modifying sensitivity.
         async with self._session.mutation_lock:
+            # Capture the pre-reset sensitivity: reset() drops it back to
+            # "public", and the elevated value the session held at reset time
+            # is exactly the forensic detail the audit entry must preserve.
+            sensitivity_before = self._session.max_sensitivity
             old_id, new_id = self._session.reset(
                 reason="operator reset via API",
                 authorized_by="api",
@@ -667,7 +676,7 @@ class MCPServer:
             call_id=None,
             tool_name=None,
             policy_decision="n/a",
-            session_sensitivity_before=self._session.max_sensitivity,
+            session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
         )
         return JSONResponse({

--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -63,6 +63,9 @@ def verify_opaque_measurement(
         return result
 
     if raw_evidence is None:
+        # Fail closed: an attestation claim with no evidence cannot verify.
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["opaque_endpoint"] = endpoint
         result.details["hint"] = "raw_evidence not provided; cannot verify with Opaque"

--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -97,8 +97,17 @@ def verify_sev_snp_measurement(
         result.details["vcek_chain"] = "requires_amd_kds_lookup"
         return result
 
-    # Step 2: Parse raw_evidence if provided
-    if raw_evidence is not None and len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory — a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(["measurement", "vcek_cert_chain"])
+        result.details["raw_evidence"] = "not provided; SNP report cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-006)
             report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
@@ -142,7 +151,7 @@ def verify_sev_snp_measurement(
             result.details["vcek_chain"] = "requires_amd_kds_lookup"
             return result
 
-    elif raw_evidence is not None and len(raw_evidence) < _SNP_REPORT_MIN_SIZE:
+    else:
         # Truncated report -- treat as parse error
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tdx.py
+++ b/src/cmcp_verify/tdx.py
@@ -98,8 +98,19 @@ def verify_tdx_measurement(
         result.details["dcap_chain"] = "requires_intel_dcap_service"
         return result
 
-    # Step 2: Parse TDREPORT if provided
-    if raw_evidence is not None and len(raw_evidence) >= _TDREPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory — a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(
+            ["measurement", "dcap_quote_signature", "tcb_status"]
+        )
+        result.details["raw_evidence"] = "not provided; TDREPORT cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _TDREPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-007)
             tdreport = _TdReport.from_buffer_copy(raw_evidence[:_TDREPORT_MIN_SIZE])
@@ -135,7 +146,7 @@ def verify_tdx_measurement(
             result.details["dcap_chain"] = "requires_intel_dcap_service"
             return result
 
-    elif raw_evidence is not None:
+    else:
         # Truncated evidence
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tpm.py
+++ b/src/cmcp_verify/tpm.py
@@ -86,23 +86,30 @@ def verify_tpm_measurement(
             unverified_fields.append("qualifying_data")
             details["tpm_parse_error"] = parse_details.get("error", "failed to parse TPM2B_ATTEST")
     else:
-        # No raw evidence — cannot verify PCR digest or qualifying data
-        unverified_fields.append("pcr_digest")
-        unverified_fields.append("qualifying_data")
+        # No raw evidence — a claim asserting a hardware platform with no
+        # evidence to check must fail closed, not pass on format checks alone.
+        unverified_fields.extend(["pcr_digest", "qualifying_data", "ek_cert_chain"])
         details["pcr_digest_note"] = "raw_evidence not provided; PCR digest unverifiable"
+        return TPMVerificationResult(
+            verified=False,
+            verified_fields=verified_fields,
+            unverified_fields=unverified_fields,
+            failure_reason="no_raw_evidence",
+            details=details,
+        )
 
     # Step 3: EK cert chain always unverified in Phase 1
     unverified_fields.append("ek_cert_chain")
     details["ek_cert_chain_validation"] = "ek_cert_chain_validation_requires_ca_lookup"
 
-    # verified=True if we have at least measurement_format and no parse failures
+    # verified=True only when the evidence parsed and matched
     verified = "measurement_format" in verified_fields and "pcr_format" not in unverified_fields
 
     return TPMVerificationResult(
         verified=verified,
         verified_fields=verified_fields,
         unverified_fields=unverified_fields,
-        failure_reason=None,
+        failure_reason=None if verified else "tpm_evidence_check_failed",
         details=details,
     )
 

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -36,7 +36,22 @@ _KNOWN_PLATFORMS = {
     "aws-nitro",
     "arm-cca",
     "google-confidential-space",
+    "software-only",
 }
+
+
+def _is_software_only(runtime: dict[str, Any]) -> bool:
+    """True for dev-mode (non-attested) records.
+
+    Current records use platform "software-only"; records produced before
+    that value existed used platform "tpm2" with the dev firmware sentinel.
+    """
+    if runtime.get("platform") == "software-only":
+        return True
+    return (
+        runtime.get("platform") == "tpm2"
+        and runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
+    )
 
 
 class VerificationStatus(StrEnum):
@@ -54,6 +69,7 @@ class VerificationError(StrEnum):
     ATTESTATION_STALE = "ATTESTATION_STALE"
     CHAIN_BROKEN = "CHAIN_BROKEN"
     CLAIM_MALFORMED = "CLAIM_MALFORMED"
+    HARDWARE_ATTESTATION_FAILED = "HARDWARE_ATTESTATION_FAILED"
 
 
 @dataclass
@@ -384,10 +400,7 @@ def verify_trace_claim(
     # An attacker who substitutes their own keypair cannot forge the TEE-signed nonce,
     # so verification fails even when the Ed25519 signature is self-consistent.
     _runtime = claim_json.get("trace", {}).get("runtime", {})
-    _is_sw_only = (
-        _runtime.get("platform") == "tpm2"
-        and _runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
-    )
+    _is_sw_only = _is_software_only(_runtime)
 
     binding_result, binding_msg = _verify_key_binding(claim_json, is_sw_only=_is_sw_only)
     if binding_result is True:
@@ -462,12 +475,11 @@ def verify_trace_claim(
 
     # Step 7: Platform-specific attestation
     platform = _runtime.get("platform", "")
-    firmware_version = _runtime.get("firmware_version", "")
 
-    if platform == "tpm2" and firmware_version == _SW_ONLY_FIRMWARE:
+    if _is_sw_only:
         unverified.append("hardware_attestation")
         details["hardware_attestation"] = "software-only mode — not hardware-backed"
-    elif platform == "tpm2" and firmware_version != _SW_ONLY_FIRMWARE:
+    elif platform == "tpm2":
         from cmcp_verify.tpm import verify_tpm_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -483,11 +495,12 @@ def verify_trace_claim(
             verified.extend(tpm_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tpm_result.failure_reason:
                 details["tpm_failure"] = tpm_result.failure_reason
         unverified.extend(tpm_result.unverified_fields)
         details.update(tpm_result.details)
-    elif platform == "sev-snp" and firmware_version != _SW_ONLY_FIRMWARE:
+    elif platform == "amd-sev-snp":
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -503,6 +516,7 @@ def verify_trace_claim(
             verified.extend(snp_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if snp_result.failure_reason:
                 details["sev_snp_failure"] = snp_result.failure_reason
         unverified.extend(snp_result.unverified_fields)
@@ -523,6 +537,7 @@ def verify_trace_claim(
             verified.extend(tdx_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tdx_result.failure_reason:
                 details["tdx_failure"] = tdx_result.failure_reason
         unverified.extend(tdx_result.unverified_fields)
@@ -541,6 +556,7 @@ def verify_trace_claim(
             verified.extend(opaque_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if opaque_result.failure_reason:
                 details["opaque_failure"] = opaque_result.failure_reason
         unverified.extend(opaque_result.unverified_fields)

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -56,11 +56,12 @@ def test_snp_struct_round_trip() -> None:
     assert bytes(report.host_data) == host_pattern
 
 
-def test_valid_measurement_format_no_evidence():
+def test_valid_measurement_format_no_evidence_fails_closed():
+    """A well-formed measurement string is not evidence."""
     good = "sha384:" + "a" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_sha256_prefix_fails_format():
@@ -158,18 +159,20 @@ def test_truncated_report_is_parse_error():
     assert result.failure_reason == "raw_evidence_parse_error"
 
 
-def test_no_raw_evidence_hardware_unverified():
+def test_no_raw_evidence_fails_closed():
+    """A hardware-platform claim with no evidence must not verify."""
     good = "sha384:" + "f" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "measurement" not in result.verified_fields
 
 
 def test_vcek_cert_chain_always_unverified_no_evidence():
     good = "sha384:" + "e" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
+    assert result.verified is False
     assert "vcek_cert_chain" in result.unverified_fields
-    assert result.details["vcek_chain"] == "requires_amd_kds_lookup"
 
 
 def test_vcek_cert_chain_always_unverified_with_matching_report():

--- a/tests/unit/test_tdx_opaque_verify.py
+++ b/tests/unit/test_tdx_opaque_verify.py
@@ -47,22 +47,23 @@ def test_tdx_invalid_measurement_hex_length():
     assert result.failure_reason == "invalid_measurement_format"
 
 
-def test_tdx_no_raw_evidence_no_dcap(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed(monkeypatch):
+    """A hardware-platform claim with no evidence must not verify."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: False)
     measurement = "sha384:" + "b" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "dcap_quote_signature" in result.unverified_fields
-    assert result.details.get("dcap_chain") == "dcap_service_unreachable"
 
 
-def test_tdx_no_raw_evidence_dcap_reachable(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed_even_with_dcap(monkeypatch):
+    """DCAP reachability cannot substitute for missing evidence."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: True)
     measurement = "sha384:" + "c" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
-    assert "dcap_quote_signature" in result.unverified_fields
-    assert "reachable" in result.details.get("dcap_qe_identity", "")
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_tdx_measurement_matches_mrtd(monkeypatch):
@@ -100,11 +101,11 @@ def test_opaque_no_endpoint_configured(monkeypatch):
     assert "opaque_managed_attestation" in result.unverified_fields
 
 
-def test_opaque_no_raw_evidence(monkeypatch):
+def test_opaque_no_raw_evidence_fails_closed(monkeypatch):
     monkeypatch.setenv("CMCP_OPAQUE_ATTESTATION_ENDPOINT", "https://attest.opaque.co/v1/verify")
     result = verify_opaque_measurement("sha384:" + "a" * 96, None)
-    assert result.verified
-    assert "opaque_managed_attestation" in result.unverified_fields
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "raw_evidence not provided" in result.details.get("hint", "")
 
 

--- a/tests/unit/test_tpm_verify.py
+++ b/tests/unit/test_tpm_verify.py
@@ -51,13 +51,15 @@ def _make_tpm2b_attest(
 # ── Unit tests for verify_tpm_measurement ────────────────────────────────────
 
 
-def test_valid_measurement_format_passes() -> None:
+def test_valid_measurement_format_alone_does_not_verify() -> None:
+    """Format checks pass, but no evidence means fail closed."""
     result = verify_tpm_measurement(
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
     assert "measurement_format" in result.verified_fields
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_invalid_measurement_no_prefix_fails() -> None:
@@ -103,8 +105,8 @@ def test_no_raw_evidence_ek_cert_always_unverified() -> None:
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
+    assert result.verified is False
     assert "ek_cert_chain" in result.unverified_fields
-    assert result.details.get("ek_cert_chain_validation") == "ek_cert_chain_validation_requires_ca_lookup"
 
 
 def test_raw_evidence_valid_magic_parsed() -> None:

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -274,9 +274,9 @@ def test_generate_claim_enforcement_mode_mapped():
 
 
 def test_generate_claim_software_only_platform():
-    """software-only provider maps to tpm2 platform with firmware marker."""
+    """software-only provider gets its own platform value, never tpm2."""
     claim = _make_claim()
-    assert claim.trace.runtime.platform == "tpm2"
+    assert claim.trace.runtime.platform == "software-only"
     assert claim.trace.runtime.firmware_version == "software-only-dev-mode"
 
 

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -211,13 +211,18 @@ def test_all_software_only_verified_fields_are_present():
 
 
 def test_known_hardware_platform_without_verifier_is_partially_verified():
-    """TEE-001 -- amd-sev-snp must be PARTIALLY_VERIFIED not VERIFIED."""
+    """TEE-001 -- amd-sev-snp without raw evidence must not be VERIFIED.
+
+    The dispatch previously compared against the provider name ("sev-snp")
+    instead of the platform name ("amd-sev-snp"), so SNP verification never
+    ran; with the dispatch fixed, the missing raw evidence fails closed.
+    """
     claim_dict, key = _make_signed_claim(provider="sev-snp")
     result = verify_trace_claim(
         claim_dict, _approved(), trusted_public_key_hex=key.public_key_hex
     )
     assert result.status == VerificationStatus.PARTIALLY_VERIFIED
-    assert result.failure_reason == VerificationError.UNSUPPORTED_PROVIDER
+    assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED
     assert "hardware_attestation" in result.unverified_fields
 
 


### PR DESCRIPTION
## Summary

Remaining review findings, all in the trust-decision path. Two were masking each other:

1. **SEV-SNP verification never ran**: the platform dispatch compared against the provider name `"sev-snp"` instead of the mapped platform name `"amd-sev-snp"`, so every SNP claim fell through to `UNSUPPORTED_PROVIDER`. Fixing the dispatch exposed:
2. **All four hardware verifiers fail open without evidence**: `tpm`, `sev_snp`, `tdx`, and `opaque` returned `verified=True` when `raw_evidence` was `None` -- a claim asserting a hardware platform was "verified" on measurement string format alone. All now fail closed (`no_raw_evidence`). On top, `verify_trace_claim` never set an overall failure when a platform verifier failed (status stayed VERIFIED) -- new `HARDWARE_ATTESTATION_FAILED` closes that.
3. **Dev-mode platform honesty**: dev-mode claims advertised `platform: "tpm2"`; `software-only` is now a first-class value (pairs with agentrust-io/trace-spec#23 -- **merge blocker: needs an agentrust-trace release containing it**). Verifier accepts legacy tpm2+sentinel records too.
4. Server hardening: malformed `_cmcp` param no longer 500s; `session_reset` audit records the pre-reset sensitivity.

## Test plan

- [x] Tests asserting the old fail-open behavior flipped to the fail-closed contract (8 updated, with docstrings explaining why)
- [x] Full suite: 679 passed, 1 skipped

Stacked on #287. Requires trace-spec#23 + agentrust-trace release before merge.

Generated with [Claude Code](https://claude.ai/code)