### PR TITLE
fix(ci): declare cedarpy dependency; repair Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,15 +8,16 @@ on:
     branches:
       - main
 
-permissions:
-  security-events: write
-  id-token: write
-  contents: read
-  actions: read
+permissions: read-all
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -25,11 +26,13 @@ jobs:
           fetch-depth: 0
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
-          publish_results: true
+          # publish_results requires a public repo; flip to true after the
+          # 2026-06-23 public launch.
+          publish_results: false
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "uvicorn>=0.29",
     "click>=8.1",
     "agent-governance-toolkit-core>=4.0",
+    "cedarpy>=4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes both red workflows on main:

- **CI** (red since 2026-06-10): `cedarpy` was never declared in pyproject. Local environments have it, so the suite passes locally; CI runners do not, so `CedarBackend` auto mode fails closed and the benchmark tests deny every call (`PolicyDeny: benchmark.tool`). The runtime is not functional without a real Cedar engine, so it belongs in core dependencies.
- **OpenSSF Scorecard**: `ossf/scorecard-action@v2` is not a resolvable ref (they publish v2.x.y) -- pinned to the v2.4.3 commit SHA. `publish_results` disabled while the repo is private (it requires a public repo; dated note to flip after the 2026-06-23 launch). Permissions aligned with the official scorecard template.

Generated with [Claude Code](https://claude.ai/code)