### PR TITLE
fix(workflows): skip maintainer gate for maintainer-authored PRs

### DIFF
--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -27,6 +27,12 @@ jobs:
           script: |
             const MAINTAINERS = ['imran-siddique'];
 
+            const author = context.payload.pull_request.user.login;
+            if (MAINTAINERS.includes(author)) {
+              core.info(`Author ${author} is a maintainer, skipping gate`);
+              return;
+            }
+
             const association = context.payload.pull_request.author_association;
             if (association === 'MEMBER' || association === 'OWNER') {
               core.info(`Author is ${association}, skipping gate`);


### PR DESCRIPTION
The gate skips when author_association is MEMBER or OWNER, but GitHub only reports MEMBER when the author's org membership is public, so a maintainer with private membership gets CONTRIBUTOR and the gate demands an approval the author cannot give (authors cannot approve their own PRs). This adds an explicit skip when the PR author is in MAINTAINERS, keeping the association skip for public members; confirmed live on cmcp#291, where the gate failed while all tests passed.

Note: this PR is itself gate-blocked by the bug it fixes. Approve and re-run the gate, or admin-merge.

Generated with [Claude Code](https://claude.ai/code)