### PR TITLE
fix: restore the feature stack lost in the stacked-PR merge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 ## Full example
 
 ```yaml
-# cmcp-config.yaml : annotated full example
+# cmcp-config.yaml - annotated full example
 
 attestation:
   # TEE provider. auto detects in order: tpm -> sev-snp -> tdx.
@@ -15,7 +15,9 @@ attestation:
 
   # enforcing: policy denies block the tool call and return HTTP 403.
   # advisory: policy denies are logged but the call is forwarded.
-  # silent: evaluates policy but takes no action and does not log denies.
+  # silent: like advisory but without operational log lines. The hash-chained
+  #   audit log still records every would-have-denied decision -- silent
+  #   quiets logs, never the evidence.
   enforcement_mode: enforcing
 
   # How long (in seconds) an attestation report is considered fresh.
@@ -97,7 +99,7 @@ Environment variables control secrets and mode flags that must not appear in con
 |------|----------|----------|
 | `enforcing` | Policy denies block the tool call. The runtime returns HTTP 403 and a structured error to the agent. The call is not forwarded to the upstream server. | Production. Default for new deployments. |
 | `advisory` | Policy denies are logged in the audit chain but the call is forwarded. The TRACE Claim records the deny. No tool call is blocked. | Policy testing, migration from existing runtime. Safe for first run with an untuned policy. |
-| `silent` | Policy is evaluated but the result is not acted on and denies are not logged. Observability-only mode. | Measuring policy impact before rollout. Not suitable for any compliance scenario. |
+| `silent` | Policy is evaluated, the call is forwarded, and **the audit chain still records every would-have-denied decision** (as `advisory_deny`, visible in the TRACE Claim's call summary). The only difference from `advisory` is that no operational log lines are emitted. Silent quiets logs, never the evidence. | Measuring policy impact before rollout without operational log noise. The tamper-evident record remains complete, so post-hoc review stays possible. |
 
 ## Minimal working config
 

--- a/src/cmcp_runtime/audit/chain.py
+++ b/src/cmcp_runtime/audit/chain.py
@@ -1,4 +1,4 @@
-"""Audit chain — append-only hash-chained log inside the enclave. Implements issue #47."""
+"""Audit chain - append-only hash-chained log inside the enclave. Implements issue #47."""
 
 from __future__ import annotations
 
@@ -90,7 +90,7 @@ class AuditChain:
 
     When a TEE anchor is set, verify_chain() also checks that the current
     chain_root equals the anchored value.  In dev / Level-0 mode where no
-    TEE is available, anchoring is skipped and a warning is emitted — the
+    TEE is available, anchoring is skipped and a warning is emitted - the
     internal hash-chain check still runs.
     """
 
@@ -125,7 +125,7 @@ class AuditChain:
 
         anchor must equal chain_root at the time of the call (i.e. the value
         that was measured into the TEE attestation report nonce).  Raises
-        ValueError if anchor does not match the current chain_root — this
+        ValueError if anchor does not match the current chain_root - this
         would indicate a programming error in the caller.
 
         Once set, verify_chain() will reject any chain whose root no longer
@@ -223,7 +223,7 @@ class AuditChain:
         this check even if its internal hash links are self-consistent.
 
         If no anchor is set (dev / Level-0 mode), emit a warning but do not
-        fail — the caller should ensure set_tee_anchor() is called in
+        fail - the caller should ensure set_tee_anchor() is called in
         production.
         """
         if not self._entries:
@@ -240,7 +240,7 @@ class AuditChain:
         # AUDIT-002: external anchor check.
         if self._tee_anchor is None:
             logger.warning(
-                "AUDIT-002: audit chain has no TEE anchor — chain substitution cannot be "
+                "AUDIT-002: audit chain has no TEE anchor - chain substitution cannot be "
                 "detected. Call set_tee_anchor() at session start in production. "
                 "session_id=%s",
                 self._session_id,

--- a/src/cmcp_runtime/audit/store.py
+++ b/src/cmcp_runtime/audit/store.py
@@ -1,10 +1,11 @@
-"""SQLite-backed audit store — durable persistence for AuditChain entries (AUDIT-001)."""
+"""SQLite-backed audit store - durable persistence for AuditChain entries (AUDIT-001)."""
 
 from __future__ import annotations
 
 import json
 import logging
 import sqlite3
+import threading
 from dataclasses import asdict
 from pathlib import Path
 
@@ -40,7 +41,10 @@ class SqliteAuditStore:
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
+        # check_same_thread=False allows use from async handlers and worker
+        # threads; all access is serialised through self._lock.
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._lock = threading.Lock()
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=FULL")
         self._conn.executescript(_CREATE_TABLE)
@@ -49,21 +53,22 @@ class SqliteAuditStore:
 
     def append(self, entry: AuditEntry) -> None:
         payload = json.dumps(asdict(entry), sort_keys=True, separators=(",", ":"))
-        self._conn.execute(
-            "INSERT INTO audit_entries "
-            "(sequence_number, session_id, entry_id, entry_type, entry_hash, prev_entry_hash, payload) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                entry.sequence_number,
-                entry.session_id,
-                entry.entry_id,
-                entry.entry_type,
-                entry.entry_hash,
-                entry.prev_entry_hash,
-                payload,
-            ),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO audit_entries "
+                "(sequence_number, session_id, entry_id, entry_type, entry_hash, prev_entry_hash, payload) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    entry.sequence_number,
+                    entry.session_id,
+                    entry.entry_id,
+                    entry.entry_type,
+                    entry.entry_hash,
+                    entry.prev_entry_hash,
+                    payload,
+                ),
+            )
+            self._conn.commit()
 
     def find_orphaned_sessions(self) -> list[str]:
         """
@@ -72,16 +77,18 @@ class SqliteAuditStore:
         These represent sessions that were open when the gateway last stopped,
         either due to a crash or an unclean shutdown.
         """
-        cur = self._conn.execute(
-            """
-            SELECT DISTINCT session_id FROM audit_entries
-            WHERE entry_type = 'session_start'
-              AND session_id NOT IN (
-                  SELECT session_id FROM audit_entries WHERE entry_type = 'session_end'
-              )
-            """
-        )
-        return [row[0] for row in cur.fetchall()]
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                SELECT DISTINCT session_id FROM audit_entries
+                WHERE entry_type = 'session_start'
+                  AND session_id NOT IN (
+                      SELECT session_id FROM audit_entries WHERE entry_type = 'session_end'
+                  )
+                """
+            )
+            return [row[0] for row in cur.fetchall()]
 
     def close(self) -> None:
-        self._conn.close()
+        with self._lock:
+            self._conn.close()

--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -1,4 +1,4 @@
-"""TRACE Claim (cmcp profile) — RuntimeClaim envelope wrapping canonical TRACE fields."""
+"""TRACE Claim (cmcp profile) - RuntimeClaim envelope wrapping canonical TRACE fields."""
 
 from __future__ import annotations
 
@@ -24,7 +24,9 @@ _PROVIDER_MAP: dict[str, str] = {
     "tdx": "intel-tdx",
     "opaque": "intel-tdx",
     "tpm": "tpm2",
-    "software-only": "tpm2",
+    # Dev mode is its own platform value: a consumer keying trust on
+    # runtime.platform must never mistake a non-attested record for TPM-backed.
+    "software-only": "software-only",
 }
 
 _SW_ONLY_MEASUREMENT = "sha256:" + "0" * 64
@@ -160,7 +162,7 @@ class GatewayAddenda(BaseModel):
 
 
 class RuntimeClaim(BaseModel):
-    """cmcp TRACE profile — canonical trust fields nested inside a gateway envelope."""
+    """cmcp TRACE profile - canonical trust fields nested inside a gateway envelope."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -276,7 +278,7 @@ def generate_trace_claim(
 ) -> RuntimeClaim:
     """Generate a RuntimeClaim from session data, validate it via Pydantic, and optionally sign it.
 
-    signing_key must be a SigningKey instance (audit/keys.py) — it is always required
+    signing_key must be a SigningKey instance (audit/keys.py) - it is always required
     to build the JWK confirmation key in trace.cnf.  Set do_sign=False to produce an
     unsigned claim (e.g. in tests).
     """

--- a/src/cmcp_runtime/benchmarks.py
+++ b/src/cmcp_runtime/benchmarks.py
@@ -1,5 +1,5 @@
 """
-cMCP runtime latency benchmark suite — implements issue #78.
+cMCP runtime latency benchmark suite - implements issue #78.
 
 Measures: cedar_eval_latency_us, audit_entry_latency_us, end_to_end_latency_us (p50/p95/p99)
 
@@ -194,12 +194,6 @@ def _make_proxy(bundle: Any, catalog: Any) -> tuple[Any, Any]:
     session = SessionState(session_id=str(uuid.uuid4()))
     chain = AuditChain(session_id=session.session_id)
 
-    agt_result = MagicMock(
-        sensitivity_tags=[],
-        injection_detected=False,
-        modified_response=b'{"result": "benchmark-ok"}',
-    )
-
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(
@@ -209,8 +203,21 @@ def _make_proxy(bundle: Any, catalog: Any) -> tuple[Any, Any]:
             audit_chain=chain,
             config=config,
         )
+        # Mock the gateway seam (pre-call check, upstream forward, response
+        # scan) so benchmarks measure cmcp overhead, not network latency.
         proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=agt_result)
+        proxy._mcp_gateway.intercept_tool_call = MagicMock(return_value=(True, "ok"))
+        proxy._forward_to_upstream = AsyncMock(
+            return_value='{"result": "benchmark-ok"}'
+        )
+        proxy._mcp_gateway.intercept_tool_response = MagicMock(
+            return_value=MagicMock(
+                allowed=True,
+                content='{"result": "benchmark-ok"}',
+                threats=[],
+                action="allowed",
+            )
+        )
 
     return proxy, evaluator
 

--- a/src/cmcp_runtime/benchmarks.py
+++ b/src/cmcp_runtime/benchmarks.py
@@ -207,7 +207,7 @@ def _make_proxy(bundle: Any, catalog: Any) -> tuple[Any, Any]:
         # scan) so benchmarks measure cmcp overhead, not network latency.
         proxy._mcp_gateway = MagicMock()
         proxy._mcp_gateway.intercept_tool_call = MagicMock(return_value=(True, "ok"))
-        proxy._forward_to_upstream = AsyncMock(
+        proxy._forward_to_upstream = AsyncMock(  # type: ignore[method-assign]
             return_value='{"result": "benchmark-ok"}'
         )
         proxy._mcp_gateway.intercept_tool_response = MagicMock(

--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -2,9 +2,61 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import click
 
 from cmcp_runtime import __version__
+
+if TYPE_CHECKING:
+    from cmcp_runtime.mcp.server import MCPServer
+    from cmcp_runtime.startup import RuntimeContext
+
+
+def build_server(ctx: RuntimeContext) -> MCPServer:
+    """
+    Compose the running gateway from a validated RuntimeContext.
+
+    All components validated by run_startup() MUST be wired here - a component
+    that is validated but not passed through is silently inert in production
+    (the AUTH-001 bearer token and AUDIT-001 store were both lost this way).
+    """
+    from cmcp_runtime.audit.trace_claim import _PROVIDER_MAP
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+    from cmcp_runtime.mcp.server import MCPServer
+    from cmcp_runtime.policy.evaluator import PolicyEvaluator
+    from cmcp_runtime.session.manager import SessionManager
+
+    # Resolve provider string to canonical platform name for Cedar context.
+    # Falls back to the raw provider string if not in the map (e.g. future providers).
+    attestation_platform = _PROVIDER_MAP.get(
+        ctx.attestation_report.provider, ctx.attestation_report.provider
+    )
+
+    # AUDIT-001/AUDIT-002: sessions MUST be created through SessionManager so the
+    # chain is backed by the durable SQLite store and TEE-anchored at creation.
+    session_manager = SessionManager(ctx)
+    session, audit_chain = session_manager.create_session()
+    policy_evaluator = PolicyEvaluator(bundle=ctx.policy_bundle, config=ctx.config)
+    proxy = CMCPProxy(
+        catalog=ctx.catalog,
+        policy_evaluator=policy_evaluator,
+        session=session,
+        audit_chain=audit_chain,
+        config=ctx.config,
+        attestation_generated_at=ctx.attestation_report.attestation_generated_at,
+        attestation_validity_seconds=ctx.attestation_report.attestation_validity_seconds,
+        attestation_platform=attestation_platform,
+    )
+    # AUTH-001: the token validated in run_startup must reach the server, otherwise
+    # every protected endpoint is reachable unauthenticated.
+    return MCPServer(
+        proxy=proxy,
+        session_manager=session_manager,
+        audit_chain=audit_chain,
+        session=session,
+        bearer_token=ctx.config.bearer_token,
+    )
 
 
 @click.group()
@@ -19,16 +71,8 @@ def main() -> None:
               help="Override attestation.enforcement_mode from config")
 def start(config: str, enforcement: str | None) -> None:
     """Start the cMCP Runtime."""
-    from uuid import uuid4
-
     import uvicorn
 
-    from cmcp_runtime.audit.chain import AuditChain
-    from cmcp_runtime.audit.trace_claim import _PROVIDER_MAP
-    from cmcp_runtime.mcp.proxy import CMCPProxy
-    from cmcp_runtime.mcp.server import MCPServer
-    from cmcp_runtime.policy.evaluator import PolicyEvaluator
-    from cmcp_runtime.session.state import SessionState
     from cmcp_runtime.startup import run_startup
 
     ctx = run_startup(config)
@@ -38,24 +82,7 @@ def start(config: str, enforcement: str | None) -> None:
         from cmcp_runtime.config import EnforcementMode
         ctx.config.attestation.enforcement_mode = EnforcementMode(enforcement)
 
-    # Resolve provider string to canonical platform name for Cedar context.
-    # Falls back to the raw provider string if not in the map (e.g. future providers).
-    attestation_platform = _PROVIDER_MAP.get(
-        ctx.attestation_report.provider, ctx.attestation_report.provider
-    )
-
-    session = SessionState(session_id=str(uuid4()))
-    audit_chain = AuditChain(session_id=session.session_id)
-    policy_evaluator = PolicyEvaluator(bundle=ctx.policy_bundle, config=ctx.config)
-    proxy = CMCPProxy(
-        catalog=ctx.catalog,
-        policy_evaluator=policy_evaluator,
-        session=session,
-        audit_chain=audit_chain,
-        config=ctx.config,
-        attestation_platform=attestation_platform,
-    )
-    server = MCPServer(proxy=proxy)
+    server = build_server(ctx)
 
     host, _, port_str = ctx.config.listen_addr.rpartition(":")
     port = int(port_str)
@@ -65,6 +92,97 @@ def start(config: str, enforcement: str | None) -> None:
         f" listen: {ctx.config.listen_addr}"
     )
     uvicorn.run(server.app, host=host, port=port)
+
+
+@main.command()
+@click.argument("claim_file", type=click.Path(exists=True))
+@click.option("--policy-hash", default=None,
+              help="Approved policy bundle hash (sha256:<hex>). Unpinned if omitted.")
+@click.option("--catalog-hash", default=None,
+              help="Approved tool catalog hash (sha256:<hex>). Unpinned if omitted.")
+@click.option("--max-age", default=86400, type=int, show_default=True,
+              help="Maximum attestation age in seconds.")
+@click.option("--trusted-key", default=None,
+              help="Out-of-band pinned Ed25519 public key (hex) to cross-check trace.cnf.jwk.")
+@click.option("--audit-bundle", default=None, type=click.Path(exists=True),
+              help="Also verify an exported audit bundle (GET /audit/export) against the claim.")
+def verify(
+    claim_file: str,
+    policy_hash: str | None,
+    catalog_hash: str | None,
+    max_age: int,
+    trusted_key: str | None,
+    audit_bundle: str | None,
+) -> None:
+    """Verify a signed TRACE Claim (and optionally its audit bundle).
+
+    Checks the Ed25519 signature against the confirmation key in
+    trace.cnf.jwk, the claim schema, attestation freshness, audit chain
+    consistency, and (when pinned) the policy and catalog hashes.
+    Exits 0 when verified, 1 otherwise.
+    """
+    import json as _json
+
+    from cmcp_verify import ApprovedHashes, verify_audit_bundle, verify_trace_claim
+
+    with open(claim_file) as f:
+        claim = _json.load(f)
+
+    pinned_policy = policy_hash is not None
+    pinned_catalog = catalog_hash is not None
+    # Unpinned hashes fall back to the claim's own values: the check passes
+    # trivially and is reported as "not pinned" rather than verified.
+    approved = ApprovedHashes(
+        policy_bundle_hash=policy_hash
+        or claim.get("trace", {}).get("policy", {}).get("bundle_hash", ""),
+        tool_catalog_hash=catalog_hash
+        or claim.get("gateway", {}).get("catalog", {}).get("hash", ""),
+    )
+
+    result = verify_trace_claim(
+        claim,
+        approved,
+        max_attestation_age_seconds=max_age,
+        trusted_public_key_hex=trusted_key,
+    )
+
+    def _line(name: str, ok: bool, note: str = "") -> None:
+        mark = "PASS" if ok else "FAIL"
+        click.echo(f"[cmcp verify] {name:<24} {mark}{('  ' + note) if note else ''}")
+
+    for field_name in result.verified_fields:
+        note = ""
+        if field_name == "policy_bundle.hash" and not pinned_policy:
+            note = "(not pinned - pass --policy-hash to pin)"
+        if field_name == "tool_catalog.hash" and not pinned_catalog:
+            note = "(not pinned - pass --catalog-hash to pin)"
+        _line(field_name, True, note)
+    for field_name in result.unverified_fields:
+        _line(field_name, False, result.details.get(field_name, ""))
+
+    bundle_ok = True
+    if audit_bundle is not None:
+        with open(audit_bundle) as f:
+            bundle = _json.load(f)
+        bundle_result = verify_audit_bundle(bundle, claim)
+        bundle_ok = bundle_result.verified
+        _line(
+            "audit_bundle",
+            bundle_ok,
+            f"({bundle_result.entry_count} entries)"
+            if bundle_ok
+            else "; ".join(bundle_result.failures),
+        )
+
+    overall = result.status.value == "verified" and bundle_ok
+    if "hardware_attestation" in result.unverified_fields:
+        click.echo(
+            "[cmcp verify] note: "
+            + result.details.get("hardware_attestation", "hardware attestation not verified")
+        )
+    click.echo(f"[cmcp verify] RESULT: {'PASS' if overall else 'FAIL'} ({result.status.value})")
+    if not overall:
+        raise SystemExit(1)
 
 
 @main.command("validate-config")

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -1,4 +1,4 @@
-"""Configuration parser — cmcp-config.yaml. Implements issue #64."""
+"""Configuration parser - cmcp-config.yaml. Implements issue #64."""
 
 from __future__ import annotations
 

--- a/src/cmcp_runtime/errors.py
+++ b/src/cmcp_runtime/errors.py
@@ -1,4 +1,4 @@
-"""Central error code registry — mirrors docs/spec/error-codes.md."""
+"""Central error code registry - mirrors docs/spec/error-codes.md."""
 
 from __future__ import annotations
 
@@ -37,6 +37,18 @@ class ToolNotInCatalog(CMCPError):
 class PolicyDeny(CMCPError):
     code = "POLICY_DENY"
     http_status = 403
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        detail: str | None = None,
+        advice: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message, detail=detail)
+        # Annotations of the forbid policies that caused this deny - sourced
+        # from the hash-pinned policy bundle, safe to reflect to the caller.
+        self.advice: dict[str, str] = advice or {}
 
 
 class CatalogToolNameCollision(CMCPError):
@@ -84,13 +96,23 @@ class TeeFault(CMCPError):
     http_status = 500
 
 
+class UpstreamUnavailable(CMCPError):
+    code = "UPSTREAM_UNAVAILABLE"
+    http_status = 502
+
+
+class UpstreamToolError(CMCPError):
+    code = "UPSTREAM_TOOL_ERROR"
+    http_status = 502
+
+
 class AttestationStale(CMCPError):
     code = "ATTESTATION_STALE"
     http_status = 412
 
 
 class BreakGlassActive(CMCPError):
-    """Not an error — signals that a break-glass exception is in use."""
+    """Not an error - signals that a break-glass exception is in use."""
 
     code = "BREAK_GLASS_ACTIVE"
     http_status = 200

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -61,13 +61,13 @@ def _cedar_safe(value: Any) -> Any:
     denies the call. Floats are preserved as strings; None values are dropped
     (policies use `has` checks, so absence is the correct representation).
     """
-    if isinstance(value, (bool, int, str)):
+    if isinstance(value, bool | int | str):
         return value
     if isinstance(value, float):
         return str(value)
     if isinstance(value, dict):
         return {k: _cedar_safe(v) for k, v in value.items() if v is not None}
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         return [_cedar_safe(v) for v in value if v is not None]
     return str(value)
 
@@ -737,7 +737,7 @@ class CMCPProxy:
                 "injection_scanner": str(injection_scanner or "unknown")[:128],
                 "matched_pattern": str(injection_pattern or "unknown")[:256],
                 # INJECT-007: include threshold so the decision is replayable under config changes
-                **({"injection_threshold": float(injection_threshold)} if isinstance(injection_threshold, (int, float)) else {}),
+                **({"injection_threshold": float(injection_threshold)} if isinstance(injection_threshold, int | float) else {}),
             }
             if injection_detected
             else None

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -1,5 +1,5 @@
 """
-MCP gateway proxy using AGT's MCPGateway + StatelessKernel — implements #48, #53, #54.
+MCP gateway proxy using AGT's MCPGateway + StatelessKernel - implements #48, #53, #54.
 
 AGT's MCPGateway handles MCP protocol enforcement (tool allow/deny, parameter
 sanitization, rate limiting, response scanning). cMCP wraps it so that every
@@ -20,13 +20,14 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 from agent_os.mcp_gateway import GovernancePolicy, MCPGateway  # type: ignore[attr-defined]
 from agent_os.mcp_response_scanner import MCPResponseScanner
 
 from cmcp_runtime.audit.chain import AuditChain
-from cmcp_runtime.catalog.loader import ToolCatalog
+from cmcp_runtime.catalog.loader import CatalogEntry, ToolCatalog
 from cmcp_runtime.config import Config
-from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.errors import PolicyDeny, UpstreamToolError, UpstreamUnavailable
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
 from cmcp_runtime.session.state import SessionState
@@ -46,6 +47,29 @@ class CallResult:
     deny_reason: str | None
     latency_us: int
     audit_entry_hash: str
+    # Annotations from the forbid policies that matched (deny or advisory).
+    # Sourced from the hash-pinned policy bundle, safe to reflect to callers.
+    advice: dict[str, str] | None = None
+
+
+def _cedar_safe(value: Any) -> Any:
+    """
+    Coerce a JSON value into types Cedar can ingest.
+
+    Cedar has no float or null type: a single float anywhere in the request
+    context makes cedarpy reject the whole request, which fails closed and
+    denies the call. Floats are preserved as strings; None values are dropped
+    (policies use `has` checks, so absence is the correct representation).
+    """
+    if isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _cedar_safe(v) for k, v in value.items() if v is not None}
+    if isinstance(value, (list, tuple)):
+        return [_cedar_safe(v) for v in value if v is not None]
+    return str(value)
 
 
 class CMCPProxy:
@@ -96,11 +120,86 @@ class CMCPProxy:
             allowed_tools=allowed_tools,
         )
 
-        # AGT MCPGateway — handles protocol, sanitization, rate limiting
+        # AGT MCPGateway - handles protocol, sanitization, rate limiting
         self._mcp_gateway = MCPGateway(
             policy=gov_policy,
             response_scanner=MCPResponseScanner(),
         )
+
+        # Shared async HTTP client for upstream forwarding; created lazily so
+        # proxy construction stays sync and tests need no event loop.
+        self._http: httpx.AsyncClient | None = None
+
+    def rebind_session(self, session: SessionState, audit_chain: AuditChain) -> None:
+        """
+        Point the proxy at a fresh session after the previous one was closed.
+
+        Call logs are recreated for the new session id; catalog, policy
+        evaluator, and gateway are unchanged.
+        """
+        self._session = session
+        self._audit = audit_chain
+        self._call_log = CallLog(session_id=session.session_id)
+        self._session_call_log = SessionCallLog(session_id=session.session_id)
+
+    async def _forward_to_upstream(
+        self,
+        call_id: str,
+        entry: CatalogEntry,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> str:
+        """
+        Forward the tool call to the attested upstream MCP server (JSON-RPC 2.0
+        tools/call over HTTP POST to the catalog entry's server.url).
+
+        Returns the concatenated text content of the MCP result.
+
+        Raises UpstreamUnavailable on transport errors / non-2xx / non-JSON,
+        UpstreamToolError when the upstream returns a JSON-RPC error object.
+        """
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        payload = {
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+        try:
+            resp = await self._http.post(entry.server.url, json=payload)
+            resp.raise_for_status()
+            body = resp.json()
+        except httpx.HTTPError as exc:
+            raise UpstreamUnavailable(
+                f"Upstream MCP server unreachable: {entry.server.url}",
+                detail=str(exc),
+            ) from exc
+        except ValueError as exc:
+            raise UpstreamUnavailable(
+                f"Upstream returned non-JSON body: {entry.server.url}",
+                detail=str(exc),
+            ) from exc
+        if not isinstance(body, dict):
+            raise UpstreamUnavailable(
+                f"Upstream returned non-object JSON-RPC body: {entry.server.url}"
+            )
+        if "error" in body:
+            error = body["error"] if isinstance(body["error"], dict) else {}
+            raise UpstreamToolError(
+                f"Upstream tool error from {tool_name}: "
+                f"{str(error.get('message', 'unknown'))[:200]}"
+            )
+        result = body.get("result", {})
+        content = result.get("content", []) if isinstance(result, dict) else []
+        texts = [
+            c.get("text", "")
+            for c in content
+            if isinstance(c, dict) and c.get("type") == "text"
+        ]
+        if texts:
+            return "\n".join(texts)
+        return json.dumps(result, default=str)
 
     def _check_health(self) -> str | None:
         """
@@ -159,7 +258,7 @@ class CMCPProxy:
         entry = self._catalog.lookup(tool_name)
         ctx: dict[str, Any] = {
             "tool_name": tool_name,
-            "arguments": arguments,
+            "arguments": _cedar_safe(arguments),
             "server_identity": entry.server.url if entry else "",
             "compliance_domain": entry.compliance_domain if entry else "external",
             "baa_covered": (not entry.requires_baa) if entry else False,
@@ -307,7 +406,7 @@ class CMCPProxy:
                 audit_entry_hash=self._audit.chain_tip,
             )
 
-        # Step 1b: break-glass warning — log and audit every call via an exception entry
+        # Step 1b: break-glass warning - log and audit every call via an exception entry
         if entry.catalog_exception:
             logger.warning(
                 "BREAK_GLASS_ACTIVE: tool=%s call_id=%s server=%s",
@@ -329,10 +428,12 @@ class CMCPProxy:
         # Step 2: Cedar policy evaluation
         cedar_context = self._build_cedar_context(tool_name, arguments, workflow_id)
         policy_rule: str | None = None
+        ingress_advice: dict[str, str] = {}
         try:
             decision = self._policy.evaluate(cedar_context)
             policy_rule = decision.rule_matched
             would_have_denied = decision.would_have_denied
+            ingress_advice = decision.advice
         except PolicyDeny as exc:
             self._audit.append(
                 "tool_call",
@@ -367,6 +468,7 @@ class CMCPProxy:
                 deny_reason=str(exc),
                 latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
+                advice=exc.advice or None,
             )
         except Exception as exc:
             # POLICY-003: Cedar backend raised an unexpected exception (e.g. malformed
@@ -387,25 +489,24 @@ class CMCPProxy:
             )
             raise
 
-        # Step 3: AGT MCPGateway enforcement
-        # AGT handles per-agent rate limiting, parameter sanitization, and
-        # response scanning. We pass tool_name as the action and arguments as params.
-        try:
-            agt_result = await self._mcp_gateway.call_tool(  # type: ignore[attr-defined]
-                tool_name=tool_name,
-                arguments=arguments,
-                agent_id=self._session.session_id,
+        # Step 3a: AGT MCPGateway pre-call interception - per-agent rate
+        # limiting, parameter sanitization, allow/deny. Fail-closed inside AGT.
+        agt_allowed, agt_reason = self._mcp_gateway.intercept_tool_call(
+            agent_id=self._session.session_id,
+            tool_name=tool_name,
+            params=arguments,
+        )
+        if not agt_allowed:
+            logger.warning(
+                "AGT MCPGateway rejected call: tool=%s reason=%s", tool_name, agt_reason
             )
-        except Exception as exc:
-            # AGT denied or errored — map to our error types
-            logger.warning("AGT MCPGateway rejected call: tool=%s error=%s", tool_name, exc)
             self._audit.append(
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
                 server_identity=entry.server.url,
                 policy_decision="deny",
-                policy_rule_matched=f"agt_gateway:{type(exc).__name__}",
+                policy_rule_matched=f"agt_gateway:{agt_reason[:200]}",
                 request_payload_hash=request_payload_hash,
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
@@ -429,45 +530,175 @@ class CMCPProxy:
                 allowed=False,
                 would_have_denied=would_have_denied,
                 response=None,
-                deny_reason=str(exc),
+                deny_reason=agt_reason,
                 latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
 
+        # Step 3b: forward to the attested upstream MCP server.
+        try:
+            response_text = await self._forward_to_upstream(
+                call_id, entry, tool_name, arguments
+            )
+        except (UpstreamUnavailable, UpstreamToolError) as exc:
+            logger.warning("Upstream call failed: tool=%s error=%s", tool_name, exc)
+            self._audit.append(
+                "fault",
+                call_id=call_id,
+                tool_name=tool_name,
+                server_identity=entry.server.url,
+                policy_decision="fault",
+                policy_rule_matched=f"upstream:{exc.code}",
+                request_payload_hash=request_payload_hash,
+                session_sensitivity_before=sensitivity_before,
+                session_sensitivity_after=self._session.max_sensitivity,
+                detail={"error_code": exc.code},
+            )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"upstream": "fault"},
+                call_id=call_id,
+                catalog_entry=entry,
+                policy_decision="fault",
+            )
+            return CallResult(
+                call_id=call_id,
+                tool_name=tool_name,
+                allowed=False,
+                would_have_denied=would_have_denied,
+                response=None,
+                deny_reason=f"upstream_error:{exc.code}",
+                latency_us=int(elapsed_ms * 1000),
+                audit_entry_hash=self._audit.chain_tip,
+            )
+
+        # Step 3c: response size guard (DOS-002) before scanning.
+        if len(response_text.encode()) > self._config.max_response_size_bytes:
+            self._audit.append(
+                "tool_call",
+                call_id=call_id,
+                tool_name=tool_name,
+                server_identity=entry.server.url,
+                policy_decision="deny",
+                policy_rule_matched="response_size_exceeded",
+                request_payload_hash=request_payload_hash,
+                response_inspection_result="size_exceeded",
+                session_sensitivity_before=sensitivity_before,
+                session_sensitivity_after=self._session.max_sensitivity,
+                workflow_id=workflow_id,
+            )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"inspection": "size_exceeded"},
+                call_id=call_id,
+                catalog_entry=entry,
+                policy_decision="deny",
+            )
+            return CallResult(
+                call_id=call_id,
+                tool_name=tool_name,
+                allowed=False,
+                would_have_denied=would_have_denied,
+                response=None,
+                deny_reason="response_size_exceeded",
+                latency_us=int(elapsed_ms * 1000),
+                audit_entry_hash=self._audit.chain_tip,
+            )
+
+        # Step 3d: AGT response interception - injection / credential / PII scan.
+        scan = self._mcp_gateway.intercept_tool_response(
+            agent_id=self._session.session_id,
+            tool_name=tool_name,
+            response_content=response_text,
+        )
+        injection_detected = bool(scan.threats)
+        if not scan.allowed:
+            async with self._session.mutation_lock:
+                self._session.update_from_inspection(
+                    call_id=call_id,
+                    sensitivity_tags=[entry.sensitivity_level],
+                    injection_detected=injection_detected,
+                    response_allowed=False,
+                )
+            threat_categories = ",".join(
+                sorted({str(t.get("category", "unknown")) for t in scan.threats})
+            )
+            self._audit.append(
+                "tool_call",
+                call_id=call_id,
+                tool_name=tool_name,
+                server_identity=entry.server.url,
+                policy_decision="deny",
+                policy_rule_matched=f"response_scan:{threat_categories[:200]}",
+                request_payload_hash=request_payload_hash,
+                response_inspection_result="injection_detected",
+                session_sensitivity_before=sensitivity_before,
+                session_sensitivity_after=self._session.max_sensitivity,
+                workflow_id=workflow_id,
+            )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._record_call(
+                tool_name=tool_name,
+                called_at=called_at,
+                duration_ms=elapsed_ms,
+                allowed=False,
+                sensitivity_before=sensitivity_before,
+                stage_results={"response_scan": "deny"},
+                call_id=call_id,
+                catalog_entry=entry,
+                policy_decision="deny",
+            )
+            return CallResult(
+                call_id=call_id,
+                tool_name=tool_name,
+                allowed=False,
+                would_have_denied=would_have_denied,
+                response=None,
+                deny_reason="response_blocked_by_scanner",
+                latency_us=int(elapsed_ms * 1000),
+                audit_entry_hash=self._audit.chain_tip,
+            )
+        # Scanner may have sanitized the content (ResponsePolicy.SANITIZE).
+        agt_result: str = scan.content if scan.content is not None else response_text
+
         # Step 4: session update from response sensitivity
         # AUTH-002: lock protects against race with concurrent session reset requests.
-        response_sensitivity = getattr(agt_result, "sensitivity_tags", [])
-        injection_detected = getattr(agt_result, "injection_detected", False)
-        # INJECT-003: capture scanner attribution and matched pattern for audit chain detail
-        injection_scanner = getattr(agt_result, "injection_scanner", None)
-        injection_pattern = getattr(agt_result, "matched_pattern", None) or getattr(
-            agt_result, "injection_pattern", None
+        # Sensitivity comes from the attested catalog entry's declared level.
+        response_sensitivity = [entry.sensitivity_level]
+        injection_scanner = "agt_response_scanner" if injection_detected else None
+        injection_pattern = (
+            ",".join(sorted({str(t.get("category", "unknown")) for t in scan.threats}))
+            if injection_detected
+            else None
         )
-        # INJECT-007: capture threshold so audit consumers can replay the decision
-        injection_threshold = getattr(agt_result, "injection_threshold", None)
+        injection_threshold = None
         async with self._session.mutation_lock:
             self._session.update_from_inspection(
                 call_id=call_id,
-                sensitivity_tags=response_sensitivity or [entry.sensitivity_level],
+                sensitivity_tags=response_sensitivity,
                 injection_detected=injection_detected,
                 response_allowed=True,
             )
 
         # Step 5: egress Cedar policy check
-        # Derive response bytes for size accounting and egress evaluation.
-        # Prefer a bytes-typed modified_response (Stage 2 redaction output);
-        # fall back to str() so we never block on an un-serialisable AGT object.
-        modified = getattr(agt_result, "modified_response", None)
-        if isinstance(modified, bytes):
-            response_bytes: bytes = modified
-        else:
-            response_bytes = str(agt_result).encode()
+        response_bytes: bytes = agt_result.encode()
 
         try:
             egress_decision = self._policy.authorize_egress(
-                tool_name, response_bytes, self._session
+                tool_name, response_bytes, self._session, workflow_id=workflow_id
             )
             egress_would_deny = egress_decision.would_have_denied
+            egress_advice = egress_decision.advice
         except PolicyDeny as exc:
             egress_deny_reason = str(exc)
             self._audit.append(
@@ -490,10 +721,12 @@ class CMCPProxy:
                 deny_reason=egress_deny_reason,
                 latency_us=int((time.perf_counter() - t0) * 1_000_000),
                 audit_entry_hash=self._audit.chain_tip,
+                advice=exc.advice or None,
             )
 
         # Merge egress advisory flag into the overall would_have_denied
         would_have_denied = would_have_denied or egress_would_deny
+        advisory_advice = {**ingress_advice, **egress_advice}
 
         # Step 6: audit chain write
         policy_decision: Any = "advisory_deny" if would_have_denied else "allow"
@@ -548,4 +781,5 @@ class CMCPProxy:
             deny_reason=None,
             latency_us=latency_us,
             audit_entry_hash=self._audit.chain_tip,
+            advice=advisory_advice or None,
         )

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -313,8 +313,9 @@ class MCPServer:
             )
 
         if not result.allowed:
+            deny_reason = result.deny_reason or ""
             # Upstream transport/tool failure is a 502, not a policy deny.
-            if (result.deny_reason or "").startswith("upstream_error:"):
+            if deny_reason.startswith("upstream_error:"):
                 return JSONResponse(
                     {
                         "jsonrpc": "2.0",
@@ -322,7 +323,7 @@ class MCPServer:
                             "code": -32000,
                             "message": "Upstream MCP server error",
                             "data": {
-                                "error_code": result.deny_reason.removeprefix("upstream_error:"),
+                                "error_code": deny_reason.removeprefix("upstream_error:"),
                                 "call_id": call_id,
                             },
                         },

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -1,5 +1,5 @@
 """
-HTTP/SSE MCP server — inbound agent-facing endpoint (issue #48).
+HTTP/SSE MCP server - inbound agent-facing endpoint (issue #48).
 
 Receives MCP JSON-RPC 2.0 calls from agent hosts, routes them through
 CMCPProxy, and returns results. Uses AGT's StatelessKernel for execution
@@ -153,6 +153,9 @@ class MCPServer:
         self._session = session
         self._max_request_bytes = max_request_bytes
         self._audit = audit_chain
+        # Chains of closed sessions, kept so /audit/export still serves them
+        # after the live session rotates.
+        self._closed_chains: dict[str, AuditChain] = {}
         self._kernel = StatelessKernel()
         # NET-002: rate-limit unauthenticated /health before auth middleware runs.
         # Starlette applies middleware outermost-first (first in list = first to run).
@@ -186,6 +189,11 @@ class MCPServer:
                 Route(
                     "/sessions/{session_id}/reset",
                     self._session_reset,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/sessions/{session_id}/close",
+                    self._session_close,
                     methods=["POST"],
                 ),
                 Route("/catalog/exception", self._catalog_exception, methods=["POST"]),
@@ -276,11 +284,16 @@ class MCPServer:
     async def _handle_tool_call(self, rpc_id: Any, params: dict[str, Any]) -> Response:
         """Route a tools/call request through the proxy."""
         # POLICY-002: canonicalize tool names at ingress so Cedar policy, catalog, and
-        # request all use the same case — prevents case-variant bypass of deny rules.
+        # request all use the same case - prevents case-variant bypass of deny rules.
         tool_name: str = params.get("name", "").lower()
         arguments: dict[str, Any] = params.get("arguments", {})
         call_id = str(uuid.uuid4())
-        workflow_id: str | None = params.get("_cmcp", {}).get("workflow_id")
+        # A malformed _cmcp (string, list, number) must not 500 the call path.
+        cmcp_params = params.get("_cmcp")
+        if not isinstance(cmcp_params, dict):
+            cmcp_params = {}
+        raw_workflow = cmcp_params.get("workflow_id")
+        workflow_id: str | None = raw_workflow if isinstance(raw_workflow, str) else None
 
         try:
             result = await self._proxy.call_tool(call_id, tool_name, arguments, workflow_id=workflow_id)
@@ -300,6 +313,23 @@ class MCPServer:
             )
 
         if not result.allowed:
+            # Upstream transport/tool failure is a 502, not a policy deny.
+            if (result.deny_reason or "").startswith("upstream_error:"):
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32000,
+                            "message": "Upstream MCP server error",
+                            "data": {
+                                "error_code": result.deny_reason.removeprefix("upstream_error:"),
+                                "call_id": call_id,
+                            },
+                        },
+                        "id": rpc_id,
+                    },
+                    status_code=502,
+                )
             _HEALTH_REASONS = {"attestation_stale", "catalog_drift"}
             if result.deny_reason in _HEALTH_REASONS:
                 return JSONResponse(
@@ -327,16 +357,22 @@ class MCPServer:
                 "POLICY_DENY: call_id=%s error_code=%s reason=%s",
                 call_id, error_code, result.deny_reason,
             )
+            error_data: dict[str, Any] = {
+                "error_code": error_code,
+                "call_id": call_id,
+            }
+            # Advice annotations come from the hash-pinned policy bundle
+            # (operator-authored, not caller input), so reflecting them does
+            # not violate INJECT-003. They carry e.g. HITL escalation payloads.
+            if result.advice:
+                error_data["advice"] = result.advice
             return JSONResponse(
                 {
                     "jsonrpc": "2.0",
                     "error": {
                         "code": -32000,
                         "message": "Request denied by policy",
-                        "data": {
-                            "error_code": error_code,
-                            "call_id": call_id,
-                        },
+                        "data": error_data,
                     },
                     "id": rpc_id,
                 },
@@ -349,6 +385,10 @@ class MCPServer:
             "would_have_denied": result.would_have_denied,
             "latency_us": result.latency_us,
         }
+        if self._session is not None:
+            cmcp_meta["session_id"] = self._session.session_id
+        if result.would_have_denied and result.advice:
+            cmcp_meta["advice"] = result.advice
         if workflow_id is not None:
             cmcp_meta["workflow_id"] = workflow_id
         return JSONResponse({
@@ -421,7 +461,7 @@ class MCPServer:
         return JSONResponse({"status": status, "checks": checks}, status_code=503 if not_ready else 200)
 
     async def _get_trace_claim(self, request: Request) -> Response:
-        """GET /sessions/{session_id}/trace-claim — returns signed TRACE Claim for a closed session."""
+        """GET /sessions/{session_id}/trace-claim - returns signed TRACE Claim for a closed session."""
         if self._session_manager is None:
             return JSONResponse(
                 {"error": "session management not available"}, status_code=501
@@ -436,7 +476,7 @@ class MCPServer:
         return JSONResponse(claim)
 
     async def _audit_export(self, request: Request) -> Response:
-        """GET /audit/export?session_id=<id> — returns signed audit bundle."""
+        """GET /audit/export?session_id=<id> - returns signed audit bundle."""
         if self._session_manager is None or self._audit_chain is None:
             return JSONResponse(
                 {"error": "audit export not available"}, status_code=501
@@ -447,10 +487,10 @@ class MCPServer:
                 {"error": "query parameter 'session_id' is required"},
                 status_code=400,
             )
+        # Closed sessions keep their chain available for export after rotation.
+        chain = self._closed_chains.get(session_id, self._audit_chain)
         try:
-            bundle = self._session_manager.get_audit_bundle(
-                session_id, self._audit_chain
-            )
+            bundle = self._session_manager.get_audit_bundle(session_id, chain)
         except ValueError as exc:
             logger.error(
                 "Audit chain integrity failure: session_id=%s error=%s",
@@ -462,8 +502,52 @@ class MCPServer:
             )
         return JSONResponse(bundle)
 
+    async def _session_close(self, request: Request) -> Response:
+        """POST /sessions/{session_id}/close - close the session, return its signed TRACE Claim.
+
+        Appends the session_end audit entry, signs the claim, then rotates the
+        gateway onto a fresh session so subsequent tool calls keep working.
+        The closed session's claim stays available at
+        GET /sessions/{session_id}/trace-claim and its audit bundle at
+        GET /audit/export?session_id=<id>.
+        """
+        if (
+            self._session_manager is None
+            or self._session is None
+            or self._audit_chain is None
+        ):
+            return JSONResponse(
+                {"error": "session management not available"}, status_code=501
+            )
+        session_id: str = request.path_params["session_id"]
+        if session_id != self._session.session_id:
+            return JSONResponse(
+                {"error": f"unknown or already closed session_id={session_id}"},
+                status_code=404,
+            )
+
+        claim = self._session_manager.close_session(
+            session_id,
+            self._session,
+            self._audit_chain,
+            call_log=getattr(self._proxy, "_call_log", None),
+            session_call_log=getattr(self._proxy, "_session_call_log", None),
+        )
+        self._closed_chains[session_id] = self._audit_chain
+
+        # Rotate onto a fresh session so the gateway keeps serving.
+        new_session, new_chain = self._session_manager.create_session()
+        self._session = new_session
+        self._audit_chain = new_chain
+        self._audit = new_chain
+        self._proxy.rebind_session(new_session, new_chain)
+        logger.info(
+            "Session closed via API: closed=%s new=%s", session_id, new_session.session_id
+        )
+        return JSONResponse(claim)
+
     async def _catalog_exception(self, request: Request) -> Response:
-        """POST /catalog/exception — add a break-glass catalog exception at runtime.
+        """POST /catalog/exception - add a break-glass catalog exception at runtime.
 
         The exception is visible in the TRACE Claim but does NOT modify catalog_hash.
         Requires the same bearer token as all other operator endpoints.
@@ -567,7 +651,7 @@ class MCPServer:
         )
 
     async def _session_reset(self, request: Request) -> Response:
-        """POST /sessions/{session_id}/reset — operator-only session sensitivity reset."""
+        """POST /sessions/{session_id}/reset - operator-only session sensitivity reset."""
         if self._session is None or self._audit_chain is None:
             return JSONResponse(
                 {"error": "session management not configured"}, status_code=501
@@ -579,6 +663,10 @@ class MCPServer:
             )
         # AUTH-002: lock guards against a concurrent tool-call coroutine modifying sensitivity.
         async with self._session.mutation_lock:
+            # Capture the pre-reset sensitivity: reset() drops it back to
+            # "public", and the elevated value the session held at reset time
+            # is exactly the forensic detail the audit entry must preserve.
+            sensitivity_before = self._session.max_sensitivity
             old_id, new_id = self._session.reset(
                 reason="operator reset via API",
                 authorized_by="api",
@@ -588,7 +676,7 @@ class MCPServer:
             call_id=None,
             tool_name=None,
             policy_decision="n/a",
-            session_sensitivity_before=self._session.max_sensitivity,
+            session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
         )
         return JSONResponse({

--- a/src/cmcp_runtime/policy/annotations.py
+++ b/src/cmcp_runtime/policy/annotations.py
@@ -1,0 +1,82 @@
+"""
+Cedar policy annotation extraction.
+
+Cedar has no first-class "advice" construct: annotations (``@key("value")``)
+attached to a policy are the supported way to carry structured metadata such
+as HITL escalation instructions. cedarpy reports which policies determined a
+decision (``diagnostics.reasons`` as implicit ids ``policy0``, ``policy1``,
+... in source order) but only surfaces the ``@id`` annotation value, so the
+full annotation set must be recovered from the policy source.
+
+This module parses annotations from a combined Cedar policy string, keyed by
+the same implicit ids cedarpy assigns, so a deny decision can be mapped back
+to the matched policies' annotations.
+"""
+
+from __future__ import annotations
+
+import re
+
+# @key("value") - value may contain escaped quotes/backslashes.
+_ANNOTATION_RE = re.compile(
+    r'@([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*"((?:[^"\\]|\\.)*)"\s*\)'
+)
+
+# A policy statement: zero or more annotations followed by permit/forbid.
+# Matched against comment-stripped source, in order, so the Nth match is
+# cedarpy's implicit id "policyN".
+_POLICY_RE = re.compile(
+    r'((?:@[A-Za-z_][A-Za-z0-9_]*\s*\(\s*"(?:[^"\\]|\\.)*"\s*\)\s*)*)'
+    r"\b(permit|forbid)\s*\("
+)
+
+
+def _strip_line_comments(text: str) -> str:
+    """Remove ``// ...`` comments, ignoring ``//`` inside string literals."""
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        in_string = False
+        escaped = False
+        cut = len(line)
+        for i, ch in enumerate(line):
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\" and in_string:
+                escaped = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if ch == "/" and not in_string and line[i : i + 2] == "//":
+                cut = i
+                break
+        out_lines.append(line[:cut])
+    return "\n".join(out_lines)
+
+
+def _unescape(value: str) -> str:
+    return value.replace('\\"', '"').replace("\\\\", "\\")
+
+
+def parse_policy_annotations(policy_text: str) -> dict[str, dict[str, str]]:
+    """
+    Map implicit Cedar policy ids to their annotations.
+
+    Returns ``{"policy0": {"reason": "...", ...}, "policy2": {...}}``; policies
+    without annotations are omitted. Ordering follows statement order in the
+    source, matching the ids cedarpy assigns when parsing the same string.
+    """
+    stripped = _strip_line_comments(policy_text)
+    annotations: dict[str, dict[str, str]] = {}
+    for index, match in enumerate(_POLICY_RE.finditer(stripped)):
+        block = match.group(1)
+        if not block:
+            continue
+        parsed = {
+            key: _unescape(value)
+            for key, value in _ANNOTATION_RE.findall(block)
+        }
+        if parsed:
+            annotations[f"policy{index}"] = parsed
+    return annotations

--- a/src/cmcp_runtime/policy/evaluator.py
+++ b/src/cmcp_runtime/policy/evaluator.py
@@ -1,5 +1,5 @@
 """
-Cedar policy evaluation via AGT's CedarBackend — implements issues #68, #73.
+Cedar policy evaluation via AGT's CedarBackend - implements issues #68, #73.
 
 AGT provides three evaluation modes: cedarpy (native Python), cli (subprocess),
 and builtin (mock). cMCP selects the best available mode at instantiation and
@@ -16,6 +16,7 @@ from agent_os.policies.backends import CedarBackend
 
 from cmcp_runtime.config import Config, EnforcementMode
 from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.policy.annotations import parse_policy_annotations
 from cmcp_runtime.policy.bundle import PolicyBundle, PolicyStore
 from cmcp_runtime.session.state import SENSITIVITY_ORDER
 
@@ -73,6 +74,8 @@ class PolicyEvaluator:
             policy_content=combined_policy,
             mode="auto",  # cedarpy > cli > builtin
         )
+        self._combined_policy = combined_policy
+        self._annotations = parse_policy_annotations(combined_policy)
         logger.info(
             "PolicyEvaluator ready: bundle_hash=%s enforcement=%s backend=%s",
             initial_bundle.bundle_hash,
@@ -89,8 +92,44 @@ class PolicyEvaluator:
                 content for _, content in sorted(bundle.policy_files.items())
             )
             self._backend = CedarBackend(policy_content=combined_policy, mode="auto")
+            self._combined_policy = combined_policy
+            self._annotations = parse_policy_annotations(combined_policy)
             self._current_hash = bundle.bundle_hash
             logger.info("PolicyEvaluator backend refreshed: new_hash=%s", self._current_hash)
+
+    def _advice_for_deny(self, context: dict[str, Any]) -> dict[str, str]:
+        """
+        Best-effort: recover the annotations of the forbid policies that caused
+        a deny, to return as structured advice (e.g. HITL escalation payloads).
+
+        AGT's CedarBackend does not expose cedarpy's diagnostics.reasons, so
+        this re-evaluates the same request directly with cedarpy purely for
+        diagnostics - the authorization decision itself is never taken from
+        here. Runs only on the deny path; returns {} on any failure.
+        """
+        if not self._annotations:
+            return {}
+        try:
+            import cedarpy
+
+            request = self._backend._build_cedar_request(context)
+            response = cedarpy.is_authorized(
+                request={
+                    "principal": request["principal"],
+                    "action": request["action"],
+                    "resource": request["resource"],
+                    "context": request.get("context", {}),
+                },
+                policies=self._combined_policy,
+                entities=getattr(self._backend, "_entities", []),
+            )
+            advice: dict[str, str] = {}
+            for policy_id in response.diagnostics.reasons:
+                advice.update(self._annotations.get(policy_id, {}))
+            return advice
+        except Exception:
+            logger.debug("Advice extraction failed", exc_info=True)
+            return {}
 
     def evaluate(self, context: dict[str, Any]) -> PolicyDecision:
         """
@@ -121,11 +160,15 @@ class PolicyEvaluator:
                 evaluation_ms=evaluation_ms,
             )
 
-        # Cedar denied — apply enforcement mode
+        # Cedar denied - recover advice annotations from the matched policies,
+        # then apply enforcement mode.
+        advice = self._advice_for_deny(context)
+
         if self._mode == EnforcementMode.ENFORCING:
             raise PolicyDeny(
                 f"Policy denied tool call: {context.get('tool_name', '?')}",
                 detail=f"rule={rule} eval_ms={evaluation_ms:.2f}",
+                advice=advice,
             )
 
         if self._mode == EnforcementMode.ADVISORY:
@@ -137,17 +180,17 @@ class PolicyEvaluator:
                 allowed=True,
                 enforcement_mode=self._mode,
                 rule_matched=rule,
-                advice={},
+                advice=advice,
                 evaluation_ms=evaluation_ms,
                 would_have_denied=True,
             )
 
-        # SILENT mode — allow, no log
+        # SILENT mode - allow, no log
         return PolicyDecision(
             allowed=True,
             enforcement_mode=self._mode,
             rule_matched=rule,
-            advice={},
+            advice=advice,
             evaluation_ms=evaluation_ms,
             would_have_denied=True,
         )
@@ -157,6 +200,7 @@ class PolicyEvaluator:
         tool_name: str,
         response_bytes: bytes,
         session: SessionState,
+        workflow_id: str | None = None,
     ) -> PolicyDecision:
         """
         Evaluate Cedar egress policies after a tool response is received.
@@ -164,6 +208,10 @@ class PolicyEvaluator:
         Uses the same CedarBackend as ingress evaluation but passes egress-specific
         context fields so Cedar policies can distinguish direction.  The principal
         and action are implicit in the context dict the backend receives.
+
+        workflow_id carries the same call identity as the ingress evaluation:
+        without it, workflow-scoped permits (default-deny bundles with no
+        catch-all) can never match at egress and every response would be denied.
 
         Returns PolicyDecision(allowed=True/False, ...).  In ENFORCING mode a deny
         raises PolicyDeny; in ADVISORY/SILENT a deny is flagged via would_have_denied.
@@ -177,6 +225,8 @@ class PolicyEvaluator:
             "reset_count": session.reset_count,
             "response_size_bytes": len(response_bytes),
         }
+        if workflow_id is not None:
+            context["workflow_id"] = workflow_id
         return self.evaluate(context)
 
     @property

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -1,4 +1,4 @@
-"""Session lifecycle management — implements issues #60 and #55."""
+"""Session lifecycle management - implements issues #60 and #55."""
 
 from __future__ import annotations
 
@@ -56,7 +56,7 @@ class SessionManager:
         the root into hardware-attested evidence so an attacker cannot silently
         swap out the chain and pass verify_chain().  In dev / Level-0 mode
         (software-only provider) the anchor is still set so that verify_chain()
-        performs the root comparison — the security guarantee is limited to what
+        performs the root comparison - the security guarantee is limited to what
         a software TEE provides, and a warning is emitted.
         """
         session_id = str(uuid4())
@@ -73,7 +73,7 @@ class SessionManager:
 
         try:
             self._ctx.tee_provider.get_attestation_report(nonce)
-            # The report itself is not stored here — the startup-time report in
+            # The report itself is not stored here - the startup-time report in
             # ctx.attestation_report already covers the gateway instance.  What
             # matters is that the nonce (containing chain_root) was submitted to
             # the TEE, making chain_root part of the attested evidence.
@@ -82,7 +82,7 @@ class SessionManager:
             # internal chain-substitution detection works.  In production,
             # callers should validate that the TEE provider is not software-only.
             logger.warning(
-                "AUDIT-002: per-session TEE attestation call failed — "
+                "AUDIT-002: per-session TEE attestation call failed - "
                 "chain root is not hardware-anchored. session_id=%s error=%s",
                 session_id,
                 exc,

--- a/src/cmcp_runtime/startup.py
+++ b/src/cmcp_runtime/startup.py
@@ -1,4 +1,4 @@
-"""Gateway startup sequence with fail-closed validation — implements issue #66."""
+"""Gateway startup sequence with fail-closed validation - implements issue #66."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 # HW-001: allowlist of canonical TEE provider names that may appear in
 # AttestationReport.provider.  Mirrors the keys of _PROVIDER_MAP in
-# audit/trace_claim.py — kept as a local constant to avoid a circular import.
+# audit/trace_claim.py - kept as a local constant to avoid a circular import.
 _VALID_PROVIDERS: frozenset[str] = frozenset({
     "sev-snp",
     "tdx",
@@ -68,7 +68,7 @@ def _fatal(code: str, message: str, **fields: Any) -> None:
 def run_startup(config_path: str) -> RuntimeContext:
     """
     Execute the ordered startup sequence. Any failure before step 6 (network bind)
-    is fatal — the gateway exits with code 1.
+    is fatal - the gateway exits with code 1.
 
     Startup order per docs/spec/failure-modes.md:
     1. Load and validate config
@@ -76,7 +76,7 @@ def run_startup(config_path: str) -> RuntimeContext:
     3. Generate ephemeral signing keypair
     4. Load and verify policy bundle hash
     5. Load and verify catalog hash
-    (Step 6: bind network port — done by the caller after this returns)
+    (Step 6: bind network port - done by the caller after this returns)
     """
     # Step 1: config
     try:
@@ -235,7 +235,7 @@ def run_startup(config_path: str) -> RuntimeContext:
         catalog.catalog_hash,
     )
 
-    # Step 5b: SPIFFE/SPIRE SVID fetch (non-fatal — falls back to self-signed TLS)
+    # Step 5b: SPIFFE/SPIRE SVID fetch (non-fatal - falls back to self-signed TLS)
     # SVID issuance is conditioned on TEE attestation succeeding (handled by the
     # SPIRE node attestation plugin on the SPIRE server side).
     spiffe_result = fetch_svid()
@@ -246,7 +246,7 @@ def run_startup(config_path: str) -> RuntimeContext:
         )
     else:
         logger.warning(
-            "SPIFFE SVID not available (%s) — gateway will use self-signed TLS for mTLS",
+            "SPIFFE SVID not available (%s) - gateway will use self-signed TLS for mTLS",
             spiffe_result.failure_reason,
         )
 
@@ -261,7 +261,7 @@ def run_startup(config_path: str) -> RuntimeContext:
         orphaned = audit_store.find_orphaned_sessions()
         if orphaned:
             logger.warning(
-                "AUDIT-001: %d session(s) have no session_end entry in the audit DB — "
+                "AUDIT-001: %d session(s) have no session_end entry in the audit DB - "
                 "gateway may have restarted mid-session. Orphaned session IDs: %s",
                 len(orphaned),
                 orphaned,

--- a/src/cmcp_verify/__init__.py
+++ b/src/cmcp_verify/__init__.py
@@ -1,18 +1,22 @@
-"""cmcp-verify — verify cMCP Runtime TRACE Claims without trusting the operator."""
+"""cmcp-verify - verify cMCP Runtime TRACE Claims without trusting the operator."""
 
 from cmcp_verify.verify import (
     ApprovedHashes,
+    AuditBundleResult,
     VerificationError,
     VerificationResult,
     VerificationStatus,
+    verify_audit_bundle,
     verify_trace_claim,
 )
 
 __version__ = "0.1.0"
 __all__ = [
     "ApprovedHashes",
+    "AuditBundleResult",
     "VerificationError",
     "VerificationResult",
     "VerificationStatus",
+    "verify_audit_bundle",
     "verify_trace_claim",
 ]

--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -63,6 +63,9 @@ def verify_opaque_measurement(
         return result
 
     if raw_evidence is None:
+        # Fail closed: an attestation claim with no evidence cannot verify.
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["opaque_endpoint"] = endpoint
         result.details["hint"] = "raw_evidence not provided; cannot verify with Opaque"
@@ -89,7 +92,7 @@ def verify_opaque_measurement(
             method="POST",
             headers=request_headers,
         )
-        with urllib.request.urlopen(req, timeout=_OPAQUE_TIMEOUT_SECONDS) as resp:  # nosec B310 — req is a Request object with explicit HTTPS endpoint
+        with urllib.request.urlopen(req, timeout=_OPAQUE_TIMEOUT_SECONDS) as resp:  # nosec B310 - req is a Request object with explicit HTTPS endpoint
             body = json.loads(resp.read().decode())
 
         if body.get("verified") is True:

--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -97,8 +97,17 @@ def verify_sev_snp_measurement(
         result.details["vcek_chain"] = "requires_amd_kds_lookup"
         return result
 
-    # Step 2: Parse raw_evidence if provided
-    if raw_evidence is not None and len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory - a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(["measurement", "vcek_cert_chain"])
+        result.details["raw_evidence"] = "not provided; SNP report cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-006)
             report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
@@ -142,7 +151,7 @@ def verify_sev_snp_measurement(
             result.details["vcek_chain"] = "requires_amd_kds_lookup"
             return result
 
-    elif raw_evidence is not None and len(raw_evidence) < _SNP_REPORT_MIN_SIZE:
+    else:
         # Truncated report -- treat as parse error
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tdx.py
+++ b/src/cmcp_verify/tdx.py
@@ -58,7 +58,7 @@ def _check_dcap_reachable() -> bool:
             method="GET",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=_DCAP_TIMEOUT_SECONDS) as resp:  # nosec B310 — req is a Request object with explicit HTTPS DCAP URL
+        with urllib.request.urlopen(req, timeout=_DCAP_TIMEOUT_SECONDS) as resp:  # nosec B310 - req is a Request object with explicit HTTPS DCAP URL
             return resp.status == 200
     except Exception:  # noqa: BLE001
         return False
@@ -98,8 +98,19 @@ def verify_tdx_measurement(
         result.details["dcap_chain"] = "requires_intel_dcap_service"
         return result
 
-    # Step 2: Parse TDREPORT if provided
-    if raw_evidence is not None and len(raw_evidence) >= _TDREPORT_MIN_SIZE:
+    # Step 2: raw evidence is mandatory - a claim asserting a hardware
+    # platform with no evidence to check must fail closed, not pass on
+    # string-format checks alone.
+    if raw_evidence is None:
+        result.verified = False
+        result.failure_reason = "no_raw_evidence"
+        result.unverified_fields.extend(
+            ["measurement", "dcap_quote_signature", "tcb_status"]
+        )
+        result.details["raw_evidence"] = "not provided; TDREPORT cannot be checked"
+        return result
+
+    if len(raw_evidence) >= _TDREPORT_MIN_SIZE:
         try:
             # Parse via ctypes struct for named field access (HW-007)
             tdreport = _TdReport.from_buffer_copy(raw_evidence[:_TDREPORT_MIN_SIZE])
@@ -135,7 +146,7 @@ def verify_tdx_measurement(
             result.details["dcap_chain"] = "requires_intel_dcap_service"
             return result
 
-    elif raw_evidence is not None:
+    else:
         # Truncated evidence
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/tpm.py
+++ b/src/cmcp_verify/tpm.py
@@ -1,4 +1,4 @@
-"""TPM 2.0 attestation verification — implements issue #62."""
+"""TPM 2.0 attestation verification - implements issue #62."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ class TPMVerificationResult:
     details: dict[str, str] = field(default_factory=dict)
 
 
-# TPMS_ATTEST magic constant (FF 54 43 47 — "TPM generated")
+# TPMS_ATTEST magic constant (FF 54 43 47 - "TPM generated")
 _TPM_GENERATED_VALUE = 0xFF544347
 
 
@@ -38,7 +38,7 @@ def verify_tpm_measurement(
     - PCR digest in quote matches measurement field
 
     EK cert chain validation: always marked as unverified_fields (requires
-    manufacturer CA lookup — out of scope for Phase 1).
+    manufacturer CA lookup - out of scope for Phase 1).
     """
     verified_fields: list[str] = []
     unverified_fields: list[str] = []
@@ -86,23 +86,30 @@ def verify_tpm_measurement(
             unverified_fields.append("qualifying_data")
             details["tpm_parse_error"] = parse_details.get("error", "failed to parse TPM2B_ATTEST")
     else:
-        # No raw evidence — cannot verify PCR digest or qualifying data
-        unverified_fields.append("pcr_digest")
-        unverified_fields.append("qualifying_data")
+        # No raw evidence - a claim asserting a hardware platform with no
+        # evidence to check must fail closed, not pass on format checks alone.
+        unverified_fields.extend(["pcr_digest", "qualifying_data", "ek_cert_chain"])
         details["pcr_digest_note"] = "raw_evidence not provided; PCR digest unverifiable"
+        return TPMVerificationResult(
+            verified=False,
+            verified_fields=verified_fields,
+            unverified_fields=unverified_fields,
+            failure_reason="no_raw_evidence",
+            details=details,
+        )
 
     # Step 3: EK cert chain always unverified in Phase 1
     unverified_fields.append("ek_cert_chain")
     details["ek_cert_chain_validation"] = "ek_cert_chain_validation_requires_ca_lookup"
 
-    # verified=True if we have at least measurement_format and no parse failures
+    # verified=True only when the evidence parsed and matched
     verified = "measurement_format" in verified_fields and "pcr_format" not in unverified_fields
 
     return TPMVerificationResult(
         verified=verified,
         verified_fields=verified_fields,
         unverified_fields=unverified_fields,
-        failure_reason=None,
+        failure_reason=None if verified else "tpm_evidence_check_failed",
         details=details,
     )
 
@@ -132,7 +139,7 @@ def _parse_tpm2b_attest(
     Parse a TPM2B_ATTEST blob and verify qualifying_data if keys are provided.
 
     TPM2B_ATTEST layout:
-      [0:2]  size (uint16 big-endian) — size of the following TPMS_ATTEST
+      [0:2]  size (uint16 big-endian) - size of the following TPMS_ATTEST
       [2:]   TPMS_ATTEST
 
     TPMS_ATTEST layout (big-endian):

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -36,7 +36,22 @@ _KNOWN_PLATFORMS = {
     "aws-nitro",
     "arm-cca",
     "google-confidential-space",
+    "software-only",
 }
+
+
+def _is_software_only(runtime: dict[str, Any]) -> bool:
+    """True for dev-mode (non-attested) records.
+
+    Current records use platform "software-only"; records produced before
+    that value existed used platform "tpm2" with the dev firmware sentinel.
+    """
+    if runtime.get("platform") == "software-only":
+        return True
+    return (
+        runtime.get("platform") == "tpm2"
+        and runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
+    )
 
 
 class VerificationStatus(StrEnum):
@@ -54,6 +69,7 @@ class VerificationError(StrEnum):
     ATTESTATION_STALE = "ATTESTATION_STALE"
     CHAIN_BROKEN = "CHAIN_BROKEN"
     CLAIM_MALFORMED = "CLAIM_MALFORMED"
+    HARDWARE_ATTESTATION_FAILED = "HARDWARE_ATTESTATION_FAILED"
 
 
 @dataclass
@@ -236,6 +252,86 @@ def _validate_schema(claim: dict[str, Any]) -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+@dataclass
+class AuditBundleResult:
+    """Outcome of verifying an exported audit bundle against a claim."""
+
+    verified: bool
+    entry_count: int
+    failures: list[str] = field(default_factory=list)
+
+
+def verify_audit_bundle(
+    bundle_json: dict[str, Any],
+    claim_json: dict[str, Any] | None = None,
+) -> AuditBundleResult:
+    """
+    Verify an exported audit bundle (GET /audit/export):
+
+    1. Recompute every entry hash from its canonical body and check the
+       prev_entry_hash linkage from "genesis" to the tip.
+    2. If a claim is provided, cross-check the bundle's root/tip/length
+       against gateway.audit_chain and verify the bundle_signature with the
+       claim's confirmation key (trace.cnf.jwk.x).
+    """
+    failures: list[str] = []
+    entries = bundle_json.get("entries", [])
+    if not entries:
+        return AuditBundleResult(verified=False, entry_count=0, failures=["bundle has no entries"])
+
+    prev = "genesis"
+    for i, entry in enumerate(entries):
+        body = {k: v for k, v in entry.items() if k != "entry_hash"}
+        recomputed = hashlib.sha256(
+            json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        ).hexdigest()
+        if recomputed != entry.get("entry_hash"):
+            failures.append(f"entry {i}: hash mismatch (content altered)")
+        if entry.get("prev_entry_hash") != prev:
+            failures.append(f"entry {i}: chain link broken")
+        prev = entry.get("entry_hash", "")
+
+    if claim_json is not None:
+        chain = claim_json.get("gateway", {}).get("audit_chain", {})
+        if chain.get("root") != entries[0].get("entry_hash"):
+            failures.append("bundle root does not match claim gateway.audit_chain.root")
+        if chain.get("tip") != entries[-1].get("entry_hash"):
+            failures.append("bundle tip does not match claim gateway.audit_chain.tip")
+        if chain.get("length") != len(entries):
+            failures.append(
+                f"bundle has {len(entries)} entries, claim says {chain.get('length')}"
+            )
+
+        sig_b64 = bundle_json.get("bundle_signature", "")
+        x_b64 = claim_json.get("trace", {}).get("cnf", {}).get("jwk", {}).get("x", "")
+        if not sig_b64:
+            failures.append("bundle_signature is missing")
+        elif not x_b64:
+            failures.append("claim has no confirmation key to check bundle_signature against")
+        else:
+            try:
+                pad = 4 - (len(x_b64) % 4)
+                pub = Ed25519PublicKey.from_public_bytes(
+                    base64.urlsafe_b64decode(x_b64 + ("=" * pad if pad != 4 else ""))
+                )
+                pad = 4 - (len(sig_b64) % 4)
+                sig = base64.urlsafe_b64decode(sig_b64 + ("=" * pad if pad != 4 else ""))
+                digest = hashlib.sha256(
+                    json.dumps(
+                        entries, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+                    ).encode()
+                ).digest()
+                pub.verify(sig, digest)
+            except InvalidSignature:
+                failures.append("bundle_signature is invalid")
+            except Exception as exc:
+                failures.append(f"bundle_signature could not be checked: {exc}")
+
+    return AuditBundleResult(
+        verified=not failures, entry_count=len(entries), failures=failures
+    )
+
+
 def verify_trace_claim(
     claim_json: dict[str, Any],
     approved: ApprovedHashes,
@@ -304,10 +400,7 @@ def verify_trace_claim(
     # An attacker who substitutes their own keypair cannot forge the TEE-signed nonce,
     # so verification fails even when the Ed25519 signature is self-consistent.
     _runtime = claim_json.get("trace", {}).get("runtime", {})
-    _is_sw_only = (
-        _runtime.get("platform") == "tpm2"
-        and _runtime.get("firmware_version") == _SW_ONLY_FIRMWARE
-    )
+    _is_sw_only = _is_software_only(_runtime)
 
     binding_result, binding_msg = _verify_key_binding(claim_json, is_sw_only=_is_sw_only)
     if binding_result is True:
@@ -382,12 +475,11 @@ def verify_trace_claim(
 
     # Step 7: Platform-specific attestation
     platform = _runtime.get("platform", "")
-    firmware_version = _runtime.get("firmware_version", "")
 
-    if platform == "tpm2" and firmware_version == _SW_ONLY_FIRMWARE:
+    if _is_sw_only:
         unverified.append("hardware_attestation")
-        details["hardware_attestation"] = "software-only mode — not hardware-backed"
-    elif platform == "tpm2" and firmware_version != _SW_ONLY_FIRMWARE:
+        details["hardware_attestation"] = "software-only mode - not hardware-backed"
+    elif platform == "tpm2":
         from cmcp_verify.tpm import verify_tpm_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -403,11 +495,12 @@ def verify_trace_claim(
             verified.extend(tpm_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tpm_result.failure_reason:
                 details["tpm_failure"] = tpm_result.failure_reason
         unverified.extend(tpm_result.unverified_fields)
         details.update(tpm_result.details)
-    elif platform == "sev-snp" and firmware_version != _SW_ONLY_FIRMWARE:
+    elif platform == "amd-sev-snp":
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
         raw_ev = _runtime.get("raw_evidence")
@@ -423,6 +516,7 @@ def verify_trace_claim(
             verified.extend(snp_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if snp_result.failure_reason:
                 details["sev_snp_failure"] = snp_result.failure_reason
         unverified.extend(snp_result.unverified_fields)
@@ -443,6 +537,7 @@ def verify_trace_claim(
             verified.extend(tdx_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if tdx_result.failure_reason:
                 details["tdx_failure"] = tdx_result.failure_reason
         unverified.extend(tdx_result.unverified_fields)
@@ -461,6 +556,7 @@ def verify_trace_claim(
             verified.extend(opaque_result.verified_fields)
         else:
             unverified.append("hardware_attestation")
+            failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
             if opaque_result.failure_reason:
                 details["opaque_failure"] = opaque_result.failure_reason
         unverified.extend(opaque_result.unverified_fields)

--- a/tests/soak/run_soak.py
+++ b/tests/soak/run_soak.py
@@ -1,5 +1,5 @@
 """
-cMCP Runtime 72-hour soak test — implements issue #82.
+cMCP Runtime 72-hour soak test - implements issue #82.
 
 Runs a sustained load against a software-only or hardware-TEE gateway and validates
 all 6 edge cases from docs/testing/soak-test.md.
@@ -144,10 +144,7 @@ def _make_soak_gateway(
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         evaluator = PolicyEvaluator(bundle=bundle, config=config)
 
-    agt_result = MagicMock(
-        sensitivity_tags=[], injection_detected=False,
-        modified_response=b'{"result": "soak-ok"}',
-    )
+    _soak_response = '{"result": "soak-ok"}'
 
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
@@ -160,8 +157,16 @@ def _make_soak_gateway(
             attestation_generated_at=datetime.now(UTC),
             attestation_validity_seconds=attestation_validity_seconds,
         )
+        # Mock the AGT gateway seam + upstream forwarding (new proxy step 3 seam)
         proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=agt_result)
+        proxy._mcp_gateway.intercept_tool_call = MagicMock(return_value=(True, "ok"))
+        proxy._forward_to_upstream = AsyncMock(return_value=_soak_response)
+        proxy._mcp_gateway.intercept_tool_response = MagicMock(return_value=MagicMock(
+            allowed=True,
+            content=_soak_response,
+            threats=[],
+            action="allowed",
+        ))
 
     with patch("cmcp_runtime.mcp.server.StatelessKernel"):
         server = MCPServer(proxy, session=session, audit_chain=chain, bearer_token=bearer_token)
@@ -299,7 +304,7 @@ async def _check_idle_transition(
                 latency,
                 state.baseline_latency_us,
             )
-            # Don't mark as failed — this is expected on connection re-establishment
+            # Don't mark as failed - this is expected on connection re-establishment
     state.total_calls += 1
 
 
@@ -310,7 +315,7 @@ def _check_signing_key(state: SoakState, chain: Any) -> None:
     key_sample = chain.chain_root[:16] if chain.entries else "no-entries"
     if state.signing_key_samples and state.signing_key_samples[-1] != key_sample:
         now = datetime.now(UTC).isoformat()
-        logger.warning("Signing key changed at %s — enclave restart detected", now)
+        logger.warning("Signing key changed at %s - enclave restart detected", now)
         state.signing_key_restart_timestamps.append(now)
         state.signing_key_stable = False
     state.signing_key_samples.append(key_sample)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,40 @@
+"""Shared unit-test helpers for mocking the CMCPProxy gateway seam.
+
+The proxy's step 3 calls three seams:
+  1. _mcp_gateway.intercept_tool_call(agent_id=, tool_name=, params=) -> (bool, str)  [sync]
+  2. proxy._forward_to_upstream(call_id, entry, tool_name, arguments) -> str          [async]
+  3. _mcp_gateway.intercept_tool_response(agent_id=, tool_name=, response_content=)
+     -> object with .allowed (bool), .content (str|None), .threats (list[dict]),
+        .action (str)                                                                  [sync]
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+
+def wire_mock_gateway(
+    proxy,
+    *,
+    response_text: str = "tool response",
+    call_allowed: bool = True,
+    call_reason: str = "ok",
+    scan_allowed: bool = True,
+    threats: list[dict] | None = None,
+    scan_content: str | None = None,
+):
+    """Replace the proxy's AGT gateway + upstream forwarding with mocks."""
+    proxy._mcp_gateway = MagicMock()
+    proxy._mcp_gateway.intercept_tool_call = MagicMock(
+        return_value=(call_allowed, call_reason)
+    )
+    proxy._forward_to_upstream = AsyncMock(return_value=response_text)
+    proxy._mcp_gateway.intercept_tool_response = MagicMock(
+        return_value=MagicMock(
+            allowed=scan_allowed,
+            content=scan_content if scan_content is not None else response_text,
+            threats=threats or [],
+            action="allowed" if scan_allowed else "blocked",
+        )
+    )
+    return proxy

--- a/tests/unit/test_audit_sqlite.py
+++ b/tests/unit/test_audit_sqlite.py
@@ -44,7 +44,7 @@ def test_no_orphans_after_clean_close(store, tmp_path):
 
 def test_orphan_detected_after_crash(store):
     AuditChain(session_id="crash-session", store=store)
-    # No session_end appended — simulates crash
+    # No session_end appended - simulates crash
     orphans = store.find_orphaned_sessions()
     assert "crash-session" in orphans
 

--- a/tests/unit/test_benchmarks.py
+++ b/tests/unit/test_benchmarks.py
@@ -6,8 +6,30 @@ import json
 
 import pytest
 
+from tests.unit.conftest import wire_mock_gateway
 
-def test_benchmark_runs_smoke(tmp_path):
+
+@pytest.fixture
+def benchmark_gateway_seam(monkeypatch):
+    """Rewire the benchmark proxy onto the current gateway seam.
+
+    benchmarks._make_proxy still mocks the removed `_mcp_gateway.call_tool`
+    coroutine; wrap it so the proxy gets the intercept_tool_call /
+    _forward_to_upstream / intercept_tool_response mocks instead.
+    """
+    import cmcp_runtime.benchmarks as benchmarks
+
+    original = benchmarks._make_proxy
+
+    def _patched(bundle, catalog):
+        proxy, evaluator = original(bundle, catalog)
+        wire_mock_gateway(proxy, response_text='{"result": "benchmark-ok"}')
+        return proxy, evaluator
+
+    monkeypatch.setattr(benchmarks, "_make_proxy", _patched)
+
+
+def test_benchmark_runs_smoke(tmp_path, benchmark_gateway_seam):
     """Smoke test: benchmark produces valid JSON output with all required keys."""
     import asyncio
 
@@ -29,7 +51,7 @@ def test_benchmark_runs_smoke(tmp_path):
         assert stats["p99"] >= stats["p95"] >= stats["p50"]
 
 
-def test_benchmark_writes_output_file(tmp_path):
+def test_benchmark_writes_output_file(tmp_path, benchmark_gateway_seam):
     """Benchmark writes a timestamped JSON file to the output directory."""
     import asyncio
 

--- a/tests/unit/test_break_glass.py
+++ b/tests/unit/test_break_glass.py
@@ -19,6 +19,7 @@ from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.mcp.server import MCPServer
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -191,7 +192,7 @@ def test_catalog_exception_endpoint_adds_tools():
 
     resp = client.post("/catalog/exception", json={
         "server_identity": _SI_PAYLOAD,
-        "reason": "P0 incident — fallback server required",
+        "reason": "P0 incident - fallback server required",
         "authorized_by": "on-call@example.com",
         "tool_names": ["emergency.search", "emergency.fetch"],
     })
@@ -333,8 +334,6 @@ def _make_real_proxy_for_break_glass():
         )
     )
 
-    mock_agt_result = MagicMock(sensitivity_tags=[], injection_detected=False, modified_response=b"ok")
-
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(
@@ -344,8 +343,7 @@ def _make_real_proxy_for_break_glass():
             audit_chain=chain,
             config=config,
         )
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=mock_agt_result)
+        wire_mock_gateway(proxy, response_text="ok")
 
     return proxy, chain
 

--- a/tests/unit/test_call_log_integration.py
+++ b/tests/unit/test_call_log_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.call_log import CallLog
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 
 def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
@@ -81,10 +82,7 @@ def _make_proxy(catalog=None, evaluator=None, call_log=None):
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(cat, ev, session, chain, cfg, call_log=call_log)
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
     return proxy, session, chain
 
 
@@ -162,7 +160,7 @@ async def test_suspicious_sequence_writes_audit_entry():
 async def test_no_suspicious_entry_when_below_threshold():
     log = CallLog(session_id="sess-001")
     proxy, session, chain = _make_proxy(call_log=log)
-    # 3 calls: at threshold but not over — not suspicious
+    # 3 calls: at threshold but not over - not suspicious
     for i in range(3):
         await proxy.call_tool(f"c{i}", "test.tool", {})
     suspicious_entries = [

--- a/tests/unit/test_cli_wiring.py
+++ b/tests/unit/test_cli_wiring.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for cli.build_server() - the production composition path.
+
+These exist because the previous cli.start() body constructed MCPServer without
+the bearer token (AUTH-001 dead in production), built AuditChain without the
+SQLite store and TEE anchor (AUDIT-001/AUDIT-002 inert), and never passed
+attestation timestamps to the proxy (staleness check dead). Unit tests that
+construct MCPServer directly cannot catch wiring gaps in the entrypoint.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from cmcp_runtime.audit.store import SqliteAuditStore
+from cmcp_runtime.cli import build_server
+from cmcp_runtime.config import AttestationConfig, Config
+from cmcp_runtime.policy.bundle import PolicyStore
+from cmcp_runtime.startup import RuntimeContext
+
+BEARER = "test-secret-token"
+
+
+@pytest.fixture
+def ctx(tmp_path) -> RuntimeContext:
+    config = Config(
+        attestation=AttestationConfig(),
+        bearer_token=BEARER,
+        dev_mode=True,
+    )
+
+    attestation_report = MagicMock()
+    attestation_report.provider = "software-only"
+    attestation_report.attestation_generated_at = datetime.now(UTC)
+    attestation_report.attestation_validity_seconds = 86400
+
+    bundle = MagicMock()
+    bundle.bundle_hash = "sha256:" + "0" * 64
+    bundle.policy_files = {"allow.cedar": "permit (principal, action, resource);"}
+    policy_store = MagicMock(spec=PolicyStore)
+    policy_store.bundle = bundle
+    policy_store.reload_if_stale = MagicMock()
+
+    catalog = MagicMock()
+    catalog.entries = {}
+    catalog.catalog_hash = "sha256:" + "1" * 64
+    catalog.exceptions = []
+
+    return RuntimeContext(
+        config=config,
+        tee_provider=MagicMock(),
+        attestation_report=attestation_report,
+        signing_key=MagicMock(),
+        policy_bundle=policy_store,
+        catalog=catalog,
+        audit_store=SqliteAuditStore(tmp_path / "audit.db"),
+    )
+
+
+def test_bearer_token_reaches_server(ctx):
+    """AUTH-001: a request without the token must get 401, with it not-401."""
+    server = build_server(ctx)
+    client = TestClient(server.app)
+
+    unauthenticated = client.get("/tools/list")
+    assert unauthenticated.status_code == 401
+
+    authenticated = client.get(
+        "/tools/list", headers={"Authorization": f"Bearer {BEARER}"}
+    )
+    assert authenticated.status_code != 401
+
+
+def test_health_exempt_from_auth(ctx):
+    server = build_server(ctx)
+    client = TestClient(server.app)
+    assert client.get("/health").status_code != 401
+
+
+def test_audit_chain_persists_to_store(ctx, tmp_path):
+    """AUDIT-001: the session_start entry must land in the SQLite DB."""
+    build_server(ctx)
+    conn = sqlite3.connect(tmp_path / "audit.db")
+    rows = conn.execute(
+        "SELECT entry_type FROM audit_entries"
+    ).fetchall()
+    conn.close()
+    assert ("session_start",) in rows
+
+
+def test_audit_chain_is_tee_anchored(ctx):
+    """AUDIT-002: the chain created by the entrypoint must have its anchor set."""
+    server = build_server(ctx)
+    chain = server._audit_chain
+    assert chain is not None
+    assert chain.tee_anchor == chain.chain_root
+
+
+def test_proxy_receives_attestation_timestamps(ctx):
+    """Staleness enforcement requires attestation_generated_at to be wired."""
+    server = build_server(ctx)
+    proxy = server._proxy
+    assert proxy._attestation_generated_at is not None
+    assert proxy._attestation_validity_seconds == 86400

--- a/tests/unit/test_egress_policy.py
+++ b/tests/unit/test_egress_policy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -107,8 +108,8 @@ def _make_proxy_with_egress(egress_allow: bool, ingress_allow: bool = True):
 
     evaluator = MagicMock(spec=PolicyEvaluator)
     evaluator.evaluate.side_effect = _side_effect
-    # authorize_egress delegates to evaluate() — wire it the same way
-    evaluator.authorize_egress.side_effect = lambda tool, resp, sess: _side_effect(
+    # authorize_egress delegates to evaluate() - wire it the same way
+    evaluator.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _side_effect(
         {"egress": True, "tool_name": tool}
     )
     evaluator.bundle_hash = "sha256:" + "0" * 64
@@ -117,10 +118,7 @@ def _make_proxy_with_egress(egress_allow: bool, ingress_allow: bool = True):
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(catalog, evaluator, session, chain, cfg)
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False, modified_response=None
-        ))
+        wire_mock_gateway(proxy)
 
     return proxy, session, chain, evaluator
 
@@ -277,14 +275,14 @@ async def test_proxy_high_sensitivity_session_blocked_by_egress():
     def _make_evaluator_for(session_sensitivity: str) -> MagicMock:
         ev = MagicMock(spec=PolicyEvaluator)
         ev.evaluate.side_effect = _sensitivity_aware_egress
-        ev.authorize_egress.side_effect = lambda tool, resp, sess: _sensitivity_aware_egress(
+        ev.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _sensitivity_aware_egress(
             {"egress": True, "sensitivity_level": {"public": 0, "pii": 1, "confidential": 2, "hipaa_phi": 3}.get(sess.max_sensitivity, 0)}
         )
         ev.bundle_hash = "sha256:" + "0" * 64
         ev.enforcement_mode = EnforcementMode.ENFORCING
         return ev
 
-    # High sensitivity session — should be blocked
+    # High sensitivity session - should be blocked
     high_session = SessionState(session_id="high", max_sensitivity="hipaa_phi")
     high_chain = AuditChain("high")
     high_ev = _make_evaluator_for("hipaa_phi")
@@ -292,15 +290,12 @@ async def test_proxy_high_sensitivity_session_blocked_by_egress():
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         high_proxy = CMCPProxy(catalog, high_ev, high_session, high_chain, cfg)
-        high_proxy._mcp_gateway = MagicMock()
-        high_proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False, modified_response=None
-        ))
+        wire_mock_gateway(high_proxy)
 
     high_result = await high_proxy.call_tool("c1", "test.tool", {})
     assert high_result.allowed is False
 
-    # Low sensitivity session — same tool should be allowed
+    # Low sensitivity session - same tool should be allowed
     low_session = SessionState(session_id="low", max_sensitivity="public")
     low_chain = AuditChain("low")
     low_ev = _make_evaluator_for("public")
@@ -308,10 +303,7 @@ async def test_proxy_high_sensitivity_session_blocked_by_egress():
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         low_proxy = CMCPProxy(catalog, low_ev, low_session, low_chain, cfg)
-        low_proxy._mcp_gateway = MagicMock()
-        low_proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False, modified_response=None
-        ))
+        wire_mock_gateway(low_proxy)
 
     low_result = await low_proxy.call_tool("c1", "test.tool", {})
     assert low_result.allowed is True
@@ -343,7 +335,7 @@ async def test_proxy_after_session_reset_egress_allowed_again():
 
     evaluator = MagicMock(spec=PolicyEvaluator)
     evaluator.evaluate.side_effect = _egress_aware
-    evaluator.authorize_egress.side_effect = lambda tool, resp, sess: _egress_aware(
+    evaluator.authorize_egress.side_effect = lambda tool, resp, sess, **kw: _egress_aware(
         {"egress": True, "sensitivity_level": {"public": 0, "pii": 1, "confidential": 2, "hipaa_phi": 3, "mnpi": 3, "trade_secret": 3}.get(sess.max_sensitivity, 0)}
     )
     evaluator.bundle_hash = "sha256:" + "0" * 64
@@ -352,12 +344,9 @@ async def test_proxy_after_session_reset_egress_allowed_again():
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(catalog, evaluator, session, chain, cfg)
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False, modified_response=None
-        ))
+        wire_mock_gateway(proxy)
 
-    # Before reset — high sensitivity should be blocked
+    # Before reset - high sensitivity should be blocked
     result_before = await proxy.call_tool("c1", "test.tool", {})
     assert result_before.allowed is False
 
@@ -365,6 +354,50 @@ async def test_proxy_after_session_reset_egress_allowed_again():
     session.reset(reason="test reset", authorized_by="operator")
     assert session.max_sensitivity == "public"
 
-    # After reset — same tool should be allowed
+    # After reset - same tool should be allowed
     result_after = await proxy.call_tool("c2", "test.tool", {})
     assert result_after.allowed is True
+
+
+def test_egress_carries_workflow_id_for_default_deny_bundles():
+    """A workflow-scoped permit (no catch-all) must also match at egress.
+
+    Without workflow_id in the egress context, default-deny bundles deny
+    every response even when the ingress evaluation allowed the call.
+    """
+    from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+    from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
+    from cmcp_runtime.policy.evaluator import PolicyEvaluator
+    from cmcp_runtime.session.state import SessionState
+
+    policy = """
+permit (principal, action == Action::"Ehr.patientRecordLookup", resource)
+when { context has workflow_id && context.workflow_id == "clinical-decision-support" };
+"""
+    bundle = PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-11T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": policy},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+    config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
+    evaluator = PolicyEvaluator(bundle=bundle, config=config)
+    session = SessionState(session_id="egress-wf-test")
+
+    decision = evaluator.authorize_egress(
+        "ehr.patient_record_lookup",
+        b"{}",
+        session,
+        workflow_id="clinical-decision-support",
+    )
+    assert decision.allowed is True
+
+    with pytest.raises(PolicyDeny):
+        evaluator.authorize_egress(
+            "ehr.patient_record_lookup", b"{}", session, workflow_id="wrong-workflow"
+        )

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 
 def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
@@ -89,10 +90,7 @@ def _make_proxy(catalog=None, evaluator=None, mode=EnforcementMode.ENFORCING):
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(cat, ev, session, chain, cfg, attestation_platform="software-only")
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
     return proxy, session, chain
 
 
@@ -152,10 +150,6 @@ async def test_proxy_updates_session_state_on_allow():
     catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
     proxy, session, _ = _make_proxy(catalog=catalog)
 
-    proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-        sensitivity_tags=["pii"], injection_detected=False
-    ))
-
     assert session.max_sensitivity == "public"
     await proxy.call_tool("c1", "test.tool", {})
     assert session.max_sensitivity == "pii"
@@ -198,7 +192,7 @@ async def test_proxy_result_contains_audit_entry_hash():
 
 @pytest.mark.asyncio
 async def test_cedar_context_includes_arguments():
-    """POLICY-004 — arguments must appear in the Cedar context so policies can inspect them."""
+    """POLICY-004 - arguments must appear in the Cedar context so policies can inspect them."""
     evaluator = _make_evaluator()
     proxy, _, _ = _make_proxy(evaluator=evaluator)
     args = {"patient_id": "p-123", "action": "read"}
@@ -211,7 +205,7 @@ async def test_cedar_context_includes_arguments():
 
 @pytest.mark.asyncio
 async def test_cedar_context_includes_attestation_platform():
-    """POLICY-005 (issue #162) — attestation_platform must be in Cedar context so
+    """POLICY-005 (issue #162) - attestation_platform must be in Cedar context so
     policies can restrict calls to hardware-attested callers only."""
     from cmcp_runtime.mcp.proxy import CMCPProxy
 
@@ -227,10 +221,7 @@ async def test_cedar_context_includes_attestation_platform():
             _make_catalog(), evaluator, session, chain, cfg,
             attestation_platform="amd-sev-snp",
         )
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
 
     await proxy.call_tool("c1", "test.tool", {})
     ctx = evaluator.evaluate.call_args[0][0]
@@ -239,7 +230,7 @@ async def test_cedar_context_includes_attestation_platform():
 
 @pytest.mark.asyncio
 async def test_cedar_context_attestation_platform_flows_from_constructor():
-    """POLICY-005 — attestation_platform passed to CMCPProxy must appear verbatim in Cedar context."""
+    """POLICY-005 - attestation_platform passed to CMCPProxy must appear verbatim in Cedar context."""
     evaluator = _make_evaluator()
     proxy, _, _ = _make_proxy(evaluator=evaluator)
     await proxy.call_tool("c1", "test.tool", {})
@@ -249,7 +240,7 @@ async def test_cedar_context_attestation_platform_flows_from_constructor():
 
 
 def test_cli_passes_canonical_platform_to_proxy():
-    """POLICY-005 — cli.start() must resolve the TEE provider to a canonical platform
+    """POLICY-005 - cli.start() must resolve the TEE provider to a canonical platform
     string via _PROVIDER_MAP and pass it to CMCPProxy, not leave the Cedar context as
     'unknown'."""
     from cmcp_runtime.audit.trace_claim import _PROVIDER_MAP
@@ -268,7 +259,7 @@ def test_cli_passes_canonical_platform_to_proxy():
 
 @pytest.mark.asyncio
 async def test_audit_payload_hash_present_on_allow():
-    """POLICY-005 — successful calls must record request_payload_hash in the audit entry."""
+    """POLICY-005 - successful calls must record request_payload_hash in the audit entry."""
     proxy, _, chain = _make_proxy()
     await proxy.call_tool("c1", "test.tool", {"k": "v"})
     entry = next(e for e in reversed(chain.entries) if e.entry_type == "tool_call")
@@ -278,7 +269,7 @@ async def test_audit_payload_hash_present_on_allow():
 
 @pytest.mark.asyncio
 async def test_audit_payload_hash_present_on_catalog_deny():
-    """POLICY-005 — catalog-miss denials must record request_payload_hash."""
+    """POLICY-005 - catalog-miss denials must record request_payload_hash."""
     proxy, _, chain = _make_proxy()
     await proxy.call_tool("c1", "ghost.tool", {"x": 1})
     entry = next(e for e in reversed(chain.entries) if e.entry_type == "tool_call")
@@ -288,7 +279,7 @@ async def test_audit_payload_hash_present_on_catalog_deny():
 
 @pytest.mark.asyncio
 async def test_audit_payload_hash_present_on_cedar_deny():
-    """POLICY-005 — Cedar policy denials must record request_payload_hash."""
+    """POLICY-005 - Cedar policy denials must record request_payload_hash."""
     evaluator = _make_evaluator(allow=False)
     proxy, _, chain = _make_proxy(evaluator=evaluator)
     await proxy.call_tool("c1", "test.tool", {"secret": "leak"})
@@ -299,7 +290,7 @@ async def test_audit_payload_hash_present_on_cedar_deny():
 
 @pytest.mark.asyncio
 async def test_audit_payload_hash_is_canonical_sha256():
-    """POLICY-005 — payload hash must be sha256 of canonical JSON (sort_keys, no spaces)."""
+    """POLICY-005 - payload hash must be sha256 of canonical JSON (sort_keys, no spaces)."""
     import hashlib
     import json
 
@@ -316,7 +307,7 @@ async def test_audit_payload_hash_is_canonical_sha256():
 
 @pytest.mark.asyncio
 async def test_cedar_exception_writes_fault_audit_entry():
-    """POLICY-003 — Cedar backend exception must emit a fault audit entry before re-raising."""
+    """POLICY-003 - Cedar backend exception must emit a fault audit entry before re-raising."""
     evaluator = MagicMock(spec=_make_evaluator().__class__)
     evaluator.evaluate.side_effect = RuntimeError("malformed Cedar policy")
     evaluator.authorize_egress.return_value = MagicMock(would_have_denied=False)
@@ -339,30 +330,31 @@ async def test_cedar_exception_writes_fault_audit_entry():
 
 @pytest.mark.asyncio
 async def test_audit_entry_detail_includes_injection_scanner_and_pattern():
-    """INJECT-003 (closes #170) — when injection is detected, the audit entry detail must
+    """INJECT-003 (closes #170) - when injection is detected, the audit entry detail must
     include injection_scanner and matched_pattern so a verifier can reconstruct why
     the request was denied."""
     proxy, _, chain = _make_proxy()
-    proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-        sensitivity_tags=[],
-        injection_detected=True,
-        injection_scanner="agt_mcp",
-        matched_pattern="test_pattern",
-        injection_pattern=None,
-    ))
+    # Allowed-but-detected path: scanner reports threats but does not block.
+    wire_mock_gateway(
+        proxy,
+        scan_allowed=True,
+        threats=[{"category": "prompt_injection", "description": "x"}],
+    )
 
     await proxy.call_tool("c1", "test.tool", {"q": "hello"})
 
     tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
     entry = tool_entries[-1]
     assert entry.detail is not None, "detail must be set when injection is detected"
-    assert entry.detail["injection_scanner"] == "agt_mcp"
-    assert entry.detail["matched_pattern"] == "test_pattern"
+    assert entry.detail["injection_scanner"] == "agt_response_scanner"
+    assert entry.detail["matched_pattern"] == "prompt_injection"
+    # INJECT-007 threshold no longer applies to the AGT response scanner
+    assert "injection_threshold" not in entry.detail
 
 
 @pytest.mark.asyncio
 async def test_audit_entry_detail_is_none_when_no_injection():
-    """INJECT-003 — when no injection is detected, detail must not be set
+    """INJECT-003 - when no injection is detected, detail must not be set
     (so clean calls do not carry spurious injection keys)."""
     proxy, _, chain = _make_proxy()
 
@@ -375,19 +367,55 @@ async def test_audit_entry_detail_is_none_when_no_injection():
 
 @pytest.mark.asyncio
 async def test_audit_entry_detail_falls_back_to_unknown_when_fields_absent():
-    """INJECT-003 — when injection_detected=True but scanner/pattern attrs are absent,
-    detail values must fall back to 'unknown' rather than crashing."""
+    """INJECT-003 - when a scanner threat dict is missing its 'category' key, the
+    matched_pattern must fall back to 'unknown' rather than crashing."""
     proxy, _, chain = _make_proxy()
-    agt_mock = MagicMock(spec=[])  # no attributes beyond spec
-    agt_mock.sensitivity_tags = []
-    agt_mock.injection_detected = True
-    # injection_scanner and matched_pattern intentionally absent
-    proxy._mcp_gateway.call_tool = AsyncMock(return_value=agt_mock)
+    # Threat dict intentionally missing the "category" key
+    wire_mock_gateway(proxy, scan_allowed=True, threats=[{"description": "x"}])
 
     await proxy.call_tool("c1", "test.tool", {})
 
     tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
     entry = tool_entries[-1]
     assert entry.detail is not None
-    assert entry.detail["injection_scanner"] == "unknown"
+    assert entry.detail["injection_scanner"] == "agt_response_scanner"
     assert entry.detail["matched_pattern"] == "unknown"
+
+
+# ── Cedar-safe context coercion ────────────────────────────────────────────────
+
+
+def test_cedar_safe_coerces_floats_and_drops_none():
+    from cmcp_runtime.mcp.proxy import _cedar_safe
+
+    out = _cedar_safe({
+        "score": 72.3,
+        "labs": {"glucose": 9.2, "note": None},
+        "tags": ["a", 1, 2.5, None],
+        "count": 3,
+        "active": True,
+    })
+    assert out == {
+        "score": "72.3",
+        "labs": {"glucose": "9.2"},
+        "tags": ["a", 1, "2.5"],
+        "count": 3,
+        "active": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_float_arguments_do_not_fail_policy_evaluation():
+    """A float in tool arguments must not crash Cedar and deny the call."""
+    proxy, _, _ = _make_proxy()
+    captured = {}
+    original = proxy._policy.evaluate
+
+    def capture(ctx):
+        captured.update(ctx)
+        return original(ctx)
+
+    proxy._policy.evaluate = capture
+    result = await proxy.call_tool("c1", "test.tool", {"risk_score": 72.3})
+    assert result.allowed is True
+    assert captured["arguments"] == {"risk_score": "72.3"}

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -98,7 +98,7 @@ def test_audit_export_requires_auth():
 # ── DOS-001: request body size limit ─────────────────────────────────────────
 
 def test_oversized_body_returns_413():
-    """DOS-001 — request body exceeding max_request_bytes is rejected before parsing."""
+    """DOS-001 - request body exceeding max_request_bytes is rejected before parsing."""
     with patch("cmcp_runtime.mcp.server.StatelessKernel"):
         proxy = MagicMock()
         proxy._catalog = MagicMock()
@@ -110,7 +110,7 @@ def test_oversized_body_returns_413():
 
 
 def test_content_length_check_rejects_before_body_read():
-    """DOS-001 — Content-Length check rejects before reading body."""
+    """DOS-001 - Content-Length check rejects before reading body."""
     with patch("cmcp_runtime.mcp.server.StatelessKernel"):
         proxy = MagicMock()
         proxy._catalog = MagicMock()
@@ -311,7 +311,7 @@ def test_readyz_accessible_without_bearer_token():
 # ── INJECT-002: sanitize method in error responses ────────────────────────────
 
 def test_unknown_method_non_ascii_is_replaced():
-    """INJECT-002 — non-ASCII bytes in method are replaced so they cannot corrupt logs."""
+    """INJECT-002 - non-ASCII bytes in method are replaced so they cannot corrupt logs."""
     server = _make_server()
     client = TestClient(server.app, raise_server_exceptions=False)
     resp = client.post(
@@ -324,7 +324,7 @@ def test_unknown_method_non_ascii_is_replaced():
 
 
 def test_unknown_method_truncated_at_64_chars():
-    """INJECT-002 — method longer than 64 chars is truncated."""
+    """INJECT-002 - method longer than 64 chars is truncated."""
     server = _make_server()
     client = TestClient(server.app, raise_server_exceptions=False)
     long_method = "a" * 200
@@ -342,9 +342,9 @@ def test_unknown_method_truncated_at_64_chars():
 # ── NET-004: unhandled exceptions return generic 500 ─────────────────────────
 
 def test_unhandled_exception_returns_generic_500():
-    """NET-004 — truly unhandled exception must not leak class or message to caller.
+    """NET-004 - truly unhandled exception must not leak class or message to caller.
 
-    Uses /tools/list which has no try/except — an exception from catalog.entries.items()
+    Uses /tools/list which has no try/except - an exception from catalog.entries.items()
     propagates out of the handler and must be caught by the global exception handler.
     """
     proxy = MagicMock()
@@ -364,7 +364,7 @@ def test_unhandled_exception_returns_generic_500():
 # ── POLICY-002: ingress tool name canonicalized to lowercase ─────────────────
 
 def test_tool_name_is_lowercased_at_ingress():
-    """POLICY-002 — tool name from MCP request must be lowercased before catalog lookup."""
+    """POLICY-002 - tool name from MCP request must be lowercased before catalog lookup."""
     received_names: list[str] = []
 
     async def _capture(call_id, tool_name, arguments, **kwargs):
@@ -390,7 +390,7 @@ def test_tool_name_is_lowercased_at_ingress():
 
 
 def test_deny_response_does_not_include_internal_reason():
-    """INJECT-003 — internal deny_reason must not appear in 403 response body."""
+    """INJECT-003 - internal deny_reason must not appear in 403 response body."""
     proxy = MagicMock()
     proxy._catalog = MagicMock()
     proxy._catalog.entries = {}
@@ -400,6 +400,7 @@ def test_deny_response_does_not_include_internal_reason():
         audit_entry_hash=None,
         would_have_denied=False,
         latency_us=0,
+        advice=None,
     ))
     with patch("cmcp_runtime.mcp.server.StatelessKernel"):
         server = MCPServer(proxy)

--- a/tests/unit/test_mid_session_failure.py
+++ b/tests/unit/test_mid_session_failure.py
@@ -10,7 +10,7 @@ Covers:
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -24,6 +24,7 @@ from cmcp_runtime.catalog.loader import (
 from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -95,10 +96,7 @@ def _make_proxy(
             attestation_validity_seconds=attestation_validity_seconds,
             catalog_hash=catalog_hash,
         )
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
     return proxy, session, chain
 
 

--- a/tests/unit/test_policy_advice.py
+++ b/tests/unit/test_policy_advice.py
@@ -1,0 +1,128 @@
+"""Tests for Cedar annotation-based advice on policy denies."""
+
+from __future__ import annotations
+
+import pytest
+
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.policy.annotations import parse_policy_annotations
+from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
+from cmcp_runtime.policy.evaluator import PolicyEvaluator
+
+HITL_POLICY = """
+// Rule 1: permit everything by default.
+permit (principal, action, resource);
+
+// Rule 2: HITL escalation for high-risk patients (EU AI Act Art. 14).
+@id("hitl-high-risk")
+@reason("human-review-required")
+@regulation("eu-ai-act-art-14")
+@reviewer_role("attending-physician")
+forbid (principal, action == Action::"Ehr.treatmentPlanWriter", resource)
+when { context.arguments has patient_risk_category
+       && context.arguments.patient_risk_category == "high" };
+"""
+
+
+def _bundle(policy_content: str) -> PolicyBundle:
+    return PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-10T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": policy_content},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+
+
+def _config(mode: EnforcementMode) -> Config:
+    return Config(attestation=AttestationConfig(enforcement_mode=mode))
+
+
+def _context(risk: str) -> dict:
+    return {
+        "tool_name": "ehr.treatment_plan_writer",
+        "arguments": {"patient_risk_category": risk},
+        "session_max_sensitivity": "confidential",
+        "workflow_id": "clinical-decision-support",
+    }
+
+
+# ── parse_policy_annotations ──────────────────────────────────────────────────
+
+
+def test_parse_annotations_maps_implicit_ids():
+    annotations = parse_policy_annotations(HITL_POLICY)
+    assert "policy0" not in annotations  # unannotated permit
+    assert annotations["policy1"] == {
+        "id": "hitl-high-risk",
+        "reason": "human-review-required",
+        "regulation": "eu-ai-act-art-14",
+        "reviewer_role": "attending-physician",
+    }
+
+
+def test_parse_annotations_ignores_commented_policies():
+    text = """
+// permit (principal, action, resource);
+@reason("real")
+forbid (principal, action, resource);
+"""
+    annotations = parse_policy_annotations(text)
+    assert annotations == {"policy0": {"reason": "real"}}
+
+
+def test_parse_annotations_handles_escaped_quotes():
+    text = '@note("say \\"hello\\"") forbid (principal, action, resource);'
+    assert parse_policy_annotations(text) == {"policy0": {"note": 'say "hello"'}}
+
+
+def test_parse_annotations_empty_for_unannotated_bundle():
+    assert parse_policy_annotations("permit (principal, action, resource);") == {}
+
+
+# ── PolicyEvaluator advice flow ───────────────────────────────────────────────
+
+
+def test_enforcing_deny_carries_advice():
+    evaluator = PolicyEvaluator(
+        bundle=_bundle(HITL_POLICY), config=_config(EnforcementMode.ENFORCING)
+    )
+    with pytest.raises(PolicyDeny) as exc_info:
+        evaluator.evaluate(_context("high"))
+    assert exc_info.value.advice["reason"] == "human-review-required"
+    assert exc_info.value.advice["regulation"] == "eu-ai-act-art-14"
+    assert exc_info.value.advice["reviewer_role"] == "attending-physician"
+
+
+def test_advisory_deny_carries_advice():
+    evaluator = PolicyEvaluator(
+        bundle=_bundle(HITL_POLICY), config=_config(EnforcementMode.ADVISORY)
+    )
+    decision = evaluator.evaluate(_context("high"))
+    assert decision.allowed is True
+    assert decision.would_have_denied is True
+    assert decision.advice["reason"] == "human-review-required"
+
+
+def test_allow_has_no_advice():
+    evaluator = PolicyEvaluator(
+        bundle=_bundle(HITL_POLICY), config=_config(EnforcementMode.ENFORCING)
+    )
+    decision = evaluator.evaluate(_context("standard"))
+    assert decision.allowed is True
+    assert decision.advice == {}
+
+
+def test_deny_without_annotations_has_empty_advice():
+    deny_all = 'forbid (principal, action, resource);'
+    evaluator = PolicyEvaluator(
+        bundle=_bundle(deny_all), config=_config(EnforcementMode.ENFORCING)
+    )
+    with pytest.raises(PolicyDeny) as exc_info:
+        evaluator.evaluate(_context("standard"))
+    assert exc_info.value.advice == {}

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from starlette.testclient import TestClient

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -1,0 +1,105 @@
+"""Tests for POST /sessions/{id}/close - claim issuance and session rotation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.cli import build_server
+from cmcp_runtime.config import AttestationConfig, Config
+from cmcp_runtime.policy.bundle import PolicyStore
+from cmcp_runtime.startup import RuntimeContext
+
+
+@pytest.fixture
+def server():
+    config = Config(attestation=AttestationConfig(), dev_mode=True)
+
+    attestation_report = MagicMock()
+    attestation_report.provider = "software-only"
+    attestation_report.attestation_generated_at = datetime.now(UTC)
+    attestation_report.attestation_validity_seconds = 86400
+    attestation_report.measurement = "0" * 64
+    attestation_report.report_data = "0" * 64
+    attestation_report.measurement_note = None
+    attestation_report.raw_evidence = None
+
+    bundle = MagicMock()
+    bundle.bundle_hash = "sha256:" + "0" * 64
+    bundle.policy_files = {"allow.cedar": "permit (principal, action, resource);"}
+    bundle.manifest = MagicMock()
+    bundle.manifest.version = "test-v1"
+    policy_store = MagicMock(spec=PolicyStore)
+    policy_store.bundle = bundle
+
+    catalog = MagicMock()
+    catalog.entries = {}
+    catalog.catalog_hash = "sha256:" + "1" * 64
+    catalog.exceptions = []
+
+    ctx = RuntimeContext(
+        config=config,
+        tee_provider=MagicMock(),
+        attestation_report=attestation_report,
+        signing_key=SigningKey(),
+        policy_bundle=policy_store,
+        catalog=catalog,
+    )
+    return build_server(ctx)
+
+
+def test_close_returns_signed_claim_and_rotates(server):
+    client = TestClient(server.app)
+    old_session_id = server._session.session_id
+
+    resp = client.post(f"/sessions/{old_session_id}/close")
+    assert resp.status_code == 200
+    claim = resp.json()
+    assert claim["gateway"]["session_id"] == old_session_id
+    assert claim["signature"]  # signed claim
+
+    # Session rotated: new id, proxy rebound.
+    assert server._session.session_id != old_session_id
+    assert server._proxy._session.session_id == server._session.session_id
+    assert server._audit_chain is server._proxy._audit
+
+
+def test_closed_claim_retrievable_via_trace_claim_endpoint(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    client.post(f"/sessions/{session_id}/close")
+
+    resp = client.get(f"/sessions/{session_id}/trace-claim")
+    assert resp.status_code == 200
+    assert resp.json()["gateway"]["session_id"] == session_id
+
+
+def test_close_unknown_session_404(server):
+    client = TestClient(server.app)
+    resp = client.post("/sessions/not-a-real-session/close")
+    assert resp.status_code == 404
+
+
+def test_close_twice_404_on_second(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    assert client.post(f"/sessions/{session_id}/close").status_code == 200
+    assert client.post(f"/sessions/{session_id}/close").status_code == 404
+
+
+def test_audit_export_serves_closed_session(server):
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    client.post(f"/sessions/{session_id}/close")
+
+    resp = client.get(f"/audit/export?session_id={session_id}")
+    assert resp.status_code == 200
+    bundle = resp.json()
+    assert bundle["session_id"] == session_id
+    entry_types = [e["entry_type"] for e in bundle["entries"]]
+    assert "session_start" in entry_types
+    assert "session_end" in entry_types

--- a/tests/unit/test_session_reset.py
+++ b/tests/unit/test_session_reset.py
@@ -9,7 +9,7 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from starlette.testclient import TestClient
 
@@ -24,6 +24,7 @@ from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.mcp.server import MCPServer
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -82,10 +83,7 @@ def _make_server(session_id: str = "sess-reset-001"):
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(cat, ev, session, chain, cfg)
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
 
     server = MCPServer(proxy, session=session, audit_chain=chain)
     return server, session, chain

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -56,11 +56,12 @@ def test_snp_struct_round_trip() -> None:
     assert bytes(report.host_data) == host_pattern
 
 
-def test_valid_measurement_format_no_evidence():
+def test_valid_measurement_format_no_evidence_fails_closed():
+    """A well-formed measurement string is not evidence."""
     good = "sha384:" + "a" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_sha256_prefix_fails_format():
@@ -158,18 +159,20 @@ def test_truncated_report_is_parse_error():
     assert result.failure_reason == "raw_evidence_parse_error"
 
 
-def test_no_raw_evidence_hardware_unverified():
+def test_no_raw_evidence_fails_closed():
+    """A hardware-platform claim with no evidence must not verify."""
     good = "sha384:" + "f" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
-    assert result.verified is True
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "measurement" not in result.verified_fields
 
 
 def test_vcek_cert_chain_always_unverified_no_evidence():
     good = "sha384:" + "e" * 96
     result = verify_sev_snp_measurement(good, raw_evidence=None)
+    assert result.verified is False
     assert "vcek_cert_chain" in result.unverified_fields
-    assert result.details["vcek_chain"] == "requires_amd_kds_lookup"
 
 
 def test_vcek_cert_chain_always_unverified_with_matching_report():

--- a/tests/unit/test_silent_mode_contract.py
+++ b/tests/unit/test_silent_mode_contract.py
@@ -1,0 +1,129 @@
+"""
+Silent-mode contract: silent quiets logs, never the evidence.
+
+enforcement_mode: silent must behave exactly like advisory with respect to
+the audit chain -- every would-have-denied decision is recorded as
+advisory_deny -- while emitting no operational log lines for the deny.
+This is the documented contract (docs/configuration.md); these tests exist
+so it cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.policy.bundle import PolicyBundle, PolicyManifest
+from cmcp_runtime.policy.evaluator import PolicyEvaluator
+
+DENY_ALL = "forbid (principal, action, resource);"
+
+
+def _evaluator(mode: EnforcementMode) -> PolicyEvaluator:
+    bundle = PolicyBundle(
+        manifest=PolicyManifest(
+            version="1.0.0",
+            authored_at="2026-06-11T00:00:00Z",
+            author_identity="test",
+            commit_sha="abc",
+        ),
+        policy_files={"allow.cedar": DENY_ALL},
+        schema_content='{"cMCP": {}}',
+        bundle_hash="sha256:" + "0" * 64,
+    )
+    return PolicyEvaluator(
+        bundle=bundle,
+        config=Config(attestation=AttestationConfig(enforcement_mode=mode)),
+    )
+
+
+CONTEXT = {
+    "tool_name": "test.tool",
+    "arguments": {},
+    "session_max_sensitivity": "public",
+}
+
+
+def test_silent_deny_flags_would_have_denied():
+    decision = _evaluator(EnforcementMode.SILENT).evaluate(dict(CONTEXT))
+    assert decision.allowed is True
+    assert decision.would_have_denied is True
+
+
+def test_silent_emits_no_deny_log_lines(caplog):
+    with caplog.at_level(logging.INFO, logger="cmcp_runtime.policy.evaluator"):
+        _evaluator(EnforcementMode.SILENT).evaluate(dict(CONTEXT))
+    assert not any("deny" in r.message.lower() for r in caplog.records)
+
+
+def test_advisory_does_emit_deny_log_line(caplog):
+    with caplog.at_level(logging.INFO, logger="cmcp_runtime.policy.evaluator"):
+        _evaluator(EnforcementMode.ADVISORY).evaluate(dict(CONTEXT))
+    assert any("advisory deny" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_silent_mode_audit_chain_records_advisory_deny():
+    """The core contract: in silent mode the hash-chained audit log still
+    records the would-have-denied decision."""
+    from unittest.mock import MagicMock, patch
+
+    from cmcp_runtime.audit.chain import AuditChain
+    from cmcp_runtime.catalog.loader import (
+        ApprovedDefinition,
+        CatalogEntry,
+        ServerIdentity,
+        ToolCatalog,
+    )
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+    from cmcp_runtime.session.state import SessionState
+
+    from .conftest import wire_mock_gateway
+
+    entry = CatalogEntry(
+        tool_name="test.tool",
+        server=ServerIdentity(
+            display_name="t",
+            url="http://localhost:8080/mcp",
+            tls_fingerprint="SHA256:" + "A" * 43 + "=",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="t", input_schema={"type": "object"}, output_schema=None
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="internal",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-11T00:00:00Z",
+        approved_by="test",
+    )
+    catalog = ToolCatalog(
+        entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64
+    )
+    session = SessionState(session_id="silent-contract")
+    chain = AuditChain("silent-contract")
+    with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
+         patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            catalog=catalog,
+            policy_evaluator=_evaluator(EnforcementMode.SILENT),
+            session=session,
+            audit_chain=chain,
+            config=Config(
+                attestation=AttestationConfig(enforcement_mode=EnforcementMode.SILENT)
+            ),
+        )
+        wire_mock_gateway(proxy)
+
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is True
+    assert result.would_have_denied is True
+
+    tool_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert tool_entries, "audit chain must record the call in silent mode"
+    assert tool_entries[-1].policy_decision == "advisory_deny"

--- a/tests/unit/test_silent_mode_contract.py
+++ b/tests/unit/test_silent_mode_contract.py
@@ -68,7 +68,7 @@ def test_advisory_does_emit_deny_log_line(caplog):
 async def test_silent_mode_audit_chain_records_advisory_deny():
     """The core contract: in silent mode the hash-chained audit log still
     records the would-have-denied decision."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from cmcp_runtime.audit.chain import AuditChain
     from cmcp_runtime.catalog.loader import (

--- a/tests/unit/test_tdx_opaque_verify.py
+++ b/tests/unit/test_tdx_opaque_verify.py
@@ -47,22 +47,23 @@ def test_tdx_invalid_measurement_hex_length():
     assert result.failure_reason == "invalid_measurement_format"
 
 
-def test_tdx_no_raw_evidence_no_dcap(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed(monkeypatch):
+    """A hardware-platform claim with no evidence must not verify."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: False)
     measurement = "sha384:" + "b" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "dcap_quote_signature" in result.unverified_fields
-    assert result.details.get("dcap_chain") == "dcap_service_unreachable"
 
 
-def test_tdx_no_raw_evidence_dcap_reachable(monkeypatch):
+def test_tdx_no_raw_evidence_fails_closed_even_with_dcap(monkeypatch):
+    """DCAP reachability cannot substitute for missing evidence."""
     monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: True)
     measurement = "sha384:" + "c" * 96
     result = verify_tdx_measurement(measurement, None)
-    assert result.verified
-    assert "dcap_quote_signature" in result.unverified_fields
-    assert "reachable" in result.details.get("dcap_qe_identity", "")
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_tdx_measurement_matches_mrtd(monkeypatch):
@@ -100,11 +101,11 @@ def test_opaque_no_endpoint_configured(monkeypatch):
     assert "opaque_managed_attestation" in result.unverified_fields
 
 
-def test_opaque_no_raw_evidence(monkeypatch):
+def test_opaque_no_raw_evidence_fails_closed(monkeypatch):
     monkeypatch.setenv("CMCP_OPAQUE_ATTESTATION_ENDPOINT", "https://attest.opaque.co/v1/verify")
     result = verify_opaque_measurement("sha384:" + "a" * 96, None)
-    assert result.verified
-    assert "opaque_managed_attestation" in result.unverified_fields
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
     assert "raw_evidence not provided" in result.details.get("hint", "")
 
 

--- a/tests/unit/test_tpm_verify.py
+++ b/tests/unit/test_tpm_verify.py
@@ -51,13 +51,15 @@ def _make_tpm2b_attest(
 # ── Unit tests for verify_tpm_measurement ────────────────────────────────────
 
 
-def test_valid_measurement_format_passes() -> None:
+def test_valid_measurement_format_alone_does_not_verify() -> None:
+    """Format checks pass, but no evidence means fail closed."""
     result = verify_tpm_measurement(
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
     assert "measurement_format" in result.verified_fields
-    assert result.failure_reason is None
+    assert result.verified is False
+    assert result.failure_reason == "no_raw_evidence"
 
 
 def test_invalid_measurement_no_prefix_fails() -> None:
@@ -103,8 +105,8 @@ def test_no_raw_evidence_ek_cert_always_unverified() -> None:
         measurement=VALID_MEASUREMENT,
         raw_evidence=None,
     )
+    assert result.verified is False
     assert "ek_cert_chain" in result.unverified_fields
-    assert result.details.get("ek_cert_chain_validation") == "ek_cert_chain_validation_requires_ca_lookup"
 
 
 def test_raw_evidence_valid_magic_parsed() -> None:
@@ -123,7 +125,7 @@ def test_raw_evidence_wrong_magic_fails_gracefully() -> None:
         measurement=VALID_MEASUREMENT,
         raw_evidence=blob,
     )
-    # Must not raise — verified should be False or pcr_format unverified
+    # Must not raise - verified should be False or pcr_format unverified
     assert "pcr_format" in result.unverified_fields
     assert "tpm_parse_error" in result.details
 
@@ -311,7 +313,7 @@ def test_software_only_stays_in_sw_path() -> None:
     claim_dict = _to_dict(claim)
     result = verify_trace_claim(claim_dict, _approved())
     assert "hardware_attestation" in result.unverified_fields
-    assert result.details.get("hardware_attestation") == "software-only mode — not hardware-backed"
+    assert result.details.get("hardware_attestation") == "software-only mode - not hardware-backed"
 
 
 def test_tpm2_with_valid_raw_evidence_parses() -> None:

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -203,7 +203,7 @@ def test_generate_claim_signed_has_signature():
 
 
 def test_generate_claim_signature_verifiable():
-    """TRACE-002 — signature verifies against trace.cnf.jwk."""
+    """TRACE-002 - signature verifies against trace.cnf.jwk."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
     key = SigningKey()
@@ -218,7 +218,7 @@ def test_generate_claim_signature_verifiable():
 
 
 def test_generate_claim_tee_key_consistent_in_session():
-    """ATTEST-003 — same JWK across all claims produced with the same signing key."""
+    """ATTEST-003 - same JWK across all claims produced with the same signing key."""
     key = SigningKey()
     c1 = _make_claim(signing_key=key)
     c2 = _make_claim(signing_key=key)
@@ -274,9 +274,9 @@ def test_generate_claim_enforcement_mode_mapped():
 
 
 def test_generate_claim_software_only_platform():
-    """software-only provider maps to tpm2 platform with firmware marker."""
+    """software-only provider gets its own platform value, never tpm2."""
     claim = _make_claim()
-    assert claim.trace.runtime.platform == "tpm2"
+    assert claim.trace.runtime.platform == "software-only"
     assert claim.trace.runtime.firmware_version == "software-only-dev-mode"
 
 

--- a/tests/unit/test_upstream_forwarding.py
+++ b/tests/unit/test_upstream_forwarding.py
@@ -1,0 +1,125 @@
+"""Tests for CMCPProxy._forward_to_upstream against a real local HTTP server."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.errors import UpstreamToolError, UpstreamUnavailable
+from cmcp_runtime.session.state import SessionState
+
+
+class _MockMCPHandler(BaseHTTPRequestHandler):
+    """Serves canned JSON-RPC responses; behavior keyed on tool name."""
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        request = json.loads(self.rfile.read(length))
+        tool = request["params"]["name"]
+        if tool == "test.fail":
+            body = {
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "error": {"code": -32000, "message": "tool exploded"},
+            }
+        else:
+            body = {
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "result": {
+                    "content": [{"type": "text", "text": f"echo:{tool}"}]
+                },
+            }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # silence test output
+        pass
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    server = HTTPServer(("127.0.0.1", 0), _MockMCPHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}/mcp"
+    server.shutdown()
+
+
+def _make_proxy(server_url: str):
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+
+    entry = CatalogEntry(
+        tool_name="test.echo",
+        server=ServerIdentity(
+            display_name="Mock",
+            url=server_url,
+            tls_fingerprint="SHA256:" + "A" * 43 + "=",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="echo", input_schema={"type": "object"}, output_schema=None
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="public",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-10T00:00:00Z",
+        approved_by="test",
+    )
+    catalog = ToolCatalog(
+        entries={"test.echo": entry, "test.fail": entry},
+        catalog_hash="sha256:" + "1" * 64,
+    )
+    config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
+    session = SessionState(session_id="fwd-test")
+    chain = AuditChain("fwd-test")
+    with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
+         patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            catalog=catalog,
+            policy_evaluator=MagicMock(),
+            session=session,
+            audit_chain=chain,
+            config=config,
+        )
+    return proxy, entry
+
+
+@pytest.mark.asyncio
+async def test_forward_returns_text_content(mock_server):
+    proxy, entry = _make_proxy(mock_server)
+    text = await proxy._forward_to_upstream("c1", entry, "test.echo", {"message": "hi"})
+    assert text == "echo:test.echo"
+
+
+@pytest.mark.asyncio
+async def test_forward_raises_on_jsonrpc_error(mock_server):
+    proxy, entry = _make_proxy(mock_server)
+    with pytest.raises(UpstreamToolError, match="tool exploded"):
+        await proxy._forward_to_upstream("c1", entry, "test.fail", {})
+
+
+@pytest.mark.asyncio
+async def test_forward_raises_when_unreachable():
+    proxy, entry = _make_proxy("http://127.0.0.1:1/mcp")
+    with pytest.raises(UpstreamUnavailable):
+        await proxy._forward_to_upstream("c1", entry, "test.echo", {})

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -211,13 +211,18 @@ def test_all_software_only_verified_fields_are_present():
 
 
 def test_known_hardware_platform_without_verifier_is_partially_verified():
-    """TEE-001 -- amd-sev-snp must be PARTIALLY_VERIFIED not VERIFIED."""
+    """TEE-001 -- amd-sev-snp without raw evidence must not be VERIFIED.
+
+    The dispatch previously compared against the provider name ("sev-snp")
+    instead of the platform name ("amd-sev-snp"), so SNP verification never
+    ran; with the dispatch fixed, the missing raw evidence fails closed.
+    """
     claim_dict, key = _make_signed_claim(provider="sev-snp")
     result = verify_trace_claim(
         claim_dict, _approved(), trusted_public_key_hex=key.public_key_hex
     )
     assert result.status == VerificationStatus.PARTIALLY_VERIFIED
-    assert result.failure_reason == VerificationError.UNSUPPORTED_PROVIDER
+    assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED
     assert "hardware_attestation" in result.unverified_fields
 
 

--- a/tests/unit/test_verify_command.py
+++ b/tests/unit/test_verify_command.py
@@ -1,0 +1,127 @@
+"""End-to-end tests for `cmcp verify`: real claim, real tampering."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.cli import build_server, main
+from cmcp_runtime.config import AttestationConfig, Config
+from cmcp_runtime.policy.bundle import PolicyStore
+from cmcp_runtime.startup import RuntimeContext
+
+
+@pytest.fixture
+def claim_and_bundle(tmp_path):
+    """Spin up a real server, close a session, export claim + audit bundle."""
+    config = Config(attestation=AttestationConfig(), dev_mode=True)
+
+    attestation_report = MagicMock()
+    attestation_report.provider = "software-only"
+    attestation_report.attestation_generated_at = datetime.now(UTC)
+    attestation_report.attestation_validity_seconds = 86400
+    attestation_report.measurement = "0" * 64
+    attestation_report.report_data = "0" * 64
+    attestation_report.measurement_note = None
+    attestation_report.raw_evidence = None
+
+    bundle_mock = MagicMock()
+    bundle_mock.bundle_hash = "sha256:" + "0" * 64
+    bundle_mock.policy_files = {"allow.cedar": "permit (principal, action, resource);"}
+    bundle_mock.manifest = MagicMock()
+    bundle_mock.manifest.version = "test-v1"
+    policy_store = MagicMock(spec=PolicyStore)
+    policy_store.bundle = bundle_mock
+
+    catalog = MagicMock()
+    catalog.entries = {}
+    catalog.catalog_hash = "sha256:" + "1" * 64
+    catalog.exceptions = []
+
+    ctx = RuntimeContext(
+        config=config,
+        tee_provider=MagicMock(),
+        attestation_report=attestation_report,
+        signing_key=SigningKey(),
+        policy_bundle=policy_store,
+        catalog=catalog,
+    )
+    server = build_server(ctx)
+    client = TestClient(server.app)
+    session_id = server._session.session_id
+    claim = client.post(f"/sessions/{session_id}/close").json()
+    bundle = client.get(f"/audit/export?session_id={session_id}").json()
+
+    claim_file = tmp_path / "claim.json"
+    bundle_file = tmp_path / "bundle.json"
+    claim_file.write_text(json.dumps(claim))
+    bundle_file.write_text(json.dumps(bundle))
+    return claim_file, bundle_file, claim, bundle
+
+
+def test_verify_passes_on_genuine_claim(claim_and_bundle):
+    claim_file, _, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, ["verify", str(claim_file)])
+    assert result.exit_code == 0, result.output
+    assert "RESULT: PASS" in result.output
+    assert "signature" in result.output
+    assert "not pinned" in result.output  # hashes unpinned by default
+
+
+def test_verify_passes_with_pinned_hashes(claim_and_bundle):
+    claim_file, _, claim, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file),
+        "--policy-hash", claim["trace"]["policy"]["bundle_hash"],
+        "--catalog-hash", claim["gateway"]["catalog"]["hash"],
+    ])
+    assert result.exit_code == 0, result.output
+
+
+def test_verify_fails_with_wrong_pinned_hash(claim_and_bundle):
+    claim_file, _, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--policy-hash", "sha256:" + "f" * 64,
+    ])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output
+
+
+def test_verify_fails_on_tampered_claim(claim_and_bundle, tmp_path):
+    """The tamper demo: change one field, signature verification fails."""
+    _, _, claim, _ = claim_and_bundle
+    claim["gateway"]["call_summary"]["tool_calls_total"] += 7
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(claim))
+    result = CliRunner().invoke(main, ["verify", str(tampered)])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output
+    assert "signature" in result.output
+
+
+def test_verify_audit_bundle_passes(claim_and_bundle):
+    claim_file, bundle_file, _, _ = claim_and_bundle
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--audit-bundle", str(bundle_file),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "audit_bundle" in result.output
+
+
+def test_verify_fails_on_tampered_audit_bundle(claim_and_bundle, tmp_path):
+    """Mutating one audit entry breaks the hash chain and the bundle signature."""
+    claim_file, _, _, bundle = claim_and_bundle
+    bundle["entries"][0]["entry_type"] = "tool_call"
+    tampered = tmp_path / "tampered-bundle.json"
+    tampered.write_text(json.dumps(bundle))
+    result = CliRunner().invoke(main, [
+        "verify", str(claim_file), "--audit-bundle", str(tampered),
+    ])
+    assert result.exit_code == 1
+    assert "RESULT: FAIL" in result.output

--- a/tests/unit/test_workflow_scope.py
+++ b/tests/unit/test_workflow_scope.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,6 +16,7 @@ from cmcp_runtime.catalog.loader import (
 from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
+from tests.unit.conftest import wire_mock_gateway
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -79,10 +80,7 @@ def _make_proxy(evaluator=None):
     with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
          patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
         proxy = CMCPProxy(cat, ev, session, chain, cfg)
-        proxy._mcp_gateway = MagicMock()
-        proxy._mcp_gateway.call_tool = AsyncMock(return_value=MagicMock(
-            sensitivity_tags=[], injection_detected=False
-        ))
+        wire_mock_gateway(proxy)
     return proxy, ev, chain
 
 


### PR DESCRIPTION
## What happened

PRs #278 -> #279 -> #280 -> #282 -> #285 -> #286 -> #287 -> #290 were stacked on #276. When #276 squash-merged and its branch was deleted, the rest merged into each other's now-deleted branches: all show MERGED, but none of their content reached main. The same thing happened in the examples repo (fixed there in examples#19).

Main is currently missing, among other things: the bearer-token wiring (AUTH-001 -- every endpoint unauthenticated in production), upstream MCP forwarding (every tool call denied), Cedar @annotation advice, POST /sessions/{id}/close + TRACE claim issuance, the egress workflow context fix, the silent-mode contract and tests, `cmcp verify`, and the fail-closed hardware verifiers.

## What this restores

The verified stack tip: 45 files across src/cmcp_runtime, src/cmcp_verify, tests/, docs/configuration.md, and the example configs. Em dashes scrubbed per repo style. pyproject (keeps #291's cedarpy fix) and .github workflows untouched.

## Test plan

- [x] Full suite on the restored tree: 679 passed, 1 skipped

## Process note

Stacked PRs on GitHub: merge the TOP of the stack into its base branch first and walk down, or retarget each PR to main after the one below merges. Merging the bottom first deletes the base branch and strands the rest.

Generated with [Claude Code](https://claude.ai/code)