### PR TITLE
chore: release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cmcp-runtime"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hardware-attested MCP runtime — TEE-enforced policy and TRACE Claim generation"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump for the first release containing the working runtime (PyPI 0.1.0 predates the restored feature stack: no auth wiring, no forwarding, no verify command). Publishing flow: merge, then a GitHub release tagged v0.2.0 triggers release.yml via the trusted publisher.

Generated with [Claude Code](https://claude.ai/code)