### PR TITLE
feat(security): response hash binding and upstream TLS pinning

### DIFF
--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -731,6 +731,10 @@ class CMCPProxy:
         # Step 6: audit chain write
         policy_decision: Any = "advisory_deny" if would_have_denied else "allow"
         latency_us = int((time.perf_counter() - t0) * 1_000_000)
+        # #293: bind the outcome into the audit entry. Hash exactly the bytes the
+        # egress check saw (post-scan, possibly sanitized) so a verifier can match
+        # the audited response against what the caller actually received.
+        response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
         # INJECT-003: include injection scanner and pattern in audit detail when detected
         injection_detail: dict[str, str | int | float] | None = (
             {
@@ -751,6 +755,7 @@ class CMCPProxy:
             policy_rule_matched=policy_rule,
             latency_us=latency_us,
             request_payload_hash=request_payload_hash,
+            response_payload_hash=response_payload_hash,
             session_sensitivity_before=sensitivity_before,
             session_sensitivity_after=self._session.max_sensitivity,
             workflow_id=workflow_id,

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -28,6 +28,7 @@ from cmcp_runtime.audit.chain import AuditChain
 from cmcp_runtime.catalog.loader import CatalogEntry, ToolCatalog
 from cmcp_runtime.config import Config
 from cmcp_runtime.errors import PolicyDeny, UpstreamToolError, UpstreamUnavailable
+from cmcp_runtime.mcp import tls_pinning
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
 from cmcp_runtime.session.state import SessionState
@@ -126,9 +127,13 @@ class CMCPProxy:
             response_scanner=MCPResponseScanner(),
         )
 
-        # Shared async HTTP client for upstream forwarding; created lazily so
-        # proxy construction stays sync and tests need no event loop.
-        self._http: httpx.AsyncClient | None = None
+        # Async HTTP clients for upstream forwarding, keyed by TLS pin so each
+        # pinned upstream gets a transport that enforces its own catalog
+        # fingerprint (#281). Created lazily so proxy construction stays sync
+        # and tests need no event loop.
+        self._http_clients: dict[str, httpx.AsyncClient] = {}
+        # Servers already warned about unenforceable pinning (warn once each).
+        self._tls_pin_warned: set[str] = set()
 
     def rebind_session(self, session: SessionState, audit_chain: AuditChain) -> None:
         """
@@ -141,6 +146,71 @@ class CMCPProxy:
         self._audit = audit_chain
         self._call_log = CallLog(session_id=session.session_id)
         self._session_call_log = SessionCallLog(session_id=session.session_id)
+
+    def _warn_pin_unenforced(self, server_url: str, reason: str) -> None:
+        """Log TLS_PIN_UNENFORCED once per server URL (#281, dev/demo paths)."""
+        if server_url in self._tls_pin_warned:
+            return
+        self._tls_pin_warned.add(server_url)
+        logger.warning("TLS_PIN_UNENFORCED: server=%s: %s", server_url, reason)
+
+    def _client_for_upstream(self, entry: CatalogEntry) -> httpx.AsyncClient:
+        """
+        Return (creating on first use) the HTTP client for this catalog entry,
+        enforcing the catalog TLS fingerprint pin (#281).
+
+        - https + real pin: client with tls_pinning.PinnedTransport. The peer
+          certificate's SHA-256 fingerprint is checked at TLS handshake time,
+          before any request bytes are written; a mismatch aborts the
+          connection (fail closed). Standard CA verification still applies -
+          the pin is additive.
+        - https + PLACEHOLDER_FINGERPRINT: unpinned dev mode. The examples ship
+          this all-"A" placeholder, meaning "no pin recorded yet"; warn once
+          per server and proceed with standard CA verification only.
+        - https + malformed pin: fail closed (UpstreamUnavailable) - a pin that
+          cannot be compared must never silently degrade to unpinned.
+        - http: pinning is impossible without TLS; warn once per server
+          (dev/demo only) and proceed.
+        """
+        server_url = entry.server.url
+        fingerprint = entry.server.tls_fingerprint
+        scheme = httpx.URL(server_url).scheme.lower()
+        if scheme != "https":
+            self._warn_pin_unenforced(
+                server_url,
+                "upstream is not https, TLS fingerprint pinning is impossible - "
+                "plain-http upstreams are for local dev/demo only",
+            )
+            key = "unpinned"
+        elif fingerprint == tls_pinning.PLACEHOLDER_FINGERPRINT:
+            self._warn_pin_unenforced(
+                server_url,
+                "catalog tls_fingerprint is the unpinned-dev placeholder - peer "
+                "identity is verified by CA trust only, not pinned to the catalog",
+            )
+            key = "unpinned"
+        elif not tls_pinning.FINGERPRINT_PATTERN.match(fingerprint):
+            raise UpstreamUnavailable(
+                f"Catalog tls_fingerprint for {server_url} is malformed - "
+                "refusing to connect",
+                detail=f"tls_fingerprint={fingerprint[:64]!r}",
+            )
+        else:
+            key = f"pin:{fingerprint}"
+
+        client = self._http_clients.get(key)
+        if client is None:
+            timeout = httpx.Timeout(30.0)
+            if key == "unpinned":
+                client = httpx.AsyncClient(
+                    timeout=timeout, verify=tls_pinning.default_ssl_context()
+                )
+            else:
+                client = httpx.AsyncClient(
+                    timeout=timeout, transport=tls_pinning.PinnedTransport(fingerprint)
+                )
+            self._http_clients[key] = client
+        return client
 
     async def _forward_to_upstream(
         self,
@@ -155,11 +225,12 @@ class CMCPProxy:
 
         Returns the concatenated text content of the MCP result.
 
-        Raises UpstreamUnavailable on transport errors / non-2xx / non-JSON,
-        UpstreamToolError when the upstream returns a JSON-RPC error object.
+        Raises UpstreamUnavailable on transport errors / non-2xx / non-JSON /
+        TLS fingerprint pin mismatch (#281, fail closed before the request is
+        sent), UpstreamToolError when the upstream returns a JSON-RPC error
+        object.
         """
-        if self._http is None:
-            self._http = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        client = self._client_for_upstream(entry)
         payload = {
             "jsonrpc": "2.0",
             "id": call_id,
@@ -167,9 +238,16 @@ class CMCPProxy:
             "params": {"name": tool_name, "arguments": arguments},
         }
         try:
-            resp = await self._http.post(entry.server.url, json=payload)
+            resp = await client.post(entry.server.url, json=payload)
             resp.raise_for_status()
             body = resp.json()
+        except tls_pinning.TLSPinMismatchError as exc:
+            raise UpstreamUnavailable(
+                f"Upstream TLS certificate fingerprint does not match the attested "
+                f"catalog pin: {entry.server.url} - connection rejected before the "
+                "request was sent (possible MITM)",
+                detail=str(exc),
+            ) from exc
         except httpx.HTTPError as exc:
             raise UpstreamUnavailable(
                 f"Upstream MCP server unreachable: {entry.server.url}",

--- a/src/cmcp_runtime/mcp/tls_pinning.py
+++ b/src/cmcp_runtime/mcp/tls_pinning.py
@@ -1,0 +1,207 @@
+"""
+TLS certificate fingerprint pinning for upstream MCP forwarding - implements #281.
+
+The attested catalog binds each tool to a server URL *and* a TLS certificate
+fingerprint (``server.tls_fingerprint``, ``"SHA256:" + base64(sha256(peer
+certificate DER))``, matching ``^SHA256:[A-Za-z0-9+/=]{43,44}$`` from
+schemas/catalog-entry.schema.json). Without enforcement, the catalog only pins
+the URL: a DNS or BGP level swap of the upstream MCP server goes undetected as
+long as the attacker presents any publicly-trusted certificate.
+
+Enforcement point (fail closed, pre-request):
+    ``PinnedTransport`` wraps the httpcore network backend so that the peer
+    certificate is checked inside ``AsyncNetworkStream.start_tls()`` - that is,
+    immediately after the TLS handshake completes and *before a single request
+    byte is written*. On a fingerprint mismatch the connection is closed and
+    ``TLSPinMismatchError`` is raised, so the request payload is never exposed
+    to the unverified peer.
+
+Standard CA verification is unchanged and runs first as part of the normal
+handshake; the pin is additive, never a replacement for PKI validation.
+
+Dev/demo escape hatches (explicit, never silent - the proxy warns once per
+server in both cases):
+  * ``PLACEHOLDER_FINGERPRINT`` (``"SHA256:" + "A" * 43 + "="``, used by every
+    shipped example catalog) means "no pin recorded yet": the proxy proceeds
+    with standard CA verification only.
+  * ``http://`` upstreams cannot be pinned at all; plain HTTP is for local
+    dev/demo only.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import re
+import ssl
+import typing
+
+import httpcore
+import httpx
+
+# "No pin recorded" placeholder used by the example catalogs and docs. A real
+# SHA-256 fingerprint of all-zero bits would be "SHA256:" followed by 43
+# base64 chars of actual digest data; 43 literal "A"s decode to 32 zero bytes,
+# which no real certificate hashes to, so the value is safe to special-case.
+PLACEHOLDER_FINGERPRINT = "SHA256:" + "A" * 43 + "="
+
+# Mirrors server.tls_fingerprint in schemas/catalog-entry.schema.json.
+FINGERPRINT_PATTERN = re.compile(r"^SHA256:[A-Za-z0-9+/=]{43,44}$")
+
+
+class TLSPinMismatchError(Exception):
+    """The peer certificate's fingerprint did not match the catalog pin.
+
+    Raised from inside the TLS handshake hook, before any request bytes are
+    written, and deliberately not an ``httpx.HTTPError`` subclass so callers
+    cannot accidentally swallow it with a generic transport-error handler.
+    """
+
+    def __init__(self, *, expected: str, actual: str) -> None:
+        super().__init__(
+            f"TLS certificate fingerprint mismatch: expected {expected}, got {actual}"
+        )
+        self.expected = expected
+        self.actual = actual
+
+
+def fingerprint_from_der(der: bytes) -> str:
+    """Catalog-format fingerprint of a certificate in DER encoding."""
+    return "SHA256:" + base64.b64encode(hashlib.sha256(der).digest()).decode("ascii")
+
+
+def fingerprints_equal(a: str, b: str) -> bool:
+    """Constant-time fingerprint compare, tolerant of optional base64 '=' padding."""
+    return hmac.compare_digest(a.rstrip("="), b.rstrip("="))
+
+
+def default_ssl_context() -> ssl.SSLContext:
+    """Standard CA-verifying client SSL context.
+
+    Module-level seam so tests can substitute a context that trusts a local
+    test CA while keeping CA verification itself enabled (the pin must stay
+    additive to PKI validation, not a replacement for it).
+    """
+    return httpx.create_ssl_context()
+
+
+class _PinnedStream(httpcore.AsyncNetworkStream):
+    """Delegating stream that verifies the peer certificate in ``start_tls()``."""
+
+    def __init__(self, inner: httpcore.AsyncNetworkStream, expected_fingerprint: str) -> None:
+        self._inner = inner
+        self._expected = expected_fingerprint
+
+    async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+        return await self._inner.read(max_bytes, timeout=timeout)
+
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+        await self._inner.write(buffer, timeout=timeout)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+    def get_extra_info(self, info: str) -> typing.Any:
+        return self._inner.get_extra_info(info)
+
+    async def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: str | None = None,
+        timeout: float | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        """Complete the TLS handshake, then enforce the fingerprint pin.
+
+        Runs after standard CA verification (part of the handshake itself) and
+        before httpcore writes any request bytes, so a mismatched peer never
+        sees the request. Fail closed: no peer certificate, or any mismatch,
+        tears the connection down and raises TLSPinMismatchError.
+        """
+        tls_stream = await self._inner.start_tls(
+            ssl_context, server_hostname=server_hostname, timeout=timeout
+        )
+        ssl_object = tls_stream.get_extra_info("ssl_object")
+        der: bytes | None = (
+            ssl_object.getpeercert(binary_form=True) if ssl_object is not None else None
+        )
+        if not der:
+            await tls_stream.aclose()
+            raise TLSPinMismatchError(expected=self._expected, actual="<no peer certificate>")
+        actual = fingerprint_from_der(der)
+        if not fingerprints_equal(actual, self._expected):
+            await tls_stream.aclose()
+            raise TLSPinMismatchError(expected=self._expected, actual=actual)
+        return tls_stream
+
+
+class _PinnedBackend(httpcore.AsyncNetworkBackend):
+    """Network backend that wraps every new connection in a ``_PinnedStream``."""
+
+    def __init__(self, inner: httpcore.AsyncNetworkBackend, expected_fingerprint: str) -> None:
+        self._inner = inner
+        self._expected = expected_fingerprint
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        stream = await self._inner.connect_tcp(
+            host,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+        return _PinnedStream(stream, self._expected)
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        stream = await self._inner.connect_unix_socket(
+            path, timeout=timeout, socket_options=socket_options
+        )
+        return _PinnedStream(stream, self._expected)
+
+    async def sleep(self, seconds: float) -> None:
+        await self._inner.sleep(seconds)
+
+
+class PinnedTransport(httpx.AsyncHTTPTransport):
+    """httpx transport that enforces a TLS certificate fingerprint pin.
+
+    Verification happens at handshake time inside the network backend (see
+    ``_PinnedStream.start_tls``), so enforcement is pre-request: a peer whose
+    certificate does not hash to ``expected_fingerprint`` never receives the
+    request. Connection reuse is safe because the pin is checked on every new
+    TLS handshake and a pooled connection keeps the certificate it was
+    verified with.
+
+    ``ssl_context`` defaults to ``default_ssl_context()`` (standard CA
+    verification); the pin is enforced in addition to, never instead of,
+    normal certificate validation.
+    """
+
+    def __init__(
+        self,
+        expected_fingerprint: str,
+        *,
+        ssl_context: ssl.SSLContext | None = None,
+    ) -> None:
+        ctx = ssl_context if ssl_context is not None else default_ssl_context()
+        super().__init__(verify=ctx)
+        # httpx.AsyncHTTPTransport exposes no public hook for a custom httpcore
+        # network backend, so rebuild the (not-yet-opened) connection pool with
+        # one that pins the handshake. ``self._pool`` is what the inherited
+        # handle_async_request() drives; stable across httpx 0.27/0.28.
+        self._pool = httpcore.AsyncConnectionPool(
+            ssl_context=ctx,
+            network_backend=_PinnedBackend(httpcore.AnyIOBackend(), expected_fingerprint),
+        )

--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -15,7 +15,7 @@ _OPAQUE_API_KEY_ENV = "OPAQUE_API_KEY"
 _OPAQUE_TIMEOUT_SECONDS = 10
 
 
-def _redact_auth_headers(headers: dict) -> dict:
+def _redact_auth_headers(headers: dict[str, str]) -> dict[str, str]:
     """HW-008: return a copy of headers with Authorization value replaced by [REDACTED]."""
     return {
         k: "[REDACTED]" if k.lower() == "authorization" else v

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -303,6 +303,59 @@ async def test_audit_payload_hash_is_canonical_sha256():
     assert entry.request_payload_hash == expected
 
 
+# ── #293: response_payload_hash in success-path audit entries ─────────────────
+
+def _sha256_of_text(text: str) -> str:
+    import hashlib
+
+    return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
+
+
+@pytest.mark.asyncio
+async def test_audit_response_payload_hash_on_success():
+    """#293 - the success-path tool_call entry must carry response_payload_hash,
+    computed over the same bytes the egress check sees."""
+    proxy, _, chain = _make_proxy()
+    wire_mock_gateway(proxy, response_text="upstream says hi")
+    result = await proxy.call_tool("c1", "test.tool", {"q": "x"})
+    assert result.allowed is True
+    entry = next(e for e in reversed(chain.entries) if e.entry_type == "tool_call")
+    assert entry.response_payload_hash == _sha256_of_text("upstream says hi")
+
+
+@pytest.mark.asyncio
+async def test_audit_response_payload_hash_uses_sanitized_content():
+    """#293 - when the scanner sanitizes the response, the audit hash must cover
+    the sanitized text (what the caller receives), not the raw upstream text."""
+    proxy, _, chain = _make_proxy()
+    wire_mock_gateway(
+        proxy,
+        response_text="raw text with SECRET-TOKEN",
+        scan_content="raw text with [REDACTED]",
+    )
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.response == "raw text with [REDACTED]"
+    entry = next(e for e in reversed(chain.entries) if e.entry_type == "tool_call")
+    assert entry.response_payload_hash == _sha256_of_text("raw text with [REDACTED]")
+    assert entry.response_payload_hash != _sha256_of_text("raw text with SECRET-TOKEN")
+
+
+@pytest.mark.asyncio
+async def test_audit_response_payload_hash_absent_when_scanner_blocks():
+    """#293 - the scanner-blocked deny entry carries no response hash: the
+    content was blocked, so there is no released response to bind."""
+    proxy, _, chain = _make_proxy()
+    wire_mock_gateway(
+        proxy,
+        scan_allowed=False,
+        threats=[{"category": "prompt_injection", "description": "x"}],
+    )
+    result = await proxy.call_tool("c1", "test.tool", {})
+    assert result.allowed is False
+    entry = next(e for e in reversed(chain.entries) if e.entry_type == "tool_call")
+    assert entry.response_payload_hash is None
+
+
 # ── POLICY-003: Cedar exception writes fault audit entry ──────────────────────
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tls_pinning.py
+++ b/tests/unit/test_tls_pinning.py
@@ -1,0 +1,303 @@
+"""Tests for upstream TLS fingerprint pinning (#281) against a real local TLS server.
+
+A self-signed certificate is generated with `cryptography` and served by a
+local HTTPS server. tls_pinning.default_ssl_context is monkeypatched to a
+context that trusts that certificate, so standard CA verification stays ON in
+every test - proving the pin is additive to, not a replacement for, PKI
+validation.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import ipaddress
+import json
+import logging
+import ssl
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.errors import UpstreamUnavailable
+from cmcp_runtime.mcp import tls_pinning
+from cmcp_runtime.session.state import SessionState
+
+_PROXY_LOGGER = "cmcp_runtime.mcp.proxy"
+
+
+class _MockMCPHandler(BaseHTTPRequestHandler):
+    """Serves canned JSON-RPC responses and counts requests actually received."""
+
+    requests_served = 0
+
+    def do_POST(self):  # noqa: N802
+        type(self).requests_served += 1
+        length = int(self.headers.get("Content-Length", 0))
+        request = json.loads(self.rfile.read(length))
+        tool = request["params"]["name"]
+        body = {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"content": [{"type": "text", "text": f"echo:{tool}"}]},
+        }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # silence test output
+        pass
+
+
+class _QuietHTTPServer(HTTPServer):
+    """Suppress tracebacks from clients that abort right after the handshake."""
+
+    def handle_error(self, request, client_address):
+        pass
+
+
+def _generate_self_signed_cert() -> tuple[bytes, bytes, bytes]:
+    """Return (key_pem, cert_pem, cert_der) for 127.0.0.1 / localhost."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return key_pem, cert.public_bytes(serialization.Encoding.PEM), cert.public_bytes(
+        serialization.Encoding.DER
+    )
+
+
+@pytest.fixture(scope="module")
+def tls_material(tmp_path_factory):
+    """Self-signed cert on disk + its catalog-format fingerprint."""
+    key_pem, cert_pem, cert_der = _generate_self_signed_cert()
+    directory = tmp_path_factory.mktemp("tls-pinning")
+    key_file = directory / "key.pem"
+    cert_file = directory / "cert.pem"
+    key_file.write_bytes(key_pem)
+    cert_file.write_bytes(cert_pem)
+    return {
+        "key_file": str(key_file),
+        "cert_file": str(cert_file),
+        "fingerprint": tls_pinning.fingerprint_from_der(cert_der),
+    }
+
+
+@pytest.fixture(scope="module")
+def tls_server(tls_material):
+    server = _QuietHTTPServer(("127.0.0.1", 0), _MockMCPHandler)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(tls_material["cert_file"], tls_material["key_file"])
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"https://127.0.0.1:{server.server_port}/mcp"
+    server.shutdown()
+
+
+@pytest.fixture(scope="module")
+def http_server():
+    server = _QuietHTTPServer(("127.0.0.1", 0), _MockMCPHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}/mcp"
+    server.shutdown()
+
+
+@pytest.fixture
+def trust_test_cert(monkeypatch, tls_material):
+    """Make default_ssl_context() trust the test CA (CA verification stays ON)."""
+    def _trusting_context() -> ssl.SSLContext:
+        return ssl.create_default_context(cafile=tls_material["cert_file"])
+
+    monkeypatch.setattr(tls_pinning, "default_ssl_context", _trusting_context)
+
+
+def _make_proxy(server_url: str, fingerprint: str):
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+
+    entry = CatalogEntry(
+        tool_name="test.echo",
+        server=ServerIdentity(
+            display_name="Pinned",
+            url=server_url,
+            tls_fingerprint=fingerprint,
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="echo", input_schema={"type": "object"}, output_schema=None
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="public",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-06-10T00:00:00Z",
+        approved_by="test",
+    )
+    catalog = ToolCatalog(entries={"test.echo": entry}, catalog_hash="sha256:" + "1" * 64)
+    config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
+    session = SessionState(session_id="pin-test")
+    chain = AuditChain("pin-test")
+    with patch("cmcp_runtime.mcp.proxy.MCPGateway"), \
+         patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"):
+        proxy = CMCPProxy(
+            catalog=catalog,
+            policy_evaluator=MagicMock(),
+            session=session,
+            audit_chain=chain,
+            config=config,
+        )
+    return proxy, entry
+
+
+def _wrong_fingerprint() -> str:
+    """A correctly-formatted pin that no real certificate hashes to."""
+    return "SHA256:" + base64.b64encode(hashlib.sha256(b"not the real cert").digest()).decode()
+
+
+def _pin_warnings(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "TLS_PIN_UNENFORCED" in r.getMessage()]
+
+
+# ── https + real pin ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_correct_pin_succeeds(tls_server, tls_material, trust_test_cert, caplog):
+    proxy, entry = _make_proxy(tls_server, tls_material["fingerprint"])
+    with caplog.at_level(logging.WARNING, logger=_PROXY_LOGGER):
+        text = await proxy._forward_to_upstream("c1", entry, "test.echo", {"m": "hi"})
+    assert text == "echo:test.echo"
+    assert _pin_warnings(caplog) == []  # enforced pins must not warn
+
+
+@pytest.mark.asyncio
+async def test_wrong_pin_fails_closed_before_request_is_sent(
+    tls_server, trust_test_cert
+):
+    proxy, entry = _make_proxy(tls_server, _wrong_fingerprint())
+    served_before = _MockMCPHandler.requests_served
+    with pytest.raises(UpstreamUnavailable, match="fingerprint does not match"):
+        await proxy._forward_to_upstream("c1", entry, "test.echo", {"secret": "x"})
+    # Fail closed means pre-request: the server never saw the payload.
+    assert _MockMCPHandler.requests_served == served_before
+
+
+@pytest.mark.asyncio
+async def test_wrong_pin_fails_closed_on_every_attempt(tls_server, trust_test_cert):
+    """A mismatch must not poison or bypass the pool: every retry fails too."""
+    proxy, entry = _make_proxy(tls_server, _wrong_fingerprint())
+    for _ in range(2):
+        with pytest.raises(UpstreamUnavailable, match="fingerprint does not match"):
+            await proxy._forward_to_upstream("c1", entry, "test.echo", {})
+
+
+@pytest.mark.asyncio
+async def test_pin_is_additive_ca_verification_still_applies(tls_server, tls_material):
+    """Correct pin but untrusted CA (no monkeypatch): the handshake itself must fail."""
+    proxy, entry = _make_proxy(tls_server, tls_material["fingerprint"])
+    with pytest.raises(UpstreamUnavailable, match="unreachable"):
+        await proxy._forward_to_upstream("c1", entry, "test.echo", {})
+
+
+# ── dev/demo escape hatches ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_placeholder_fingerprint_warns_once_and_proceeds(
+    tls_server, trust_test_cert, caplog
+):
+    proxy, entry = _make_proxy(tls_server, tls_pinning.PLACEHOLDER_FINGERPRINT)
+    with caplog.at_level(logging.WARNING, logger=_PROXY_LOGGER):
+        first = await proxy._forward_to_upstream("c1", entry, "test.echo", {})
+        second = await proxy._forward_to_upstream("c2", entry, "test.echo", {})
+    assert first == "echo:test.echo"
+    assert second == "echo:test.echo"
+    warnings = _pin_warnings(caplog)
+    assert len(warnings) == 1  # once per server, not per call
+    assert "placeholder" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_http_upstream_warns_once_and_proceeds(http_server, caplog):
+    proxy, entry = _make_proxy(http_server, _wrong_fingerprint())
+    with caplog.at_level(logging.WARNING, logger=_PROXY_LOGGER):
+        first = await proxy._forward_to_upstream("c1", entry, "test.echo", {})
+        second = await proxy._forward_to_upstream("c2", entry, "test.echo", {})
+    assert first == "echo:test.echo"
+    assert second == "echo:test.echo"
+    warnings = _pin_warnings(caplog)
+    assert len(warnings) == 1
+    assert "not https" in warnings[0].getMessage()
+
+
+# ── malformed pins fail closed ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_malformed_fingerprint_fails_closed(tls_server, trust_test_cert):
+    proxy, entry = _make_proxy(tls_server, "SHA256:not-valid-base64!")
+    served_before = _MockMCPHandler.requests_served
+    with pytest.raises(UpstreamUnavailable, match="malformed"):
+        await proxy._forward_to_upstream("c1", entry, "test.echo", {})
+    assert _MockMCPHandler.requests_served == served_before
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def test_fingerprint_from_der_is_catalog_format():
+    fp = tls_pinning.fingerprint_from_der(b"example der bytes")
+    assert tls_pinning.FINGERPRINT_PATTERN.match(fp)
+    expected = base64.b64encode(hashlib.sha256(b"example der bytes").digest()).decode()
+    assert fp == f"SHA256:{expected}"
+
+
+def test_placeholder_matches_schema_pattern():
+    assert tls_pinning.FINGERPRINT_PATTERN.match(tls_pinning.PLACEHOLDER_FINGERPRINT)
+
+
+def test_fingerprints_equal_tolerates_base64_padding():
+    fp = tls_pinning.fingerprint_from_der(b"x")
+    assert tls_pinning.fingerprints_equal(fp, fp.rstrip("="))
+    assert not tls_pinning.fingerprints_equal(fp, tls_pinning.PLACEHOLDER_FINGERPRINT)


### PR DESCRIPTION
Two security issues in one PR with separated commits (deliberately not stacked PRs, after the recent stacked-merge breakage).

## Commit 1 - Closes #293: response_payload_hash in audit entries

The success-path tool_call audit entry now carries `response_payload_hash`: sha256 over the exact post-scan bytes the egress check evaluates (sanitized text when the scanner sanitized). The audit chain now binds what came back, not just what was sent - the gap the industrial-embodied-ai example (examples#16) surfaced.

## Commit 2 - Closes #281: TLS fingerprint pinning for upstream forwarding

New `tls_pinning.PinnedTransport`: the catalog's `server.tls_fingerprint` is enforced at TLS handshake time, inside the httpcore network backend, **before a single request byte is written** - a mismatched peer never sees the request. Properties:
- Fail closed: mismatch or absent peer certificate tears down the connection (`TLSPinMismatchError`, deliberately not an `httpx.HTTPError` so generic handlers cannot swallow it; the proxy maps it to a fault audit + 502)
- Additive to CA verification, never a replacement; constant-time fingerprint compare
- Malformed pins fail closed (never silently degrade to unpinned)
- Explicit dev escape hatches, warned once per server: the all-"A" placeholder fingerprint the examples ship, and plain-http upstreams
- Per-pin client cache; pool reuse is safe (pin checked on every new handshake)

Known fragility, documented in-code: httpx exposes no public hook for a custom network backend, so the transport rebuilds its (unopened) connection pool - stable across httpx 0.27/0.28.

## Test plan

- Live TLS round-trips against a local server with a self-signed cert generated in-test: correct pin passes, wrong pin fails closed pre-request, placeholder warns + proceeds, http warns + proceeds
- Response-hash tests recompute the digest, including the sanitized-content case
- Full suite: 692 passed, 1 skipped; ruff clean; mypy clean

Generated with [Claude Code](https://claude.ai/code)