### PR TITLE
docs: add community Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   </strong>
 </p>
 
-[![CI](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/cmcp-runtime)](https://pypi.org/project/cmcp-runtime/) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agentrust-io/cmcp/badge)](https://scorecard.dev/viewer/?uri=github.com/agentrust-io/cmcp)
+[![CI](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/agentrust-io/cmcp/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/cmcp-runtime)](https://pypi.org/project/cmcp-runtime/) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agentrust-io/cmcp/badge)](https://scorecard.dev/viewer/?uri=github.com/agentrust-io/cmcp) [![Discord](https://dcbadge.limes.pink/api/server/9JWNpH7E?style=flat)](https://discord.gg/9JWNpH7E)
 
 > **Developer Preview** - launching at Confidential Computing Summit, June 23 2026. May have breaking changes before v1.0.
 
@@ -244,6 +244,8 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting and response SLAs. Se
 ## Contributing
 
 [CONTRIBUTING.md](CONTRIBUTING.md) · [GOVERNANCE.md](GOVERNANCE.md) · [Discussions](https://github.com/agentrust-io/cmcp/discussions)
+
+Join the community on [Discord](https://discord.gg/9JWNpH7E).
 
 Using cMCP in production? Add your organization to [ADOPTERS.md](ADOPTERS.md).
 


### PR DESCRIPTION
Adds the community Discord badge to the top-of-README badge block and a Discord link in the community/contributing section, mirroring the AGT pattern.

Invite: https://discord.gg/9JWNpH7E

Generated with [Claude Code](https://claude.ai/code)