### PR TITLE
docs: add mkdocs site setup for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+      - "GOVERNANCE.md"
+      - "ROADMAP.md"
+      - "LIMITATIONS.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Build and deploy docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: |
+          pip install -r requirements-docs.txt
+          pip install -e ".[dev]"
+
+      - name: Build and deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --clean

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,24 @@
+:root {
+  --md-primary-fg-color: #7c3aed;
+  --md-primary-fg-color--light: #a78bfa;
+  --md-primary-fg-color--dark: #5b21b6;
+  --md-accent-fg-color: #0ea5e9;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #818cf8;
+  --md-primary-fg-color--light: #a5b4fc;
+  --md-primary-fg-color--dark: #6366f1;
+  --md-accent-fg-color: #38bdf8;
+  --md-default-bg-color: #0f0a1e;
+  --md-default-bg-color--light: #1a1033;
+  --md-code-bg-color: #1e1533;
+}
+
+.md-header {
+  background: linear-gradient(135deg, #0d0a1f 0%, #071828 100%);
+}
+
+.md-hero__inner {
+  padding-top: 2rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,146 @@
+site_name: cMCP
+site_description: Confidential MCP Runtime — hardware-attested policy enforcement for MCP tool calls
+site_url: https://agentrust-io.github.io/cmcp
+repo_url: https://github.com/agentrust-io/cmcp
+repo_name: agentrust-io/cmcp
+edit_uri: edit/main/
+docs_dir: .
+exclude_docs: |
+  .github/
+  node_modules/
+  benchmarks/
+  src/
+  tests/
+  schemas/
+  Dockerfile
+  docker-compose.yml
+  LICENSE
+  NOTICE
+  ANTITRUST.md
+  ADOPTERS.md
+  MAINTAINERS.md
+  SECURITY.md
+  CHARTER.md
+  CODE_OF_CONDUCT.md
+  pyproject.toml
+  .gitignore
+
+theme:
+  name: material
+  logo: docs/assets/icon.svg
+  favicon: docs/assets/icon.svg
+  palette:
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.path
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+    - toc.follow
+    - header.autohide
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter, system-ui, -apple-system, sans-serif
+    code: JetBrains Mono, Cascadia Code, monospace
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            unwrap_annotated: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/agentrust-io/cmcp
+  generator: false
+
+extra_css:
+  - docs/stylesheets/extra.css
+
+nav:
+  - Home: README.md
+  - Quick Start: docs/quickstart.md
+  - Configuration: docs/configuration.md
+  - Specification:
+      - Overview: docs/SPEC.md
+      - Component Model: docs/spec/component-model.md
+      - Cedar Policy: docs/spec/cedar-policy.md
+      - Attestation: docs/spec/attestation.md
+      - Transport: docs/spec/transport.md
+      - Session Policy: docs/spec/session-policy.md
+      - Tool Identity: docs/spec/tool-identity.md
+      - Response Inspection: docs/spec/response-inspection.md
+      - Call Graph: docs/spec/call-graph.md
+      - Proxy Security: docs/spec/proxy-security.md
+      - Verification Library: docs/spec/verification-library.md
+      - Error Codes: docs/spec/error-codes.md
+      - Failure Modes: docs/spec/failure-modes.md
+      - Threat Model: docs/spec/threat-model.md
+      - Phase 2 Server: docs/spec/phase2-server.md
+  - Testing:
+      - Benchmarks: docs/testing/benchmarks.md
+      - Soak Test: docs/testing/soak-test.md
+  - Project:
+      - Limitations: LIMITATIONS.md
+      - Changelog: CHANGELOG.md
+      - Contributing: CONTRIBUTING.md
+      - Governance: GOVERNANCE.md
+      - Roadmap: ROADMAP.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-minify-plugin>=0.8
+pymdown-extensions>=10.7
+mkdocstrings[python]>=0.25
+griffe>=0.47


### PR DESCRIPTION
Adds docs site infrastructure for agentrust-io.github.io/cmcp. The README already has the docs badge pointing to this URL — this makes it work.

## Changes

- **mkdocs.yml** — `docs_dir: .` so the full nav covers both `docs/` content (quickstart, configuration, 14 spec files, 2 testing files) and root-level project docs (LIMITATIONS, CHANGELOG, CONTRIBUTING, GOVERNANCE, ROADMAP) without any stub files. API reference auto-generated from `src/` via mkdocstrings.
- **requirements-docs.txt** — mkdocs-material, minify, pymdownx, mkdocstrings. Matches agent-manifest and trace-spec pattern.
- **.github/workflows/docs.yml** — deploys to GitHub Pages on push to main when docs-relevant files change. Will activate once the repo goes public.
- **docs/stylesheets/extra.css** — purple/indigo brand theme matching the agentrust-io org palette.

## Notes

- Pages deploy will fail on private repos — workflow is ready for June 23 visibility flip.
- Nav covers all 14 spec files in `docs/spec/`, quickstart, configuration, and testing docs.