### PR TITLE
chore(deps): bump mkdocs-material >=9.7.6 and mkdocstrings >=1.0.4

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 mkdocs>=1.6.1
-mkdocs-material>=9.5
+mkdocs-material>=9.7.6
 mkdocs-minify-plugin>=0.8
 pymdown-extensions>=10.21.3
-mkdocstrings[python]>=0.25
+mkdocstrings[python]>=1.0.4
 griffe>=2.0.2


### PR DESCRIPTION
Applies the two remaining dependabot dep bumps that hit merge conflicts after the other docs-deps PRs merged in the same batch.

- `mkdocs-material`: `>=9.5` → `>=9.7.6`
- `mkdocstrings[python]`: `>=0.25` → `>=1.0.4`

Closes #309, closes #310.