### PR TITLE
docs: add v0.2.0 CHANGELOG entry and fix Quick Start package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-06-23
+## [0.2.0] - 2026-06-12
+
+### Added
+
+- Bearer-token auth (`Authorization: Bearer`) wired into the live gateway server
+- Upstream MCP forwarding: AGT pre-call interception, JSON-RPC forward to the attested catalog server, response size guard, injection/credential/PII response scanning
+- Durable SQLite audit store (WAL mode, synchronous) with TEE-anchored hash chains and orphaned-session detection
+- `POST /sessions/{id}/close` issues the signed TRACE Trust Record and rotates the session
+- Cedar `@annotation` metadata returned as structured advice on deny decisions (HITL payloads)
+- `cmcp-verify`: one-command verification of claims and signed audit bundles, tamper-evident
+- Fail-closed hardware verifiers (TPM, SEV-SNP, TDX, Opaque): no attestation evidence means no verification
+- Dev-mode records carry `platform: software-only`, never `tpm2` (requires `agentrust-trace>=0.1.1`)
+- Silent mode contract: operational logs quiet, audit evidence always recorded
+
+## [0.1.0] - 2026-06-09
 
 ### Added
 
@@ -17,5 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cmcp-verify` standalone verifier for validating TRACE Claims offline
 - Audit chain with Ed25519 signing for tamper-evident log integrity
 
-[Unreleased]: https://github.com/agentrust-io/cmcp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/agentrust-io/cmcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/agentrust-io/cmcp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/agentrust-io/cmcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Unlike tunnel-based connectivity solutions, the cMCP Runtime processes tool-call
 ## Quick Start
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 ```
 
 Create `cmcp-config.yaml`:


### PR DESCRIPTION
Two launch-blocking fixes.

**CHANGELOG**: v0.2.0 shipped June 12 but the CHANGELOG was still frozen at v0.1.0 with an empty `[Unreleased]`. Adds the full v0.2.0 entry covering bearer auth, audit store, TRACE Trust Record on session close, Cedar deny advice, `cmcp-verify`, fail-closed TEE verifiers, dev-mode platform field, and silent mode contract. Also corrects the v0.1.0 date (was `2026-06-23`, the planned launch date; actual release was June 9).

**README**: Quick Start `pip install cmcp-gateway` → `pip install cmcp-runtime`. Package was renamed from `cmcp-gateway` to `cmcp-runtime` in v0.1.0 — this is the first command any new user runs.