### PR TITLE
docs: custom domain and workflow fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,15 @@ on:
       - "GOVERNANCE.md"
       - "ROADMAP.md"
       - "LIMITATIONS.md"
+      - "CNAME"
   workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -24,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -38,5 +43,27 @@ jobs:
           pip install -r requirements-docs.txt
           pip install -e ".[dev]"
 
+      - name: Configure git for gh-deploy
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Assemble docs build directory
+        run: |
+          BUILD=.docs_build
+          mkdir -p $BUILD
+
+          if [ -d docs ]; then cp -r docs $BUILD/docs; fi
+
+          for fname in README.md CHANGELOG.md CONTRIBUTING.md GOVERNANCE.md ROADMAP.md LIMITATIONS.md CNAME; do
+            if [ -f "$fname" ]; then cp "$fname" "$BUILD/$fname"; fi
+          done
+
+          echo "Build dir contains $(find $BUILD -type f | wc -l) files"
+
+      - name: Generate build config
+        run: |
+          sed 's|^docs_dir: \.$|docs_dir: .docs_build|' mkdocs.yml > .mkdocs_build.yml
+
       - name: Build and deploy to GitHub Pages
-        run: mkdocs gh-deploy --force --clean
+        run: mkdocs gh-deploy --force --clean --config-file .mkdocs_build.yml

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+cmcp.agentrust-io.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: cMCP
 site_description: Confidential MCP Runtime — hardware-attested policy enforcement for MCP tool calls
-site_url: https://agentrust-io.github.io/cmcp
+site_url: https://cmcp.agentrust-io.com
 repo_url: https://github.com/agentrust-io/cmcp
 repo_name: agentrust-io/cmcp
 edit_uri: edit/main/


### PR DESCRIPTION
Switch site_url to cmcp.agentrust-io.com, add CNAME, fix checkout@v6→v4, add concurrency guard, add build-dir assembly to match trace-spec pattern.

## Changes
- `mkdocs.yml`: `site_url` → `https://cmcp.agentrust-io.com`
- `CNAME`: new file with `cmcp.agentrust-io.com`
- `.github/workflows/docs.yml`: fix `actions/checkout@v6` → `v4`, add `concurrency` block, add `CNAME` to trigger paths, add build-dir assembly step, use `--config-file` flag on deploy

DNS record needed: `cmcp.agentrust-io.com CNAME agentrust-io.github.io`