### PR TITLE
docs(tutorials): add cmcp tutorial series (6 tutorials)

### DIFF
--- a/docs/tutorials/cedar-policy-walkthrough.md
+++ b/docs/tutorials/cedar-policy-walkthrough.md
@@ -1,0 +1,178 @@
+# Cedar Policy Walkthrough
+
+Write and test Cedar policies that control which tools a cMCP-governed agent can call.
+
+## What you'll learn
+
+- How Cedar policy syntax maps to cMCP entity types (principal, action, resource)
+- How to write a minimal allow-all policy and a production-grade restrictive policy
+- How to test policies with `cedar-policy-analysis` before deploying
+- The most common mistakes and how to avoid them
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway
+pip install cedar-policy-analysis   # CLI for local Cedar evaluation
+```
+
+---
+
+## Understand the entity model
+
+cMCP evaluates every tool call against Cedar policies using three entities:
+
+| Entity role | cMCP type | Example value |
+|---|---|---|
+| `principal` | `cMCP::Principal` | session that initiated the call |
+| `action` | `cMCP::Action::"call_tool"` | fixed — all tool calls use this action |
+| `resource` | `cMCP::Resource` | the tool being called |
+
+The principal carries `session_id` and `workflow_id`. The resource carries `tool_name` and `server_domain`. Cedar also receives a `context` record with `session_max_sensitivity` and `workflow_id`.
+
+A tool call is denied unless at least one `permit` rule matches and no `forbid` rule matches. Cedar evaluates `forbid` before `permit`, so a `forbid` always wins.
+
+---
+
+## Write a minimal allow-all policy
+
+This policy is appropriate for local development. It permits every tool call unconditionally.
+
+Create `policies/allow-all.cedar`:
+
+```cedar
+permit (
+  principal,
+  action == Action::"call_tool",
+  resource
+);
+```
+
+Add a `policies/manifest.json` so cMCP can compute the bundle hash:
+
+```json
+{
+  "version": "0.1.0",
+  "authored_at": "2026-06-01T00:00:00Z",
+  "author_identity": "developer@example.com",
+  "commit_sha": "local-dev"
+}
+```
+
+Add a minimal `policies/schema.cedarschema` (one line, no whitespace):
+
+```
+{"cMCP":{"entityTypes":{"Principal":{"memberOfTypes":[],"shape":{"type":"Record","attributes":{"session_id":{"type":"String","required":true},"workflow_id":{"type":"String","required":true}}}},"Resource":{"memberOfTypes":[],"shape":{"type":"Record","attributes":{"tool_name":{"type":"String","required":true}}}}},"actions":{"call_tool":{"appliesTo":{"principalTypes":["cMCP::Principal"],"resourceTypes":["cMCP::Resource"],"context":{"type":"Record","attributes":{"session_max_sensitivity":{"type":"String","required":true},"workflow_id":{"type":"String","required":true}}}}}}}}
+```
+
+Start the runtime with dev mode:
+
+```bash
+CMCP_DEV_MODE=1 cmcp start --config cmcp-config.yaml
+```
+
+---
+
+## Write a production policy
+
+Production policies should be explicit about what is permitted and deny everything else. This policy allows a specific workflow to call a named set of tools, blocks calls when PII is in session, and denies all other calls by default.
+
+Create `policies/production.cedar`:
+
+```cedar
+// Permit the customer-onboarding workflow to call approved tools only
+permit (
+  principal,
+  action == Action::"call_tool",
+  resource
+)
+when {
+  context.workflow_id == "customer_onboarding" &&
+  resource.tool_name in ["crm.get_customer", "kyc.verify_identity", "salesforce.contacts"]
+};
+
+// Block salesforce.contacts when the session has reached PII sensitivity
+forbid (
+  principal,
+  action == Action::"call_tool",
+  resource
+)
+when {
+  context.session_max_sensitivity == "pii" &&
+  resource.tool_name == "salesforce.contacts"
+};
+
+// Explicit default-deny: Cedar is default-deny already, but this makes it
+// auditable — the bundle hash changes if this rule is removed
+forbid (
+  principal,
+  action == Action::"call_tool",
+  resource
+);
+```
+
+The explicit `forbid` at the bottom ensures that removing all `permit` rules does not silently open access: the default deny is now tamper-evident (changing it changes the bundle hash).
+
+---
+
+## Test a policy with cedar-policy-analysis
+
+Before loading a policy bundle into the runtime, test it locally with `cedar-policy-analysis`. This lets you verify decisions without starting the gateway.
+
+```bash
+cedar-policy-analysis evaluate \
+  --policy policies/production.cedar \
+  --schema policies/schema.cedarschema \
+  --principal '{"type":"cMCP::Principal","attributes":{"session_id":"s1","workflow_id":"customer_onboarding"}}' \
+  --action 'Action::"call_tool"' \
+  --resource '{"type":"cMCP::Resource","attributes":{"tool_name":"crm.get_customer"}}' \
+  --context '{"session_max_sensitivity":"public","workflow_id":"customer_onboarding"}'
+```
+
+Expected output: `ALLOW`
+
+Test the forbid rule:
+
+```bash
+cedar-policy-analysis evaluate \
+  --policy policies/production.cedar \
+  --schema policies/schema.cedarschema \
+  --principal '{"type":"cMCP::Principal","attributes":{"session_id":"s1","workflow_id":"customer_onboarding"}}' \
+  --action 'Action::"call_tool"' \
+  --resource '{"type":"cMCP::Resource","attributes":{"tool_name":"salesforce.contacts"}}' \
+  --context '{"session_max_sensitivity":"pii","workflow_id":"customer_onboarding"}'
+```
+
+Expected output: `DENY`
+
+---
+
+## Common mistakes
+
+**Missing `when` condition on a permit rule.** A `permit` without a `when` block allows all matching calls unconditionally. Always scope permits to at least a `workflow_id` or tool name list:
+
+```cedar
+// Wrong: permits every tool call from every principal
+permit (principal, action == Action::"call_tool", resource);
+
+// Right: scoped to a workflow and tool list
+permit (principal, action == Action::"call_tool", resource)
+when {
+  context.workflow_id == "my_workflow" &&
+  resource.tool_name in ["tool_a", "tool_b"]
+};
+```
+
+**Overly permissive resource match.** If the `resource` clause is just `resource` (wildcard), the rule applies to every tool. In a production policy, always bind the resource to a specific tool name or a named list.
+
+**Forgetting that `forbid` always wins.** If you have both a `permit` and a `forbid` that match the same call, the call is denied. Order in the policy file does not matter; Cedar semantics are: any `forbid` match overrides all `permit` matches.
+
+**Changing the schema without recomputing the bundle hash.** The bundle hash covers the schema file. Any change to `schema.cedarschema` changes the hash and invalidates `CMCP_POLICY_HASH`. After every schema or policy file change, recompute the bundle hash and update the env var before restarting the runtime.
+
+---
+
+## Summary
+
+You wrote a minimal dev policy and a production policy with workflow scoping, a PII-triggered forbid, and an explicit default-deny. You tested both with `cedar-policy-analysis` before loading them into the runtime. Any change to the policy bundle changes the `policy_bundle.hash` field in TRACE Claims, making the active policy tamper-evident.
+
+Related tutorials: [Verify a TRACE claim](./verifying-a-trace-claim.md) — confirm the policy hash in a produced claim matches what you deployed. [Multi-tenant deployment](./multi-tenant-config.md) — run per-tenant policy bundles with separate hashes.

--- a/docs/tutorials/multi-tenant-config.md
+++ b/docs/tutorials/multi-tenant-config.md
@@ -1,0 +1,271 @@
+# Multi-Tenant Deployment
+
+Run cMCP with per-tenant policy isolation by deploying separate runtime instances, each with its own Cedar bundle, catalog, and audit chain.
+
+## What you'll learn
+
+- The config-level approach to per-tenant isolation (no multi-tenant API exists)
+- How separate policy bundle hashes identify tenant policies in TRACE records
+- An example with two tenants using different tool allowlists
+- How audit chain isolation works per session
+- What verifiers see when comparing claims across tenants
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway
+```
+
+---
+
+## Understand the isolation model
+
+cMCP does not have a built-in multi-tenant API. Tenant isolation is achieved by running one gateway instance per tenant, each with its own configuration. Each instance:
+
+- Loads its own Cedar policy bundle (different `policy_bundle_path`)
+- Loads its own tool catalog (different `catalog_path`)
+- Has its own `CMCP_POLICY_HASH` and `CMCP_CATALOG_HASH`
+- Listens on a separate port (different `listen_addr`)
+- Maintains separate session state and audit chains
+
+This is the only supported isolation model. A single gateway instance with shared state does not provide tenant policy isolation.
+
+---
+
+## Lay out the directory structure
+
+```
+cmcp-tenants/
+  tenant-a/
+    cmcp-config.yaml
+    policies/
+      allow.cedar
+      manifest.json
+      schema.cedarschema
+    catalog.json
+  tenant-b/
+    cmcp-config.yaml
+    policies/
+      allow.cedar
+      manifest.json
+      schema.cedarschema
+    catalog.json
+```
+
+---
+
+## Configure tenant A
+
+Tenant A is a customer-facing workflow. It can call CRM and support tools only.
+
+`tenant-a/cmcp-config.yaml`:
+
+```yaml
+attestation:
+  provider: auto
+  enforcement_mode: enforcing
+policy_bundle_path: ./policies/
+catalog_path: ./catalog.json
+listen_addr: "0.0.0.0:8443"
+```
+
+`tenant-a/policies/allow.cedar`:
+
+```cedar
+permit (
+  principal,
+  action == Action::"call_tool",
+  resource
+)
+when {
+  resource.tool_name in ["crm.get_customer", "support.create_ticket"]
+};
+
+forbid (
+  principal,
+  action == Action::"call_tool",
+  resource
+);
+```
+
+`tenant-a/catalog.json` — includes only the two tools tenant A is allowed to call:
+
+```json
+[
+  {
+    "tool_name": "crm.get_customer",
+    "server": {
+      "display_name": "CRM Server",
+      "url": "https://crm.internal/mcp",
+      "tls_fingerprint": "SHA256:<crm-server-fingerprint>=",
+      "transport": "http-sse",
+      "rotation_mode": "key-pinned"
+    },
+    "approved_definition": { ... },
+    "definition_hash": "sha256:<hash>",
+    "sensitivity_level": "pii",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "platform-team@example.com"
+  },
+  {
+    "tool_name": "support.create_ticket",
+    ...
+  }
+]
+```
+
+---
+
+## Configure tenant B
+
+Tenant B is an internal analytics workflow. It can call data warehouse tools only.
+
+`tenant-b/cmcp-config.yaml`:
+
+```yaml
+attestation:
+  provider: auto
+  enforcement_mode: enforcing
+policy_bundle_path: ./policies/
+catalog_path: ./catalog.json
+listen_addr: "0.0.0.0:8444"
+```
+
+`tenant-b/policies/allow.cedar`:
+
+```cedar
+permit (
+  principal,
+  action == Action::"call_tool",
+  resource
+)
+when {
+  resource.tool_name in ["snowflake.query", "bigquery.read"]
+};
+
+forbid (
+  principal,
+  action == Action::"call_tool",
+  resource
+);
+```
+
+`tenant-b/catalog.json` — includes only the analytics tools.
+
+---
+
+## Start both instances
+
+Each tenant gets its own set of env vars:
+
+```bash
+# Tenant A
+CMCP_BEARER_TOKEN="$(openssl rand -hex 32)" \
+CMCP_POLICY_HASH="sha256:<tenant-a-bundle-hash>" \
+CMCP_CATALOG_HASH="sha256:<tenant-a-catalog-hash>" \
+cmcp start --config tenant-a/cmcp-config.yaml &
+
+# Tenant B
+CMCP_BEARER_TOKEN="$(openssl rand -hex 32)" \
+CMCP_POLICY_HASH="sha256:<tenant-b-bundle-hash>" \
+CMCP_CATALOG_HASH="sha256:<tenant-b-catalog-hash>" \
+cmcp start --config tenant-b/cmcp-config.yaml &
+```
+
+Each instance prints its own hashes at startup:
+
+```
+[cmcp] policy bundle loaded: sha256:<tenant-a-bundle-hash>
+[cmcp] catalog loaded: 2 tools, sha256:<tenant-a-catalog-hash>
+[cmcp] listening on 0.0.0.0:8443
+
+[cmcp] policy bundle loaded: sha256:<tenant-b-bundle-hash>
+[cmcp] catalog loaded: 2 tools, sha256:<tenant-b-catalog-hash>
+[cmcp] listening on 0.0.0.0:8444
+```
+
+The bundle hashes differ because the policy files differ.
+
+---
+
+## Compare TRACE records across tenants
+
+A TRACE claim from tenant A's gateway:
+
+```json
+{
+  "trace": {
+    "policy": {
+      "bundle_hash": "sha256:<tenant-a-bundle-hash>",
+      "enforcement_mode": "enforcing"
+    }
+  },
+  "gateway": {
+    "catalog": {
+      "hash": "sha256:<tenant-a-catalog-hash>"
+    },
+    "call_summary": {
+      "tools_invoked": ["crm.get_customer"]
+    }
+  }
+}
+```
+
+A TRACE claim from tenant B's gateway:
+
+```json
+{
+  "trace": {
+    "policy": {
+      "bundle_hash": "sha256:<tenant-b-bundle-hash>",
+      "enforcement_mode": "enforcing"
+    }
+  },
+  "gateway": {
+    "catalog": {
+      "hash": "sha256:<tenant-b-catalog-hash>"
+    },
+    "call_summary": {
+      "tools_invoked": ["snowflake.query"]
+    }
+  }
+}
+```
+
+When verifying, pass the approved hashes for the specific tenant:
+
+```python
+from cmcp_verify import verify_trace_claim, ApprovedHashes
+
+# Verifying a tenant A claim
+approved_a = ApprovedHashes(
+    policy_bundle_hash="sha256:<tenant-a-bundle-hash>",
+    tool_catalog_hash="sha256:<tenant-a-catalog-hash>",
+)
+result = verify_trace_claim(tenant_a_claim, approved_a)
+
+# Verifying a tenant B claim
+approved_b = ApprovedHashes(
+    policy_bundle_hash="sha256:<tenant-b-bundle-hash>",
+    tool_catalog_hash="sha256:<tenant-b-catalog-hash>",
+)
+result = verify_trace_claim(tenant_b_claim, approved_b)
+```
+
+If you accidentally verify a tenant B claim with tenant A's approved hashes, `policy_bundle.hash` and `tool_catalog.hash` will be in `unverified_fields` and the result will be `unverified`.
+
+---
+
+## Audit chain isolation
+
+Each session gets its own `AuditChain` instance inside the gateway. Sessions from different tenants run on different gateway processes, so their audit chains are physically separate. The `session_id` is scoped to the gateway instance. There is no cross-tenant session state.
+
+When you export the audit bundle for a session (`GET /audit/export`), the bundle contains only the entries for that session. The `gateway.audit_chain.root` and `.tip` in the TRACE claim refer to that session's chain only.
+
+---
+
+## Summary
+
+Per-tenant isolation in cMCP is one gateway instance per tenant, each with its own config, Cedar bundle, catalog, and listener port. The policy bundle hash and catalog hash differ per tenant and are recorded in TRACE claims, making tenant identity tamper-evident to verifiers. Audit chains are session-scoped and process-isolated.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — writing the per-tenant Cedar policies. [Verify a TRACE claim](./verifying-a-trace-claim.md) — verifying tenant-specific claims with the correct approved hashes.

--- a/docs/tutorials/response-inspection.md
+++ b/docs/tutorials/response-inspection.md
@@ -1,0 +1,173 @@
+# Response Inspection
+
+Tune the cMCP response inspector to block prompt injection patterns in tool responses, adjust the default pattern list to reduce false positives, and monitor inspection events in the audit chain.
+
+## What you'll learn
+
+- What the response inspection pipeline catches and how it fits into the call flow
+- The default injection detection patterns and their false-positive risks
+- What happens when a pattern fires: the call is blocked and the audit entry records why
+- How to configure allow-list exceptions for deployments with legitimate XML or role-description content
+- What audit fields to watch for inspection events
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway
+```
+
+---
+
+## Understand where inspection runs
+
+Response inspection runs after the upstream tool server returns a response, before the response is delivered to the agent. Cedar policy evaluation runs before the call; inspection runs after. The two stages are complementary: Cedar controls what calls are allowed, inspection controls what responses reach the agent.
+
+The pipeline has four stages that run in sequence. All stages run even if an earlier stage would deny — this produces a complete audit record rather than stopping at first failure:
+
+1. **Size check** — reject responses over `max_response_size_bytes` (default 2 MB)
+2. **Schema validation** — check response against the tool's `output_schema` in the catalog; strip or reject surplus fields
+3. **Sensitivity classification** — tag the response with sensitivity labels (`pii`, `hipaa_phi`, etc.) from catalog annotations and field-level schema tags
+4. **Injection detection** — scan response content for patterns that resemble injected instructions
+
+A response denied at any stage is not delivered to the agent. Session sensitivity state is updated regardless of whether the response was denied.
+
+---
+
+## Read the default injection patterns
+
+The Phase 1 default pattern list, from the source:
+
+| Pattern name | Regex | Notes |
+|---|---|---|
+| `xml_system` | `<system>.*?</system>` | XML-style system block |
+| `xml_instructions` | `<instructions>.*?</instructions>` | XML-style instructions block |
+| `xml_context` | `<context>.*?</context>` | Can match legitimate XML |
+| `ignore_previous` | `(?i)ignore (previous\|all\|above) instructions` | |
+| `disregard_system` | `(?i)disregard (your\|the) (previous\|system\|initial) (prompt\|instructions\|context)` | |
+| `persona_hijack` | `(?i)(you are now\|from now on you are\|act as) [A-Z][a-zA-Z]+` | Can match legitimate role descriptions |
+| `exfil_instruction` | `(?i)(exfiltrate\|send\|forward\|transmit) (the\|all\|this\|user\|customer) (data\|information\|context\|message)` | |
+| `system_override` | `SYSTEM OVERRIDE` | |
+| `begin_system_block` | `---BEGIN SYSTEM---` | |
+| `llama_inst` | `\[INST\].*?\[/INST\]` | Llama-style instruction markers |
+| `conv_reset` | `Human:.*?Assistant:` | Embedded conversation resets |
+
+These patterns are matched against the full response body as a UTF-8 string.
+
+The patterns `xml_context` and `persona_hijack` carry documented false-positive risk. A CRM tool that returns contact roles ("Account Executive") can match `persona_hijack`. A data API that returns XML with `<context>` elements will match `xml_context`.
+
+---
+
+## Configure the pattern list
+
+The pattern list is a configurable deployment file, not hardcoded in the binary. Provide your deployment's pattern config to override or extend the defaults.
+
+Create `inspection-config.yaml`:
+
+```yaml
+injection_patterns:
+  # Disable high-false-positive patterns for this deployment
+  disabled:
+    - xml_context
+    - persona_hijack
+
+  # Add deployment-specific patterns
+  additional:
+    - name: internal_exfil
+      regex: "(?i)(upload|post|push) (to|into) (s3|gcs|blob|external)"
+      notes: "Internal data exfil to cloud storage"
+```
+
+Reference it in `cmcp-config.yaml`:
+
+```yaml
+attestation:
+  provider: auto
+  enforcement_mode: enforcing
+policy_bundle_path: ./policies/
+catalog_path: ./catalog.json
+inspection_config_path: ./inspection-config.yaml
+```
+
+When you disable a pattern, that pattern no longer contributes to injection detection for any tool response in this deployment. Document the rationale in the config file — the config path and content are version-controlled alongside the rest of the deployment.
+
+---
+
+## Understand what happens when a pattern fires
+
+When an injection pattern matches a response:
+
+1. The response is denied. It is not delivered to the agent.
+2. The audit entry records `response_inspection_result: "injection_detected"` and `injection_pattern_matched: "<pattern_name>"`.
+3. A 50-character window centered on the match location is logged for investigation. The full response payload is not logged — it may contain sensitive data. The full response hash is available as `response_payload_hash` in the audit entry.
+4. Session sensitivity state is updated even for the denied response.
+5. The gateway returns a structured error to the agent.
+
+The audit entry fields written by the inspection pipeline:
+
+| Field | Type | Description |
+|---|---|---|
+| `response_inspection_result` | string | `"allow"`, `"allow_redacted"`, or `"deny"` |
+| `response_payload_hash` | string | SHA-256 of the response payload (hex). Present even for denied responses. |
+| `response_sensitivity_tags` | array | Sensitivity tags from Stage 3 |
+| `surplus_fields_count` | integer | Fields stripped by schema redaction, or 0 |
+| `injection_pattern_matched` | string or null | Name of the matched pattern, or null |
+
+---
+
+## Monitor inspection events in the audit chain
+
+Export the audit bundle for a session to inspect the full record:
+
+```bash
+curl http://localhost:8443/audit/export?session_id=<session_id> \
+  | python3 -m json.tool > audit-bundle.json
+```
+
+Filter for injection events:
+
+```python
+import json
+
+with open("audit-bundle.json") as f:
+    bundle = json.load(f)
+
+injection_events = [
+    e for e in bundle["entries"]
+    if e.get("response_inspection_result") == "deny"
+    and e.get("injection_pattern_matched") is not None
+]
+
+for event in injection_events:
+    print(
+        f"Tool: {event['tool_name']}, "
+        f"Pattern: {event['injection_pattern_matched']}, "
+        f"Response hash: {event['response_payload_hash']}"
+    )
+```
+
+In the TRACE claim, the presence of denied inspection events is reflected in `gateway.call_summary.tool_calls_faulted`. A session with a high ratio of denied responses to total calls is worth investigating.
+
+To verify that the audit chain has not been tampered with after export, use `verify_audit_bundle`:
+
+```python
+from cmcp_verify import verify_audit_bundle
+import json
+
+with open("audit-bundle.json") as f:
+    bundle = json.load(f)
+with open("claim.json") as f:
+    claim = json.load(f)
+
+result = verify_audit_bundle(bundle, claim)
+print(f"Bundle verified: {result.verified}, entries: {result.entry_count}")
+if result.failures:
+    print(f"Failures: {result.failures}")
+```
+
+---
+
+## Summary
+
+The response inspection pipeline runs four stages after every tool call returns. Injection detection in Stage 4 matches the full response body against configurable patterns. When a pattern fires, the response is blocked and the audit chain records the pattern name and a location window. False-positive-prone patterns (`xml_context`, `persona_hijack`) can be disabled in the deployment's inspection config. Monitor for injection events by filtering exported audit bundles on `response_inspection_result: "deny"`.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — Cedar `advice` blocks in policy rules instruct the inspection pipeline to redact named fields from the response. [Verify a TRACE claim](./verifying-a-trace-claim.md) — the audit chain that inspection writes to is verified as part of TRACE claim verification.

--- a/docs/tutorials/tee-attestation.md
+++ b/docs/tutorials/tee-attestation.md
@@ -1,0 +1,162 @@
+# TEE Attestation
+
+Deploy cMCP on real Trusted Execution Environment hardware so TRACE claims carry hardware-backed measurements instead of software-only placeholders.
+
+## What you'll learn
+
+- The valid `CMCP_TEE_PROVIDER` values and what each one requires
+- What hardware attestation actually proves (and what it does not)
+- What changes in the TRACE record when you switch from software-only to real hardware
+- AMD SEV-SNP setup: the attestation report path and what the measurement covers
+- When to use software-only versus a production TEE
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway
+```
+
+For AMD SEV-SNP: an Azure DCasv5 VM or any host running a kernel with `/dev/sev-guest`.
+For Intel TDX: an Azure DCedsv5 VM or any host with a TDX-capable processor.
+
+---
+
+## Understand the provider values
+
+The `provider` field in `cmcp-config.yaml` controls which TEE the runtime uses. Valid values (from the startup source):
+
+| `provider` value | What it requires |
+|---|---|
+| `auto` | Probes in order: `tpm`, `sev-snp`, `tdx`. Falls back to `software-only` only when `CMCP_DEV_MODE=1` is set. |
+| `tpm` | TPM 2.0 chip present and accessible. |
+| `sev-snp` | AMD SEV-SNP hardware. Requires `/dev/sev-guest` or the path set in `CMCP_AMD_SEV_SNP_REPORT_PATH`. |
+| `tdx` | Intel TDX hardware. |
+| `opaque` | Opaque Managed Runtime. Requires `OPAQUE_ATTESTATION_URL` env var. |
+| `software-only` | No hardware. Requires `CMCP_DEV_MODE=1`. |
+
+`software-only` is rejected at startup unless `CMCP_DEV_MODE=1` is set. Do not set `CMCP_DEV_MODE=1` in production.
+
+---
+
+## Understand what hardware attestation proves
+
+When the runtime starts on real TEE hardware, the TEE produces an attestation report. This report:
+
+- Is signed by hardware-resident keys that the operator cannot access
+- Contains a measurement of the workload: a hash of the code and configuration loaded into the enclave
+- Commits a runtime-supplied nonce (which includes the Ed25519 signing key fingerprint) into the report, binding the report to the specific key that will sign TRACE claims
+
+What this proves: the measurement in the TRACE claim was produced by a known workload running on the reported hardware platform. A verifier who trusts the hardware vendor's root certificates can confirm that no operator intervention occurred between enclave load and attestation.
+
+What this does not prove: the contents of individual tool call arguments or responses are not measured by the TEE. The TEE measures the workload binary and its startup configuration. Per-call evidence lives in the audit chain (hashed and chained by the workload), not in the TEE hardware report.
+
+---
+
+## Compare Level 0 (software-only) to Level 1+
+
+In `software-only` mode:
+
+- `trace.runtime.platform` is `"software-only"` (or `"tpm2"` with the dev firmware sentinel on older builds)
+- `trace.runtime.measurement` is all zeros: `sha256:0000000000000000000000000000000000000000000000000000000000000000`
+- `verify_trace_claim` returns `status: "partially_verified"` with `hardware_attestation` in `unverified_fields`
+
+On a real TEE host:
+
+- `trace.runtime.platform` reflects the hardware: `"amd-sev-snp"`, `"tpm2"`, `"intel-tdx"`, etc.
+- `trace.runtime.measurement` is the real hardware measurement — a non-zero hash specific to the loaded workload
+- `verify_trace_claim` returns `status: "verified"` with `hardware_attestation` in `verified_fields`
+
+The measurement value is deterministic for a given workload binary and startup config. If the workload binary changes (e.g., an update to `cmcp-gateway`) the measurement changes, and verifiers who pinned the previous measurement will see a mismatch.
+
+---
+
+## Set up AMD SEV-SNP
+
+On an AMD SEV-SNP VM (Azure DCasv5 or equivalent):
+
+1. Confirm the device is present:
+
+```bash
+ls -la /dev/sev-guest
+```
+
+2. Set the provider in `cmcp-config.yaml`:
+
+```yaml
+attestation:
+  provider: sev-snp
+  enforcement_mode: enforcing
+  validity_seconds: 86400
+  staleness_policy: fail_closed
+```
+
+3. Optionally, if the device is not at the default path, point the runtime at it:
+
+```bash
+export CMCP_AMD_SEV_SNP_REPORT_PATH=/dev/sev-guest
+```
+
+4. Set the required production env vars before starting:
+
+```bash
+export CMCP_BEARER_TOKEN="$(openssl rand -hex 32)"
+export CMCP_POLICY_HASH="sha256:<bundle hash>"
+export CMCP_CATALOG_HASH="sha256:<catalog hash>"
+cmcp start --config cmcp-config.yaml
+```
+
+At startup the runtime calls `get_attestation_report(nonce)` where the nonce encodes the signing key fingerprint in its first 32 bytes. The SEV-SNP hardware commits this nonce into the attestation report's `REPORT_DATA` field. The TRACE claim carries this nonce as `trace.runtime.nonce`. Verifiers re-derive the key fingerprint from `trace.cnf.jwk.x` and compare against `nonce[:32]` to confirm the signing key is bound to this specific attestation report.
+
+---
+
+## Read the changed TRACE fields
+
+After switching from software-only to SEV-SNP, the TRACE claim shows:
+
+```json
+{
+  "trace": {
+    "runtime": {
+      "platform": "amd-sev-snp",
+      "measurement": "sha256:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2",
+      "firmware_version": "1.51.00",
+      "nonce": "<base64url 64-byte nonce>"
+    }
+  }
+}
+```
+
+`measurement` is the value the SEV-SNP hardware measures at enclave load. Pin this value in `attestation.expected_measurement` to reject unknown workload versions at startup:
+
+```yaml
+attestation:
+  provider: sev-snp
+  enforcement_mode: enforcing
+  expected_measurement: "sha256:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2"
+```
+
+If the deployed binary differs from the expected measurement, the runtime exits at startup rather than producing claims with an unexpected measurement.
+
+---
+
+## Choose between software-only and a production TEE
+
+Use `software-only` when:
+- Running locally during development
+- Running CI tests that do not have access to TEE hardware
+- Evaluating policy logic before deploying to hardware
+
+Use a real TEE in production when:
+- Consumers of TRACE claims need hardware-backed evidence (compliance requirements, contractual obligations, regulated data)
+- You need the signing key bound to the hardware report (CRYPTO-001 check in `verify_trace_claim`)
+- You are protecting against threat classes T1-T4 as defined in the threat model (operator tampering, policy substitution, catalog substitution, key substitution)
+
+Software-only mode leaves all four threat classes open. The audit chain and policy hash checks still run and provide evidence, but nothing prevents an operator from restarting the runtime with a different policy bundle and a different key.
+
+---
+
+## Summary
+
+You configured cMCP for AMD SEV-SNP, confirmed the `trace.runtime.platform` and `trace.runtime.measurement` fields reflect real hardware values, and pinned the expected measurement in config. On a real TEE host, `verify_trace_claim` returns `status: "verified"` with `hardware_attestation` in `verified_fields`, providing hardware-backed assurance that the workload was not tampered with.
+
+Related tutorials: [Verify a TRACE claim](./verifying-a-trace-claim.md) — hardware attestation is one of the verification steps that determines overall status. [Multi-tenant deployment](./multi-tenant-config.md) — each tenant's policy bundle hash is separate; the hardware measurement is shared across tenants on the same host.

--- a/docs/tutorials/tls-pinning.md
+++ b/docs/tutorials/tls-pinning.md
@@ -1,0 +1,149 @@
+# TLS Pinning
+
+Configure certificate pinning for upstream tool servers so the audit chain records whether a call was made to a server whose certificate was verified at connection time.
+
+## What you'll learn
+
+- What `PLACEHOLDER_FINGERPRINT` means and why it must be replaced before production
+- How to extract the real SHA-256 fingerprint from an upstream server's certificate
+- How to set `tls_fingerprint` in `catalog.json`
+- What `evidence_class` values `"tls-pinned"` and `"hash-only"` mean in audit entries
+- What TLS pinning does and does not prove
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway
+openssl  # standard on Linux/macOS; available via Git Bash on Windows
+```
+
+---
+
+## Understand the placeholder fingerprint
+
+The quickstart `catalog.json` uses this fingerprint value:
+
+```json
+"tls_fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+```
+
+This is a sentinel, not a real certificate pin. The runtime accepts it in dev mode (`CMCP_DEV_MODE=1`) and records `evidence_class: "hash-only"` in the audit chain for every call to that server. In production the sentinel is rejected and the runtime will not start.
+
+Replace it with the real SHA-256 fingerprint of your upstream server's certificate before setting `enforcement_mode: enforcing`.
+
+---
+
+## Get the server certificate fingerprint
+
+Use `openssl s_client` to retrieve the certificate and extract its fingerprint:
+
+```bash
+openssl s_client -connect your-tool-server.example.com:443 \
+  -servername your-tool-server.example.com \
+  </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256
+```
+
+The output looks like:
+
+```
+SHA256 Fingerprint=AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78
+```
+
+Convert it to the format cMCP expects. Remove the colons and base64-encode the raw bytes:
+
+```bash
+openssl s_client -connect your-tool-server.example.com:443 \
+  -servername your-tool-server.example.com \
+  </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 \
+  | sed 's/SHA256 Fingerprint=//' \
+  | tr -d ':' \
+  | xxd -r -p \
+  | base64
+```
+
+The result is a 44-character base64 string. Prefix it with `SHA256:` in `catalog.json`.
+
+---
+
+## Set the fingerprint in catalog.json
+
+Update the `server` block for the tool entry:
+
+```json
+{
+  "tool_name": "your-company.tool-name",
+  "server": {
+    "display_name": "Your Tool Server",
+    "url": "https://your-tool-server.example.com/mcp",
+    "tls_fingerprint": "SHA256:q7AcXxYZ8nQmKpLsWdHuFrNbTgVjCeOaIyMkUvPwEx4=",
+    "transport": "http-sse",
+    "rotation_mode": "key-pinned"
+  },
+  ...
+}
+```
+
+The runtime verifies this fingerprint on every outbound connection to the tool server. If the server's certificate has changed (including rotation), the connection is refused and the call is blocked before it reaches Cedar policy evaluation.
+
+After updating `catalog.json`, recompute the catalog hash and set `CMCP_CATALOG_HASH`:
+
+```bash
+python3 -c "
+import json, hashlib
+with open('catalog.json', 'rb') as f:
+    data = f.read()
+print('sha256:' + hashlib.sha256(data).hexdigest())
+"
+```
+
+Set the result as the env var before restarting the runtime:
+
+```bash
+export CMCP_CATALOG_HASH="sha256:<hex from above>"
+cmcp start --config cmcp-config.yaml
+```
+
+---
+
+## Read the evidence class in the audit chain
+
+Every audit entry includes an `evidence_class` field. The value reflects what the runtime verified about the server connection at the time of the call:
+
+| `evidence_class` value | Meaning |
+|---|---|
+| `"tls-pinned"` | The upstream server's certificate fingerprint was verified against `catalog.json` at connection time. The call was made to the pinned server. |
+| `"hash-only"` | The tool call and response were hashed and chained, but the server certificate was not pinned. Either `PLACEHOLDER_FINGERPRINT` was used or the connection succeeded without fingerprint verification. |
+
+In your audit entries:
+
+```json
+{
+  "entry_type": "tool_call",
+  "tool_name": "your-company.tool-name",
+  "evidence_class": "tls-pinned",
+  "policy_decision": "allow",
+  ...
+}
+```
+
+`evidence_class: "tls-pinned"` appears in the TRACE Claim's audit chain and is visible to verifiers who export the audit bundle.
+
+---
+
+## Understand what TLS pinning proves and does not prove
+
+TLS pinning verifies that the runtime connected to the specific server whose certificate you approved at catalog-build time. This closes several attack vectors: DNS spoofing, certificate misissuance, and BGP hijacking that redirects tool calls to a server with a different certificate.
+
+What pinning does not prove: it does not prove non-repudiation of individual responses. The server is verified at connection time; individual response payloads are hashed and chained in the audit log (via `response_payload_hash`), but the hash alone does not prove the server signed that specific response. For response-level non-repudiation you need the upstream server to sign its responses, which is outside the scope of cMCP's current catalog format.
+
+If the upstream server rotates its certificate, you must update `catalog.json`, recompute the catalog hash, and restart the runtime. With `rotation_mode: "key-pinned"`, the runtime will refuse connections to the server after rotation until the catalog is updated.
+
+---
+
+## Summary
+
+You replaced the development sentinel fingerprint with a real SHA-256 certificate pin, updated the catalog hash, and confirmed that audit entries record `evidence_class: "tls-pinned"` for verified connections. TLS pinning prevents server substitution attacks but does not extend to individual response non-repudiation.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — the catalog is also covered by the attestation measurement. [Verify a TRACE claim](./verifying-a-trace-claim.md) — the catalog hash in the TRACE claim must match the catalog you pinned.

--- a/docs/tutorials/verifying-a-trace-claim.md
+++ b/docs/tutorials/verifying-a-trace-claim.md
@@ -1,0 +1,165 @@
+# Verify a TRACE Claim
+
+Use `cmcp_verify` to confirm that a TRACE claim produced by cMCP is cryptographically valid, bound to the approved policy and catalog, and backed by a fresh attestation.
+
+## What you'll learn
+
+- How to install and call `verify_trace_claim`
+- What `ApprovedHashes` fields are and where the values come from
+- What each field in `VerificationResult` means
+- The difference between `verified`, `partially_verified`, and `unverified`
+- Where to integrate verification in a pipeline that consumes agent output
+
+## Prerequisites
+
+```bash
+pip install cmcp-gateway   # includes cmcp_verify
+```
+
+---
+
+## Install the verify library
+
+`cmcp_verify` ships as part of `cmcp-gateway`. No separate install is needed:
+
+```python
+from cmcp_verify import verify_trace_claim, ApprovedHashes
+```
+
+---
+
+## Obtain the approved hashes
+
+The approved hashes are the SHA-256 values printed by the gateway at startup:
+
+```
+[cmcp] policy bundle loaded: sha256:abc123...
+[cmcp] catalog loaded: 3 tools, sha256:def456...
+```
+
+In production, these values come from your deployment pipeline — not from the operator. The point of verification is to confirm the runtime loaded what your organization approved, without trusting the operator's assertion. Store the hashes in your CI artifact registry or secrets manager at bundle-build time and retrieve them at verification time.
+
+---
+
+## Call verify_trace_claim
+
+```python
+import json
+from cmcp_verify import verify_trace_claim, ApprovedHashes
+
+with open("claim.json") as f:
+    claim = json.load(f)
+
+approved = ApprovedHashes(
+    policy_bundle_hash="sha256:abc123...",
+    tool_catalog_hash="sha256:def456...",
+)
+
+result = verify_trace_claim(claim, approved)
+
+print(f"Status:           {result.status.value}")
+print(f"Verified fields:  {result.verified_fields}")
+print(f"Unverified fields:{result.unverified_fields}")
+print(f"Attestation age:  {result.attestation_age_seconds}s")
+print(f"Attestation fresh:{result.is_attestation_fresh}")
+if result.failure_reason:
+    print(f"Failure reason:   {result.failure_reason}")
+if result.details:
+    print(f"Details:          {result.details}")
+```
+
+The function also accepts optional parameters:
+
+```python
+result = verify_trace_claim(
+    claim_json=claim,
+    approved=approved,
+    max_attestation_age_seconds=3600,       # default 86400; tighten for short-lived sessions
+    trusted_public_key_hex="abcdef...",     # optional: cross-check against a pinned key
+)
+```
+
+---
+
+## Read the VerificationResult
+
+`VerificationResult` has these fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `VerificationStatus` | Overall result: `"verified"`, `"partially_verified"`, or `"unverified"` |
+| `verified_fields` | `list[str]` | Fields that passed their checks |
+| `unverified_fields` | `list[str]` | Fields that failed or could not be checked |
+| `failure_reason` | `VerificationError \| None` | First failure code, or `None` on full verification |
+| `attestation_age_seconds` | `int` | Seconds since the attestation report was generated |
+| `is_attestation_fresh` | `bool` | `True` if `attestation_age_seconds <= max_attestation_age_seconds` |
+| `details` | `dict[str, str]` | Structured detail for individual check failures |
+
+`verified_fields` can include: `schema`, `signature`, `public_key_binding`, `policy_bundle.hash`, `tool_catalog.hash`, `attestation_freshness`, `audit_chain`, `hardware_attestation`, `trusted_public_key`.
+
+---
+
+## Understand partially_verified
+
+`partially_verified` means some checks passed and at least one failed. The most common reason in a correct deployment is that the gateway ran in software-only mode (`CMCP_DEV_MODE=1`): hardware attestation cannot be verified, but all cryptographic fields are valid.
+
+Example output for a dev-mode claim:
+
+```
+Status:           partially_verified
+Verified fields:  ['schema', 'signature', 'policy_bundle.hash', 'tool_catalog.hash', 'attestation_freshness', 'audit_chain']
+Unverified fields:['hardware_attestation']
+Attestation age:  8s
+Attestation fresh:True
+Details:          {'hardware_attestation': 'software-only mode - not hardware-backed'}
+```
+
+`hardware_attestation` is in `unverified_fields` but no `failure_reason` is set for it in isolation — the status rolls up to `partially_verified` because other fields were verified. On a real TEE host, `hardware_attestation` moves to `verified_fields` and status becomes `verified`.
+
+`unverified` (with no verified fields at all) means the claim is either malformed, signature-invalid, or the hashes do not match. Treat this as a hard rejection.
+
+---
+
+## Integrate verification at job start
+
+The right integration point is before your pipeline processes any agent output. Verify the TRACE claim at the start of the consuming job, before reading `tool_transcript` or acting on results:
+
+```python
+import json
+import sys
+from cmcp_verify import verify_trace_claim, ApprovedHashes
+
+def load_approved_hashes() -> ApprovedHashes:
+    # Fetch from your secrets manager / artifact registry
+    return ApprovedHashes(
+        policy_bundle_hash=get_secret("cmcp/policy-bundle-hash"),
+        tool_catalog_hash=get_secret("cmcp/catalog-hash"),
+    )
+
+def verify_session_claim(claim_path: str) -> None:
+    with open(claim_path) as f:
+        claim = json.load(f)
+
+    result = verify_trace_claim(claim, load_approved_hashes())
+
+    if result.status.value == "unverified":
+        print(f"CLAIM REJECTED: {result.failure_reason}", file=sys.stderr)
+        sys.exit(1)
+
+    if result.status.value == "partially_verified":
+        # Accept in staging; reject in production if hardware attestation is required
+        if not result.is_attestation_fresh:
+            print(f"CLAIM STALE: age={result.attestation_age_seconds}s", file=sys.stderr)
+            sys.exit(1)
+        print(f"WARNING: partially verified — {result.unverified_fields}")
+
+    print(f"Claim verified. Tools called: {claim['gateway']['call_summary']['tools_invoked']}")
+```
+
+---
+
+## Summary
+
+You called `verify_trace_claim` with `ApprovedHashes` sourced from your deployment pipeline (not from the operator), read `VerificationResult` fields to distinguish full verification from partial (dev-mode) verification, and integrated the check at pipeline entry. A claim that returns `unverified` must be rejected before any downstream processing uses the session output.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — the policy bundle hash you verify here is the hash of the Cedar bundle loaded at runtime. [TEE attestation](./tee-attestation.md) — switching from software-only to a real TEE makes `hardware_attestation` move from `unverified_fields` to `verified_fields`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,13 @@ nav:
   - Home: README.md
   - Quick Start: docs/quickstart.md
   - Configuration: docs/configuration.md
+  - Tutorials:
+      - Cedar policy walkthrough: docs/tutorials/cedar-policy-walkthrough.md
+      - TLS pinning: docs/tutorials/tls-pinning.md
+      - Verify a TRACE claim: docs/tutorials/verifying-a-trace-claim.md
+      - TEE attestation: docs/tutorials/tee-attestation.md
+      - Multi-tenant deployment: docs/tutorials/multi-tenant-config.md
+      - Response inspection: docs/tutorials/response-inspection.md
   - Specification:
       - Overview: docs/SPEC.md
       - Component Model: docs/spec/component-model.md


### PR DESCRIPTION
Adds six tutorial pages covering Cedar policy, TLS pinning, TRACE claim verification, TEE attestation, multi-tenant deployment, and response inspection. Part of the agentrust-io tutorial series for the CC Summit launch.