### PR TITLE
fix: remove commercial-program language from specs and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Issues in this repo track spec decisions, not implementation bugs. Each issue co
 
 | File | Covers | Phase | Status | Issues |
 |------|--------|-------|--------|--------|
-| docs/SPEC.md | Problem taxonomy, coverage matrix, target customer, success metric | 1+2 | Draft v0.1 | - |
+| docs/SPEC.md | Problem taxonomy, coverage matrix, Phase 1/2 scope | 1+2 | Draft v0.1 | - |
 | docs/spec/component-model.md | All MCP components, trust levels, hardware vs. software boundaries | 1+2 | Draft v0.1 | #43 |
 | docs/spec/transport.md | HTTP/SSE scope, stdio gap, SPIFFE-to-TEE binding spike | 1 | Draft v0.1 | #20, #21 |
 | docs/spec/attestation.md | TEE provider detection, audit chain, key management, catalog pinning | 1 | Draft v0.1 | #5, #6, #23, #33, #38 |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,7 +1,6 @@
 ﻿# cMCP Runtime - Product Specification
 
-Status: Draft | Target: CC Summit June 23, 2026
-Primary opportunity: Enterprises cannot prove to regulators, auditors, or customers how their data was handled during AI processing.
+Status: Draft v0.1
 
 Architectural conviction: in the agent era, the agent-to-tool boundary is a primary control surface, not a backup to deterministic backends. Primary control surfaces must be tamper-evident in hardware. Phase 1 attests that boundary on the consumer side (the gateway). Phase 2 attests it on the provider side (the server).
 
@@ -292,4 +291,4 @@ Five attestable properties unique to Phase 2:
 | Multi-tenant isolation hardware-provable | SaaS providers demonstrate that tenant boundaries were enforced, not just configured. |
 | Cross-organizational attestation chains | Party A verifies party B's server directly -- no shared operator, no SOC 2 in between. |
 
-Not the current build focus. Revisit after Phase 1 GA and first design partner cohort feedback.
+Not the current build focus. Revisit after Phase 1 GA and early production feedback.

--- a/docs/spec/phase2-server.md
+++ b/docs/spec/phase2-server.md
@@ -8,7 +8,7 @@ Stability: Unstable , expect breaking changes before v1.0
 
 ## Section 1 : Phase 2 Architecture Overview
 
-Phase 2 targets a different buyer than Phase 1. The Phase 1 buyer is an agent developer who deploys a runtime in front of their own agents. The Phase 2 buyer is a SaaS vendor or AI platform provider who exposes MCP endpoints to enterprise customers. Their enterprise customers - Phase 1 buyers - eventually ask: "prove your server code has not changed since I approved it." Phase 2 answers that question.
+Phase 2 targets a different deployer than Phase 1. The Phase 1 deployer is an agent developer who runs a runtime in front of their own agents. The Phase 2 deployer is a SaaS vendor or AI platform provider who exposes MCP endpoints to enterprise customers. Those enterprise customers — Phase 1 deployers — eventually ask: "prove your server code has not changed since I approved it." Phase 2 answers that question.
 
 Phase 1 closes from the agent side: the runtime attests what the agent sent and what policy was applied. Phase 2 closes from the server side: the MCP server binary, its tool surface, and its egress behavior are all measured inside a TEE and published as a second TRACE Claim that any enterprise verifier can check without trusting the SaaS operator.
 
@@ -44,7 +44,7 @@ SaaS / Platform Provider
 
 The combined trust artifact delivered to the verifier is a pair of TRACE Claims: the Phase 1 runtime claim (proves runtime policy ran) and the Phase 2 server claim (proves server binary and tool surface are attested). Neither claim requires trusting the other party's operator.
 
-**Sequencing note.** Phase 2 is the natural pull from Phase 1 adoption. It is not the current build focus. Revisit after Phase 1 GA and first design partner cohort feedback.
+**Sequencing note.** Phase 2 is the natural pull from Phase 1 adoption. It is not the current build focus. Revisit after Phase 1 GA and early production feedback.
 
 ---
 
@@ -186,7 +186,7 @@ Maximum bytes buffered before forced termination: configurable per tool, default
 
 ## Section 4 : Phase 2 Proxy Reliability Targets
 
-These targets apply to the proxy classification path under nominal load with a representative policy suite. They are design targets for the Phase 2 implementation milestone; final values will be validated against benchmark results from the first design partner deployments.
+These targets apply to the proxy classification path under nominal load with a representative policy suite. They are design targets for the Phase 2 implementation milestone; final values will be validated against benchmark results from early production deployments.
 
 | Metric | Target | Notes |
 |---|---|---|

--- a/examples/bfsi-demo/README.md
+++ b/examples/bfsi-demo/README.md
@@ -1,6 +1,6 @@
 # BFSI Demo : cMCP Gateway
 
-Demonstrates the CC Summit demo scenario: an agent calls financial tools, the gateway enforces Cedar policies, and produces a TRACE Claim an auditor can verify.
+Demonstrates a financial services governance scenario: an agent calls financial tools, the gateway enforces Cedar policies, and produces a TRACE Claim an auditor can verify.
 
 ## Scenario
 


### PR DESCRIPTION
## Summary

Removes internal commercial information that leaked into public-facing files:

- **docs/SPEC.md**: Removed `Target: CC Summit June 23, 2026` internal tracking header and `Primary opportunity:` GTM framing line (sales positioning has no place in an OSS spec). Replaced "design partner cohort" with "early production" in the Phase 2 out-of-scope note.
- **docs/spec/phase2-server.md**: Replaced "buyer" with "deployer" throughout — sales persona framing doesn't belong in a technical spec. Also replaced two instances of "design partner deployments/cohort" with "early production deployments/feedback."
- **examples/bfsi-demo/README.md**: Removed "CC Summit demo scenario" reference that tied the example to an internal launch event. Replaced with a generic scenario description.
- **docs/README.md**: Updated stale spec index row that still referenced "target customer, success metric" sections that were removed from SPEC.md in PR #326.

## Test plan

- [ ] CI passes
- [ ] `grep -r "design partner\|Primary opportunity\|CC Summit demo\|target customer\|success metric" docs/` returns no hits
- [ ] `grep -r "buyer" docs/spec/phase2-server.md` returns no hits