### PR TITLE
fix(schema): add software-only to platform enum; fix gateway field drift (#324)

### DIFF
--- a/schemas/trace-claim.schema.json
+++ b/schemas/trace-claim.schema.json
@@ -41,7 +41,8 @@
               "type": "string",
               "enum": [
                 "intel-tdx", "amd-sev-snp", "nvidia-h100", "nvidia-blackwell",
-                "aws-nitro", "arm-cca", "google-confidential-space", "tpm2"
+                "aws-nitro", "arm-cca", "google-confidential-space", "tpm2",
+                "software-only"
               ]
             },
             "measurement": {
@@ -135,6 +136,12 @@
       "description": "cmcp-specific addenda outside the canonical TRACE spec.",
       "properties": {
         "session_id": { "type": "string" },
+        "gateway_version": { "type": "string" },
+        "sequence_number": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Monotonically increasing claim counter for this gateway instance (AUDIT-005)."
+        },
         "audit_chain": {
           "type": "object",
           "additionalProperties": false,

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -504,3 +504,17 @@ def test_transcript_entries_optional():
     claim = _make_claim()
     assert claim.trace.tool_transcript.entries is None
     assert claim.trace.tool_transcript.call_count == 2
+
+
+# ── JSON schema conformance (#324) ──────────────────────────────────────────────
+
+
+def test_software_only_claim_validates_against_json_schema():
+    """A software-only claim must pass JSON schema validation (issue #324)."""
+    import pathlib
+    import jsonschema
+
+    schema_path = pathlib.Path(__file__).parents[2] / "schemas" / "trace-claim.schema.json"
+    schema = json.loads(schema_path.read_text())
+    claim = _make_claim()
+    jsonschema.validate(instance=_to_dict(claim), schema=schema)

--- a/tests/unit/test_trace_claim.py
+++ b/tests/unit/test_trace_claim.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import base64
 import json
+import pathlib
+
+import jsonschema
 
 from cmcp_runtime.audit.chain import AuditChain
 from cmcp_runtime.audit.keys import SigningKey
@@ -511,9 +514,6 @@ def test_transcript_entries_optional():
 
 def test_software_only_claim_validates_against_json_schema():
     """A software-only claim must pass JSON schema validation (issue #324)."""
-    import pathlib
-    import jsonschema
-
     schema_path = pathlib.Path(__file__).parents[2] / "schemas" / "trace-claim.schema.json"
     schema = json.loads(schema_path.read_text())
     claim = _make_claim()


### PR DESCRIPTION
## Summary

- Adds `"software-only"` to `trace.runtime.platform.enum` in `schemas/trace-claim.schema.json` — fixes the schema rejection reported in #324
- Also adds `gateway_version` and `sequence_number` to the `gateway` properties block; the runtime was emitting both but neither was declared, causing `additionalProperties: false` to reject any schema-validated claim
- Adds `test_software_only_claim_validates_against_json_schema` to catch this class of drift going forward: generates a real software-only `RuntimeClaim`, serializes it, and validates against the exported schema file

## Test plan

- [ ] `python -m pytest tests/unit/test_trace_claim.py::test_software_only_claim_validates_against_json_schema` — new test, must pass
- [ ] `python -m pytest -x -q` — full suite, 734 passed locally
- [ ] Manual: run the reproduction script from #324 — `jsonschema.validate` must succeed

Closes #324