### PR TITLE
fix(docs): correct hallucinations and wrong values in tutorials

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,7 @@ pip --version
 ## Install
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 ```
 
 This installs:

--- a/docs/tutorials/cedar-policy-walkthrough.md
+++ b/docs/tutorials/cedar-policy-walkthrough.md
@@ -6,14 +6,14 @@ Write and test Cedar policies that control which tools a cMCP-governed agent can
 
 - How Cedar policy syntax maps to cMCP entity types (principal, action, resource)
 - How to write a minimal allow-all policy and a production-grade restrictive policy
-- How to test policies with `cedar-policy-analysis` before deploying
+- How to test policies with the `cedar` CLI before deploying
 - The most common mistakes and how to avoid them
 
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway
-pip install cedar-policy-analysis   # CLI for local Cedar evaluation
+pip install cmcp-runtime
+cargo install cedar-policy-cli   # Cedar CLI for local policy evaluation
 ```
 
 ---
@@ -43,7 +43,7 @@ Create `policies/allow-all.cedar`:
 ```cedar
 permit (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 );
 ```
@@ -83,7 +83,7 @@ Create `policies/production.cedar`:
 // Permit the customer-onboarding workflow to call approved tools only
 permit (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 )
 when {
@@ -94,7 +94,7 @@ when {
 // Block salesforce.contacts when the session has reached PII sensitivity
 forbid (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 )
 when {
@@ -106,7 +106,7 @@ when {
 // auditable — the bundle hash changes if this rule is removed
 forbid (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 );
 ```
@@ -115,17 +115,17 @@ The explicit `forbid` at the bottom ensures that removing all `permit` rules doe
 
 ---
 
-## Test a policy with cedar-policy-analysis
+## Test a policy with the cedar CLI
 
-Before loading a policy bundle into the runtime, test it locally with `cedar-policy-analysis`. This lets you verify decisions without starting the gateway.
+Before loading a policy bundle into the runtime, test it locally with the `cedar` CLI. Install it with `cargo install cedar-policy-cli`. This lets you verify decisions without starting the gateway.
 
 ```bash
-cedar-policy-analysis evaluate \
-  --policy policies/production.cedar \
+cedar authorize \
+  --policies policies/production.cedar \
   --schema policies/schema.cedarschema \
-  --principal '{"type":"cMCP::Principal","attributes":{"session_id":"s1","workflow_id":"customer_onboarding"}}' \
-  --action 'Action::"call_tool"' \
-  --resource '{"type":"cMCP::Resource","attributes":{"tool_name":"crm.get_customer"}}' \
+  --principal 'cMCP::Principal::"s1"' \
+  --action 'cMCP::Action::"call_tool"' \
+  --resource 'cMCP::Resource::"crm.get_customer"' \
   --context '{"session_max_sensitivity":"public","workflow_id":"customer_onboarding"}'
 ```
 
@@ -134,12 +134,12 @@ Expected output: `ALLOW`
 Test the forbid rule:
 
 ```bash
-cedar-policy-analysis evaluate \
-  --policy policies/production.cedar \
+cedar authorize \
+  --policies policies/production.cedar \
   --schema policies/schema.cedarschema \
-  --principal '{"type":"cMCP::Principal","attributes":{"session_id":"s1","workflow_id":"customer_onboarding"}}' \
-  --action 'Action::"call_tool"' \
-  --resource '{"type":"cMCP::Resource","attributes":{"tool_name":"salesforce.contacts"}}' \
+  --principal 'cMCP::Principal::"s1"' \
+  --action 'cMCP::Action::"call_tool"' \
+  --resource 'cMCP::Resource::"salesforce.contacts"' \
   --context '{"session_max_sensitivity":"pii","workflow_id":"customer_onboarding"}'
 ```
 
@@ -153,10 +153,10 @@ Expected output: `DENY`
 
 ```cedar
 // Wrong: permits every tool call from every principal
-permit (principal, action == Action::"call_tool", resource);
+permit (principal, action == cMCP::Action::"call_tool", resource);
 
 // Right: scoped to a workflow and tool list
-permit (principal, action == Action::"call_tool", resource)
+permit (principal, action == cMCP::Action::"call_tool", resource)
 when {
   context.workflow_id == "my_workflow" &&
   resource.tool_name in ["tool_a", "tool_b"]
@@ -173,6 +173,6 @@ when {
 
 ## Summary
 
-You wrote a minimal dev policy and a production policy with workflow scoping, a PII-triggered forbid, and an explicit default-deny. You tested both with `cedar-policy-analysis` before loading them into the runtime. Any change to the policy bundle changes the `policy_bundle.hash` field in TRACE Claims, making the active policy tamper-evident.
+You wrote a minimal dev policy and a production policy with workflow scoping, a PII-triggered forbid, and an explicit default-deny. You tested both with the `cedar` CLI before loading them into the runtime. Any change to the policy bundle changes the `policy_bundle.hash` field in TRACE Claims, making the active policy tamper-evident.
 
 Related tutorials: [Verify a TRACE claim](./verifying-a-trace-claim.md) — confirm the policy hash in a produced claim matches what you deployed. [Multi-tenant deployment](./multi-tenant-config.md) — run per-tenant policy bundles with separate hashes.

--- a/docs/tutorials/multi-tenant-config.md
+++ b/docs/tutorials/multi-tenant-config.md
@@ -74,7 +74,7 @@ listen_addr: "0.0.0.0:8443"
 ```cedar
 permit (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 )
 when {
@@ -83,7 +83,7 @@ when {
 
 forbid (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 );
 ```
@@ -136,7 +136,7 @@ listen_addr: "0.0.0.0:8444"
 ```cedar
 permit (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 )
 when {
@@ -145,7 +145,7 @@ when {
 
 forbid (
   principal,
-  action == Action::"call_tool",
+  action == cMCP::Action::"call_tool",
   resource
 );
 ```

--- a/docs/tutorials/multi-tenant-config.md
+++ b/docs/tutorials/multi-tenant-config.md
@@ -13,7 +13,7 @@ Run cMCP with per-tenant policy isolation by deploying separate runtime instance
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 ```
 
 ---

--- a/docs/tutorials/response-inspection.md
+++ b/docs/tutorials/response-inspection.md
@@ -1,19 +1,18 @@
 # Response Inspection
 
-Tune the cMCP response inspector to block prompt injection patterns in tool responses, adjust the default pattern list to reduce false positives, and monitor inspection events in the audit chain.
+Monitor prompt injection detection in tool responses and understand the audit trail that inspection events produce.
 
 ## What you'll learn
 
 - What the response inspection pipeline catches and how it fits into the call flow
 - The default injection detection patterns and their false-positive risks
 - What happens when a pattern fires: the call is blocked and the audit entry records why
-- How to configure allow-list exceptions for deployments with legitimate XML or role-description content
 - What audit fields to watch for inspection events
 
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 ```
 
 ---
@@ -35,60 +34,26 @@ A response denied at any stage is not delivered to the agent. Session sensitivit
 
 ## Read the default injection patterns
 
-The Phase 1 default pattern list, from the source:
+The Phase 1 default pattern list, from `src/cmcp_runtime/inspection/patterns_v1.json`:
 
 | Pattern name | Regex | Notes |
 |---|---|---|
-| `xml_system` | `<system>.*?</system>` | XML-style system block |
-| `xml_instructions` | `<instructions>.*?</instructions>` | XML-style instructions block |
-| `xml_context` | `<context>.*?</context>` | Can match legitimate XML |
-| `ignore_previous` | `(?i)ignore (previous\|all\|above) instructions` | |
-| `disregard_system` | `(?i)disregard (your\|the) (previous\|system\|initial) (prompt\|instructions\|context)` | |
-| `persona_hijack` | `(?i)(you are now\|from now on you are\|act as) [A-Z][a-zA-Z]+` | Can match legitimate role descriptions |
-| `exfil_instruction` | `(?i)(exfiltrate\|send\|forward\|transmit) (the\|all\|this\|user\|customer) (data\|information\|context\|message)` | |
-| `system_override` | `SYSTEM OVERRIDE` | |
-| `begin_system_block` | `---BEGIN SYSTEM---` | |
-| `llama_inst` | `\[INST\].*?\[/INST\]` | Llama-style instruction markers |
-| `conv_reset` | `Human:.*?Assistant:` | Embedded conversation resets |
+| `xml-system-tag` | `<system>[\s\S]*?</system>` | XML-style system block |
+| `xml-instructions-tag` | `<instructions>[\s\S]*?</instructions>` | XML-style instructions block |
+| `xml-context-tag` | `<context>[\s\S]*?</context>` | Can match legitimate XML |
+| `ignore-instructions` | `(?i)ignore (previous\|all\|above) instructions` | |
+| `disregard-instructions` | `(?i)disregard (your\|the) (previous\|system\|initial) (prompt\|instructions\|context)` | |
+| `persona-hijack` | `(?i)(you are now\|from now on you are\|act as) [A-Z][a-zA-Z]+` | Can match legitimate role descriptions |
+| `exfiltrate` | `(?i)(exfiltrate\|send\|forward\|transmit) (the\|all\|this\|user\|customer) (data\|information\|context\|message)` | |
+| `system-override` | `SYSTEM OVERRIDE` | |
+| `begin-system-marker` | `---BEGIN SYSTEM---` | |
+| `llama-instruction-markers` | `\[INST\][\s\S]*?\[/INST\]` | Llama-style instruction markers |
 
 These patterns are matched against the full response body as a UTF-8 string.
 
-The patterns `xml_context` and `persona_hijack` carry documented false-positive risk. A CRM tool that returns contact roles ("Account Executive") can match `persona_hijack`. A data API that returns XML with `<context>` elements will match `xml_context`.
+The patterns `xml-context-tag` and `persona-hijack` carry documented false-positive risk. A CRM tool that returns contact roles ("Account Executive") can match `persona-hijack`. A data API that returns XML with `<context>` elements will match `xml-context-tag`.
 
----
-
-## Configure the pattern list
-
-The pattern list is a configurable deployment file, not hardcoded in the binary. Provide your deployment's pattern config to override or extend the defaults.
-
-Create `inspection-config.yaml`:
-
-```yaml
-injection_patterns:
-  # Disable high-false-positive patterns for this deployment
-  disabled:
-    - xml_context
-    - persona_hijack
-
-  # Add deployment-specific patterns
-  additional:
-    - name: internal_exfil
-      regex: "(?i)(upload|post|push) (to|into) (s3|gcs|blob|external)"
-      notes: "Internal data exfil to cloud storage"
-```
-
-Reference it in `cmcp-config.yaml`:
-
-```yaml
-attestation:
-  provider: auto
-  enforcement_mode: enforcing
-policy_bundle_path: ./policies/
-catalog_path: ./catalog.json
-inspection_config_path: ./inspection-config.yaml
-```
-
-When you disable a pattern, that pattern no longer contributes to injection detection for any tool response in this deployment. Document the rationale in the config file — the config path and content are version-controlled alongside the rest of the deployment.
+The pattern list is compiled into the binary from `patterns_v1.json`. There is no runtime config key to disable individual patterns or add custom patterns in the current release — customization requires rebuilding with a modified patterns file.
 
 ---
 
@@ -168,6 +133,6 @@ if result.failures:
 
 ## Summary
 
-The response inspection pipeline runs four stages after every tool call returns. Injection detection in Stage 4 matches the full response body against configurable patterns. When a pattern fires, the response is blocked and the audit chain records the pattern name and a location window. False-positive-prone patterns (`xml_context`, `persona_hijack`) can be disabled in the deployment's inspection config. Monitor for injection events by filtering exported audit bundles on `response_inspection_result: "deny"`.
+The response inspection pipeline runs four stages after every tool call returns. Injection detection in Stage 4 matches the full response body against the patterns in `patterns_v1.json`. When a pattern fires, the response is blocked and the audit chain records the pattern name and a location window. Monitor for injection events by filtering exported audit bundles on `response_inspection_result: "deny"`.
 
 Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — Cedar `advice` blocks in policy rules instruct the inspection pipeline to redact named fields from the response. [Verify a TRACE claim](./verifying-a-trace-claim.md) — the audit chain that inspection writes to is verified as part of TRACE claim verification.

--- a/docs/tutorials/tee-attestation.md
+++ b/docs/tutorials/tee-attestation.md
@@ -13,7 +13,7 @@ Deploy cMCP on real Trusted Execution Environment hardware so TRACE claims carry
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 ```
 
 For AMD SEV-SNP: an Azure DCasv5 VM or any host running a kernel with `/dev/sev-guest`.
@@ -29,7 +29,7 @@ The `provider` field in `cmcp-config.yaml` controls which TEE the runtime uses. 
 |---|---|
 | `auto` | Probes in order: `tpm`, `sev-snp`, `tdx`. Falls back to `software-only` only when `CMCP_DEV_MODE=1` is set. |
 | `tpm` | TPM 2.0 chip present and accessible. |
-| `sev-snp` | AMD SEV-SNP hardware. Requires `/dev/sev-guest` or the path set in `CMCP_AMD_SEV_SNP_REPORT_PATH`. |
+| `sev-snp` | AMD SEV-SNP hardware. Requires `/dev/sev-guest` (device path is hardcoded; no env var override). |
 | `tdx` | Intel TDX hardware. |
 | `opaque` | Opaque Managed Runtime. Requires `OPAQUE_ATTESTATION_URL` env var. |
 | `software-only` | No hardware. Requires `CMCP_DEV_MODE=1`. |
@@ -66,7 +66,7 @@ On a real TEE host:
 - `trace.runtime.measurement` is the real hardware measurement — a non-zero hash specific to the loaded workload
 - `verify_trace_claim` returns `status: "verified"` with `hardware_attestation` in `verified_fields`
 
-The measurement value is deterministic for a given workload binary and startup config. If the workload binary changes (e.g., an update to `cmcp-gateway`) the measurement changes, and verifiers who pinned the previous measurement will see a mismatch.
+The measurement value is deterministic for a given workload binary and startup config. If the workload binary changes (e.g., an update to `cmcp-runtime`) the measurement changes, and verifiers who pinned the previous measurement will see a mismatch.
 
 ---
 
@@ -90,13 +90,7 @@ attestation:
   staleness_policy: fail_closed
 ```
 
-3. Optionally, if the device is not at the default path, point the runtime at it:
-
-```bash
-export CMCP_AMD_SEV_SNP_REPORT_PATH=/dev/sev-guest
-```
-
-4. Set the required production env vars before starting:
+3. Set the required production env vars before starting:
 
 ```bash
 export CMCP_BEARER_TOKEN="$(openssl rand -hex 32)"
@@ -118,7 +112,7 @@ After switching from software-only to SEV-SNP, the TRACE claim shows:
   "trace": {
     "runtime": {
       "platform": "amd-sev-snp",
-      "measurement": "sha256:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2",
+      "measurement": "sha384:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
       "firmware_version": "1.51.00",
       "nonce": "<base64url 64-byte nonce>"
     }
@@ -132,7 +126,7 @@ After switching from software-only to SEV-SNP, the TRACE claim shows:
 attestation:
   provider: sev-snp
   enforcement_mode: enforcing
-  expected_measurement: "sha256:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2"
+  expected_measurement: "sha384:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 ```
 
 If the deployed binary differs from the expected measurement, the runtime exits at startup rather than producing claims with an unexpected measurement.

--- a/docs/tutorials/tls-pinning.md
+++ b/docs/tutorials/tls-pinning.md
@@ -13,7 +13,7 @@ Configure certificate pinning for upstream tool servers so the audit chain recor
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway
+pip install cmcp-runtime
 openssl  # standard on Linux/macOS; available via Git Bash on Windows
 ```
 
@@ -27,7 +27,7 @@ The quickstart `catalog.json` uses this fingerprint value:
 "tls_fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 ```
 
-This is a sentinel, not a real certificate pin. The runtime accepts it in dev mode (`CMCP_DEV_MODE=1`) and records `evidence_class: "hash-only"` in the audit chain for every call to that server. In production the sentinel is rejected and the runtime will not start.
+This is a sentinel, not a real certificate pin. When the runtime encounters this placeholder it logs a one-time warning and falls back to standard CA verification — the connection proceeds but peer identity is verified by CA trust only, not pinned to the catalog. The audit chain records `evidence_class: "hash-only"` for every call to that server.
 
 Replace it with the real SHA-256 fingerprint of your upstream server's certificate before setting `enforcement_mode: enforcing`.
 
@@ -87,14 +87,18 @@ Update the `server` block for the tool entry:
 
 The runtime verifies this fingerprint on every outbound connection to the tool server. If the server's certificate has changed (including rotation), the connection is refused and the call is blocked before it reaches Cedar policy evaluation.
 
-After updating `catalog.json`, recompute the catalog hash and set `CMCP_CATALOG_HASH`:
+After updating `catalog.json`, recompute the catalog hash and set `CMCP_CATALOG_HASH`.
+
+The runtime computes the hash over the canonical JSON of the catalog entries sorted by `tool_name` — not over the raw file bytes. The snippet below replicates that computation exactly:
 
 ```bash
 python3 -c "
 import json, hashlib
-with open('catalog.json', 'rb') as f:
-    data = f.read()
-print('sha256:' + hashlib.sha256(data).hexdigest())
+with open('catalog.json') as f:
+    entries = json.load(f)
+sorted_entries = sorted(entries, key=lambda e: e['tool_name'])
+canonical = json.dumps(sorted_entries, sort_keys=True, separators=(',', ':'), ensure_ascii=True)
+print('sha256:' + hashlib.sha256(canonical.encode()).hexdigest())
 "
 ```
 

--- a/docs/tutorials/verifying-a-trace-claim.md
+++ b/docs/tutorials/verifying-a-trace-claim.md
@@ -13,14 +13,14 @@ Use `cmcp_verify` to confirm that a TRACE claim produced by cMCP is cryptographi
 ## Prerequisites
 
 ```bash
-pip install cmcp-gateway   # includes cmcp_verify
+pip install cmcp-runtime   # includes cmcp_verify
 ```
 
 ---
 
 ## Install the verify library
 
-`cmcp_verify` ships as part of `cmcp-gateway`. No separate install is needed:
+`cmcp_verify` ships as part of `cmcp-runtime`. No separate install is needed:
 
 ```python
 from cmcp_verify import verify_trace_claim, ApprovedHashes


### PR DESCRIPTION
## Summary

Systematic audit of all 7 tutorial files against actual source code found 9 categories of issues. All fixed.

## Fixes

| File | Issues fixed |
|---|---|
| All 7 files | `pip install cmcp-gateway` → `pip install cmcp-runtime` (wrong PyPI package name) |
| `cedar-policy-walkthrough.md` | `cedar-policy-analysis` (nonexistent pip package) → `cedar-policy-cli` (Rust crate via cargo); added `cMCP::` namespace to all Cedar `Action` and `Resource` references |
| `response-inspection.md` | Removed fabricated `inspection_config_path` config key (not in `_KNOWN_TOP_KEYS`, causes `ConfigError`); fixed all pattern names from underscore to hyphen-separated to match `patterns_v1.json`; removed `conv_reset` (does not exist) |
| `tls-pinning.md` | Fixed sentinel behavior description (warns + falls back to CA, does not fail closed); fixed catalog hash snippet to use canonical JSON re-serialization matching `catalog/loader.py _catalog_hash()`, not raw file bytes |
| `tee-attestation.md` | Removed `CMCP_AMD_SEV_SNP_REPORT_PATH` export (env var does not exist; path hardcoded in `sev_snp.py`); fixed measurement prefix `sha256:` → `sha384:` in sample output and `expected_measurement` config |

## Test plan
- [ ] `pip install cmcp-runtime` resolves correctly
- [ ] Cedar policy snippets pass `cedar validate` with the `cMCP::` namespace
- [ ] Pattern names in response-inspection tutorial match `patterns_v1.json`
- [ ] Catalog hash snippet produces the same value as the runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)