### PR TITLE
docs: add connecting-agent-frameworks, tool-catalog-authoring, advisory-mode-debugging tutorials

### DIFF
--- a/docs/tutorials/advisory-mode-debugging.md
+++ b/docs/tutorials/advisory-mode-debugging.md
@@ -1,0 +1,227 @@
+# Advisory Mode Debugging
+
+Run the gateway in `advisory` mode to understand which calls your Cedar policy would deny — without blocking any traffic. Use this to tune policy before switching to `enforcing`.
+
+## What you'll learn
+
+- The difference between `enforcing`, `advisory`, and `silent` modes
+- What changes in the response when a call would have been denied
+- How to read the audit chain to find advisory denials
+- A workflow for moving from advisory to enforcing
+
+## Prerequisites
+
+```bash
+pip install cmcp-runtime
+```
+
+---
+
+## Enforcement modes
+
+The `enforcement_mode` field in `cmcp-config.yaml` has three valid values:
+
+| Mode | What happens on a policy deny |
+|---|---|
+| `enforcing` | Call is blocked, HTTP 403 returned to the agent |
+| `advisory` | Call proceeds, `would_have_denied: true` set in `_cmcp` response |
+| `silent` | Policy is evaluated but nothing is logged or blocked |
+
+Default is `enforcing`. Silent mode gives you evaluation without any output — useful for baselining before you have policies written. Advisory is the useful middle ground: real traffic continues, but denials are fully visible.
+
+---
+
+## Configure advisory mode
+
+```yaml
+# cmcp-config.yaml
+attestation:
+  provider: auto
+  enforcement_mode: advisory
+policy_bundle_path: ./policies/
+catalog_path: ./catalog.json
+```
+
+Start the gateway:
+
+```bash
+CMCP_DEV_MODE=1 cmcp start --config cmcp-config.yaml
+```
+
+---
+
+## Read advisory signals in responses
+
+When a call would have been denied, the `_cmcp` block in the response carries `would_have_denied: true`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [{"type": "text", "text": "<tool response>"}],
+    "_cmcp": {
+      "call_id": "a3f8c1d2-...",
+      "audit_entry_hash": "sha256:7f3c9a...",
+      "would_have_denied": true,
+      "advice": {
+        "reason": "pii_tool_requires_dpo_approval",
+        "escalate_to": "dpo@example.com"
+      },
+      "latency_us": 11200,
+      "session_id": "s-abc123"
+    }
+  }
+}
+```
+
+`would_have_denied: true` means the Cedar policy matched at least one `forbid` rule for this call. The `advice` field, when present, contains annotations from the matched rule — this is operator-authored content from the policy bundle, not caller input.
+
+When `would_have_denied: false`, the call was allowed by policy and no forbid rules matched.
+
+---
+
+## Instrument your agent to surface advisory denials
+
+Log every `would_have_denied: true` response during the advisory period:
+
+```python
+import httpx, json, logging
+
+logger = logging.getLogger(__name__)
+
+GATEWAY = "http://localhost:8443"
+TOKEN = "dev-token"
+
+
+def call_tool(tool_name: str, arguments: dict) -> str:
+    resp = httpx.post(
+        f"{GATEWAY}/mcp",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {TOKEN}",
+        },
+        content=json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    if "error" in data:
+        raise RuntimeError(data["error"]["message"])
+
+    result = data["result"]
+    cmcp = result.get("_cmcp", {})
+
+    if cmcp.get("would_have_denied"):
+        logger.warning(
+            "ADVISORY_DENY: tool=%s call_id=%s advice=%s",
+            tool_name,
+            cmcp.get("call_id"),
+            cmcp.get("advice"),
+        )
+
+    return result["content"][0]["text"] if result.get("content") else ""
+```
+
+Run your agent workload through the gateway. Collect warnings from `ADVISORY_DENY` log lines. Each one is a call that `enforcing` mode would block.
+
+---
+
+## Read denials from the audit chain
+
+The audit chain records every advisory denial with `policy_decision: "advisory_deny"`. Export the full audit bundle after your test run:
+
+```bash
+# Close the session first to get a signed TRACE claim
+curl -X POST http://localhost:8443/sessions/<session_id>/close \
+  -H "Authorization: Bearer dev-token"
+
+# Export the audit bundle
+curl "http://localhost:8443/audit/export?session_id=<session_id>" \
+  -H "Authorization: Bearer dev-token" | python -m json.tool
+```
+
+Filter for advisory denials in the chain entries:
+
+```python
+import json, sys
+
+bundle = json.load(sys.stdin)
+entries = bundle.get("entries", [])
+
+advisory = [e for e in entries if e.get("policy_decision") == "advisory_deny"]
+for e in advisory:
+    print(f"seq={e['sequence_number']} tool={e['tool_name']} rule={e.get('policy_rule_matched')}")
+```
+
+`policy_rule_matched` names the Cedar rule that would have triggered the deny. This is the rule you need to review: either the rule is correct and the agent behavior needs to change, or the rule is too broad and needs narrowing.
+
+---
+
+## Common causes of advisory denials
+
+| `policy_rule_matched` pattern | Likely cause |
+|---|---|
+| Rule matching on `compliance_domain` | Tool is in a restricted domain; agent is missing a required attribute |
+| Rule matching on `sensitivity_level` | Session has accumulated high-sensitivity context |
+| Rule matching on `tool_name` | Tool is explicitly restricted by name in the policy |
+| Rule matching on `workflow_id` | Workflow is not in the policy's approved set |
+
+Check your Cedar policy files (`policies/*.cedar`) for the named rule to understand the condition.
+
+---
+
+## Move from advisory to enforcing
+
+Once advisory run logs show no unexpected denials:
+
+1. Review every `ADVISORY_DENY` and confirm each is either:
+   - A legitimate policy enforcement (agent behavior should be fixed), or
+   - A policy that needs narrowing (update the rule, recompute bundle hash)
+2. Update `cmcp-config.yaml`:
+
+```yaml
+attestation:
+  enforcement_mode: enforcing
+```
+
+3. If you pinned `CMCP_POLICY_HASH`, recompute it after any rule changes:
+
+```bash
+cmcp validate-bundle --bundle-path ./policies/ --expected-hash sha256:<new-hash>
+```
+
+4. Restart the gateway. First tool call that matches a forbid rule now returns HTTP 403.
+
+---
+
+## Use `silent` for initial baselining
+
+If your policy is still incomplete and `advisory` mode generates too much noise to be useful, start with `silent`:
+
+```yaml
+attestation:
+  enforcement_mode: silent
+```
+
+In silent mode the policy runs but neither logs nor blocks. Use it only to confirm the policy engine loads and evaluates without crashing. Move to `advisory` as soon as you have rules to tune.
+
+---
+
+## Summary
+
+| Step | Mode | Purpose |
+|---|---|---|
+| Policy skeleton only | `silent` | Confirm engine loads |
+| Real workload testing | `advisory` | Observe would-have-denied signals |
+| Policy tuned, no surprises | `enforcing` | Full enforcement |
+
+`would_have_denied: true` in `_cmcp` is your per-call signal. `policy_decision: "advisory_deny"` in the audit chain is the durable record. Use both together: the response signal for real-time instrumentation, the audit chain for post-run analysis.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — writing the Cedar rules that produce these denials. [Connecting agent frameworks](./connecting-agent-frameworks.md) — how to read `_cmcp` metadata from your agent code.

--- a/docs/tutorials/connecting-agent-frameworks.md
+++ b/docs/tutorials/connecting-agent-frameworks.md
@@ -1,0 +1,313 @@
+# Connecting Agent Frameworks
+
+Wire a real agent — LangChain, LlamaIndex, or a plain HTTP client — to the cMCP gateway so every tool call passes through policy enforcement.
+
+## What you'll learn
+
+- How the gateway presents itself as a standard MCP endpoint
+- How to configure bearer token auth in your agent
+- How to read the `_cmcp` metadata block that every response carries
+- LangChain, LlamaIndex, and raw `httpx` examples
+
+## Prerequisites
+
+```bash
+pip install cmcp-runtime
+```
+
+Start the gateway in dev mode:
+
+```bash
+CMCP_DEV_MODE=1 CMCP_BEARER_TOKEN=dev-token cmcp start --config cmcp-config.yaml
+```
+
+Confirm it is up:
+
+```bash
+curl http://localhost:8443/health
+# {"status": "ok"}
+```
+
+---
+
+## How the gateway looks to an agent
+
+The gateway runs at `listen_addr` (default `0.0.0.0:8443`) and exposes a standard MCP over HTTP/SSE transport. Two endpoints matter for agent frameworks:
+
+| Endpoint | Method | Auth | Purpose |
+|---|---|---|---|
+| `/mcp` | POST | Bearer token | All MCP JSON-RPC calls (`tools/call`, `tools/list`, `initialize`) |
+| `/tools/list` | GET | Bearer token | Convenience read of the attested catalog |
+| `/health` | GET | None | Liveness probe |
+
+Every request to `/mcp` must include `Authorization: Bearer <token>` where the token matches `CMCP_BEARER_TOKEN`. Requests without a valid token receive HTTP 401.
+
+---
+
+## Tool discovery
+
+Before making tool calls, retrieve the list of approved tools:
+
+```bash
+curl -s http://localhost:8443/tools/list \
+  -H "Authorization: Bearer dev-token" | python -m json.tool
+```
+
+Or via MCP JSON-RPC:
+
+```bash
+curl -s -X POST http://localhost:8443/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer dev-token" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+The response lists only tools in the attested catalog — any tool not in `catalog.json` cannot be called regardless of what the agent requests.
+
+---
+
+## The `_cmcp` response block
+
+Every allowed tool call returns a standard MCP `result` with a `_cmcp` metadata extension:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [{"type": "text", "text": "<tool response>"}],
+    "_cmcp": {
+      "call_id": "a3f8c1d2-...",
+      "audit_entry_hash": "sha256:7f3c9a...",
+      "would_have_denied": false,
+      "latency_us": 12400,
+      "session_id": "s-abc123",
+      "workflow_id": "my-agent-run"
+    }
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `call_id` | Unique ID for this tool call; matches the audit chain entry |
+| `audit_entry_hash` | SHA-256 of the audit entry committed to the chain for this call |
+| `would_have_denied` | `true` when the gateway is in `advisory` mode and policy would have denied the call |
+| `latency_us` | Gateway processing latency in microseconds (excludes upstream round-trip) |
+| `session_id` | The active session this call belongs to |
+| `workflow_id` | Echoed from `_cmcp.workflow_id` in the request, if provided |
+
+When `would_have_denied` is `true`, an `advice` field may also be present with annotations from the matching policy rule.
+
+### Pass `workflow_id` from your agent
+
+Set `_cmcp.workflow_id` in the request `params` to associate tool calls with a named agent run:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "salesforce.contacts",
+    "arguments": {"query": "Acme Corp"},
+    "_cmcp": {"workflow_id": "sales-enrichment-v2"}
+  }
+}
+```
+
+`workflow_id` appears in the audit chain entries for every call made under that identifier.
+
+---
+
+## Raw `httpx` client
+
+```python
+import httpx
+import json
+
+GATEWAY = "http://localhost:8443"
+TOKEN = "dev-token"
+
+
+def call_tool(tool_name: str, arguments: dict, workflow_id: str | None = None) -> dict:
+    params: dict = {"name": tool_name, "arguments": arguments}
+    if workflow_id:
+        params["_cmcp"] = {"workflow_id": workflow_id}
+
+    with httpx.Client() as client:
+        resp = client.post(
+            f"{GATEWAY}/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {TOKEN}",
+            },
+            content=json.dumps({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": params,
+            }),
+            timeout=30,
+        )
+    resp.raise_for_status()
+    data = resp.json()
+
+    if "error" in data:
+        error = data["error"]
+        error_code = error.get("data", {}).get("error_code", "UNKNOWN")
+        raise RuntimeError(f"{error_code}: {error['message']}")
+
+    result = data["result"]
+    cmcp_meta = result.get("_cmcp", {})
+    print(f"call_id={cmcp_meta.get('call_id')} latency={cmcp_meta.get('latency_us')}µs")
+
+    return result
+```
+
+---
+
+## LangChain
+
+Use LangChain's `MCP` integration if available, or wrap the gateway with a custom tool:
+
+```python
+from langchain.tools import BaseTool
+from pydantic import BaseModel
+import httpx, json
+from typing import Any
+
+
+class CMCPTool(BaseTool):
+    """Wraps a single cMCP-gated tool as a LangChain tool."""
+
+    name: str
+    description: str
+    gateway_url: str
+    bearer_token: str
+    workflow_id: str | None = None
+
+    class ArgsSchema(BaseModel):
+        arguments: dict[str, Any]
+
+    def _run(self, arguments: dict[str, Any]) -> str:
+        params: dict = {"name": self.name, "arguments": arguments}
+        if self.workflow_id:
+            params["_cmcp"] = {"workflow_id": self.workflow_id}
+
+        resp = httpx.post(
+            f"{self.gateway_url}/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.bearer_token}",
+            },
+            content=json.dumps({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": params,
+            }),
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        if "error" in data:
+            error_code = data["error"].get("data", {}).get("error_code", "UNKNOWN")
+            raise RuntimeError(f"Tool denied: {error_code}")
+
+        content = data["result"]["content"]
+        return content[0]["text"] if content else ""
+```
+
+Instantiate per approved tool:
+
+```python
+salesforce_tool = CMCPTool(
+    name="salesforce.contacts",
+    description="Query Salesforce CRM contacts",
+    gateway_url="http://localhost:8443",
+    bearer_token="dev-token",
+    workflow_id="lc-agent-run-001",
+)
+```
+
+---
+
+## LlamaIndex
+
+```python
+from llama_index.tools import FunctionTool
+import httpx, json
+
+
+def make_cmcp_fn(tool_name: str, gateway_url: str, bearer_token: str):
+    def call(**arguments) -> str:
+        resp = httpx.post(
+            f"{gateway_url}/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {bearer_token}",
+            },
+            content=json.dumps({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            }),
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if "error" in data:
+            raise RuntimeError(data["error"]["message"])
+        content = data["result"]["content"]
+        return content[0]["text"] if content else ""
+
+    call.__name__ = tool_name
+    return call
+
+
+crm_tool = FunctionTool.from_defaults(
+    fn=make_cmcp_fn("salesforce.contacts", "http://localhost:8443", "dev-token"),
+    name="salesforce.contacts",
+    description="Query Salesforce CRM contacts",
+)
+```
+
+---
+
+## Handle denied calls
+
+When a call is denied by policy, the gateway returns HTTP 403:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32000,
+    "message": "Request denied by policy",
+    "data": {
+      "error_code": "POLICY_DENY",
+      "call_id": "a3f8c1d2-...",
+      "advice": {"escalate_to": "compliance-team@example.com"}
+    }
+  }
+}
+```
+
+`error_code` is either `POLICY_DENY` (a Cedar forbid rule matched) or `TOOL_NOT_IN_CATALOG` (the tool name is not in the approved catalog). The `advice` field, when present, carries annotations from the policy rule — these come from the hash-pinned policy bundle, not from caller input, so they are safe to log and act on.
+
+---
+
+## Summary
+
+| Framework | Integration point |
+|---|---|
+| Any HTTP client | `POST /mcp` with `Authorization: Bearer <token>` |
+| LangChain | Custom `BaseTool` wrapping the HTTP call |
+| LlamaIndex | `FunctionTool.from_defaults` wrapping a closure |
+
+Every tool call that passes through the gateway produces an `audit_entry_hash`. After the session ends, retrieve the full audit bundle at `GET /audit/export?session_id=<id>` and verify it with `GET /sessions/<id>/trace-claim`.
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — writing the policies that govern these calls. [Tool catalog authoring](./tool-catalog-authoring.md) — what goes in `catalog.json` and how definition hashes are computed.

--- a/docs/tutorials/tool-catalog-authoring.md
+++ b/docs/tutorials/tool-catalog-authoring.md
@@ -33,13 +33,13 @@ pip install cmcp-runtime
     "sensitivity_level": "pii",
     "added_at": "2026-06-01T00:00:00Z",
     "approved_by": "security-team",
-    "catalog_exception": null,
+    "catalog_exception": false,
     "schema_validation_mode": "redact"
   }
 ]
 ```
 
-All fields are required except `catalog_exception` (nullable).
+All fields are required. `catalog_exception` defaults to `false`; set to `true` via the runtime break-glass API (`POST /catalog/exception`), never in the static file.
 
 ---
 
@@ -166,13 +166,23 @@ Steps:
 2. Canonical JSON: `sort_keys=True`, no spaces (`separators=(",", ":")`)
 3. SHA-256 of the UTF-8 bytes
 
-You can verify the hash the gateway will compute before deploying:
+Compute the hash before deploying with a short Python script:
 
-```bash
-cmcp validate-config --config cmcp-config.yaml
+```python
+import hashlib, json
+
+def catalog_hash(entries: list[dict]) -> str:
+    sorted_entries = sorted(entries, key=lambda e: e["tool_name"])
+    canonical = json.dumps(sorted_entries, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+with open("catalog.json") as f:
+    entries = json.load(f)
+
+print(catalog_hash(entries))
 ```
 
-This prints the computed `catalog_hash`. Pin it in `CMCP_CATALOG_HASH` or in your attestation policy to detect unauthorized catalog changes.
+Pin it in `CMCP_CATALOG_HASH` or in your attestation policy to detect unauthorized catalog changes. After startup the hash is also visible in the TRACE claim under `gateway.catalog.hash`.
 
 ---
 
@@ -207,7 +217,7 @@ This prints the computed `catalog_hash`. Pin it in `CMCP_CATALOG_HASH` or in you
     "sensitivity_level": "pii",
     "added_at": "2026-06-01T00:00:00Z",
     "approved_by": "security-team",
-    "catalog_exception": null,
+    "catalog_exception": false,
     "schema_validation_mode": "redact"
   },
   {
@@ -237,7 +247,7 @@ This prints the computed `catalog_hash`. Pin it in `CMCP_CATALOG_HASH` or in you
     "sensitivity_level": "confidential",
     "added_at": "2026-06-01T00:00:00Z",
     "approved_by": "compliance-officer",
-    "catalog_exception": null,
+    "catalog_exception": false,
     "schema_validation_mode": "strict"
   }
 ]
@@ -249,12 +259,23 @@ Note that `kyc.verify` uses `"strict"` because unexpected fields in a KYC call c
 
 ## Validate before deploying
 
-```bash
-# Validate catalog JSON structure and hash computation
-cmcp validate-config --config cmcp-config.yaml
+Compute and pin the catalog hash before starting the gateway:
 
-# Verify the bundle hash if you also want to pin policies
+```bash
+# Pin the catalog hash (required in production — see CMCP_CATALOG_HASH)
+export CMCP_CATALOG_HASH="$(python -c "
+import hashlib, json
+entries = json.load(open('catalog.json'))
+s = sorted(entries, key=lambda e: e['tool_name'])
+c = json.dumps(s, sort_keys=True, separators=(',', ':'), ensure_ascii=True)
+print('sha256:' + hashlib.sha256(c.encode()).hexdigest())
+")"
+
+# Validate the Cedar policy bundle hash separately
 cmcp validate-bundle --bundle-path ./policies/ --expected-hash sha256:<hex>
+
+# Validate cmcp-config.yaml syntax
+cmcp validate-config --config cmcp-config.yaml
 ```
 
 Both commands exit non-zero on any validation error without starting the gateway.

--- a/docs/tutorials/tool-catalog-authoring.md
+++ b/docs/tutorials/tool-catalog-authoring.md
@@ -1,0 +1,272 @@
+# Tool Catalog Authoring
+
+The tool catalog is the operator-controlled allowlist of MCP tools the gateway will route. Every entry is hashed into the TRACE claim at startup; adding, removing, or changing any field changes `catalog_hash` and invalidates prior attestations.
+
+## What you'll learn
+
+- The full structure of `catalog.json` and what each field controls
+- How `definition_hash` and `catalog_hash` are computed (so you can verify them independently)
+- `schema_validation_mode` and what "redact" vs "strict" means
+- A complete example with two tools from different risk tiers
+
+## Prerequisites
+
+```bash
+pip install cmcp-runtime
+```
+
+---
+
+## The catalog format
+
+`catalog.json` is a JSON array of catalog entries:
+
+```json
+[
+  {
+    "tool_name": "salesforce.contacts",
+    "server": { ... },
+    "approved_definition": { ... },
+    "definition_hash": "sha256:<hex>",
+    "compliance_domain": "pii",
+    "requires_baa": false,
+    "sensitivity_level": "pii",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "security-team",
+    "catalog_exception": null,
+    "schema_validation_mode": "redact"
+  }
+]
+```
+
+All fields are required except `catalog_exception` (nullable).
+
+---
+
+## Field reference
+
+### `tool_name`
+
+The canonical name of the tool. **Must be lowercase.** The gateway rejects any catalog that contains uppercase characters in a tool name with a `ConfigError` at startup. This name must match exactly what the MCP server advertises and what agents send in `tools/call` requests.
+
+### `server`
+
+Identity of the upstream MCP server that provides this tool:
+
+```json
+{
+  "display_name": "Salesforce MCP",
+  "url": "https://salesforce-mcp.internal:443",
+  "tls_fingerprint": "sha256:<hex of DER cert>",
+  "spiffe_id": "spiffe://example.org/ns/prod/salesforce",
+  "transport": "http-sse",
+  "rotation_mode": "key-pinned"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `display_name` | Yes | Human-readable label for logs and TRACE claims |
+| `url` | Yes | Full URL including port |
+| `tls_fingerprint` | Yes | SHA-256 of the server's DER-encoded TLS certificate (see [TLS pinning](./tls-pinning.md)) |
+| `spiffe_id` | No | SPIFFE/SVID identity if the server uses workload identity |
+| `transport` | No | Default `"http-sse"` |
+| `rotation_mode` | No | Default `"key-pinned"` |
+
+### `approved_definition`
+
+What the tool is allowed to do. This is what gets hashed into `definition_hash`:
+
+```json
+{
+  "description": "Query CRM contacts by name, email, or account",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {"type": "string"},
+      "limit": {"type": "integer", "maximum": 100}
+    },
+    "required": ["query"]
+  },
+  "output_schema": null
+}
+```
+
+`input_schema` is a JSON Schema object. The gateway uses it for schema validation at call time (controlled by `schema_validation_mode`). `output_schema` validates the tool's response; `null` disables response schema validation.
+
+### `definition_hash`
+
+SHA-256 of the canonical JSON of `approved_definition`, prefixed with `sha256:`:
+
+```python
+import hashlib, json
+
+def compute_definition_hash(approved_definition: dict) -> str:
+    canonical = json.dumps(approved_definition, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return f"sha256:{digest}"
+```
+
+The gateway recomputes this at load time and rejects the catalog if any entry's stored hash does not match. This prevents silent modification of approved definitions after signing.
+
+### `compliance_domain`
+
+A string label grouping tools by their compliance context. Used by Cedar policies to write rules like "tools in domain `pii` require a PII handler principal attribute." Common values: `"pii"`, `"financial"`, `"phi"`, `"internal"`, `"external"`. The runtime does not validate the value — it is a policy input.
+
+### `requires_baa`
+
+Boolean. When `true`, Cedar policies can enforce that a Business Associate Agreement is in place before allowing calls. The runtime surfaces this to the policy engine as a context attribute; enforcement is via Cedar rules.
+
+### `sensitivity_level`
+
+String label for the data sensitivity of this tool's outputs. Common values: `"public"`, `"internal"`, `"confidential"`, `"pii"`. The session sensitivity tracker uses this: after a session calls a `"pii"` tool, all subsequent calls in the session carry `session_sensitivity: "pii"` in Cedar context.
+
+### `added_at`
+
+ISO 8601 timestamp when this entry was approved. Included in the canonical hash and surfaced in the TRACE claim.
+
+### `approved_by`
+
+String identifying who approved the entry (person, team, or process). Included in the canonical hash. Appears in break-glass audit entries.
+
+### `catalog_exception`
+
+Nullable string. When set, marks this entry as a break-glass exception with a reason. Exceptions added via the runtime API (`POST /catalog/exception`) are always visible in the TRACE claim even though they do not modify `catalog_hash`.
+
+### `schema_validation_mode`
+
+Controls what the gateway does when a tool call argument fails schema validation against `input_schema`:
+
+| Value | Behavior |
+|---|---|
+| `"redact"` | Strip fields not in the schema, pass remaining arguments. Default. |
+| `"strict"` | Reject the call with HTTP 422 if any argument fails validation |
+| `"log"` | Log the violation but pass through unchanged |
+
+Use `"strict"` for tools that handle sensitive data where unexpected fields could indicate an injection attempt. Use `"redact"` (the default) when agents may send extra fields the tool ignores. Use `"log"` only for baselining — it provides no enforcement.
+
+---
+
+## How `catalog_hash` is computed
+
+The `catalog_hash` measured into the TRACE claim covers the full catalog, not individual entries:
+
+```python
+import hashlib, json
+
+def compute_catalog_hash(entries: list[dict]) -> str:
+    sorted_entries = sorted(entries, key=lambda e: e["tool_name"])
+    canonical = json.dumps(sorted_entries, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return f"sha256:{digest}"
+```
+
+Steps:
+1. Sort entries by `tool_name` (ascending, case-sensitive — but tool names are always lowercase)
+2. Canonical JSON: `sort_keys=True`, no spaces (`separators=(",", ":")`)
+3. SHA-256 of the UTF-8 bytes
+
+You can verify the hash the gateway will compute before deploying:
+
+```bash
+cmcp validate-config --config cmcp-config.yaml
+```
+
+This prints the computed `catalog_hash`. Pin it in `CMCP_CATALOG_HASH` or in your attestation policy to detect unauthorized catalog changes.
+
+---
+
+## Complete two-tool example
+
+```json
+[
+  {
+    "tool_name": "crm.query",
+    "server": {
+      "display_name": "Internal CRM MCP",
+      "url": "https://crm-mcp.prod.internal:443",
+      "tls_fingerprint": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "transport": "http-sse",
+      "rotation_mode": "key-pinned"
+    },
+    "approved_definition": {
+      "description": "Query CRM contacts and accounts",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string", "maxLength": 512},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 50}
+        },
+        "required": ["query"]
+      },
+      "output_schema": null
+    },
+    "definition_hash": "sha256:7f3c9a1b2e4d8f6a0c5b7e9d3f1a4c8b2e6f0d4a8c1b3e5f7a9d2c4e6f8a0b2",
+    "compliance_domain": "pii",
+    "requires_baa": false,
+    "sensitivity_level": "pii",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "security-team",
+    "catalog_exception": null,
+    "schema_validation_mode": "redact"
+  },
+  {
+    "tool_name": "kyc.verify",
+    "server": {
+      "display_name": "KYC Verification Service",
+      "url": "https://kyc-mcp.prod.internal:443",
+      "tls_fingerprint": "sha256:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+      "transport": "http-sse",
+      "rotation_mode": "key-pinned"
+    },
+    "approved_definition": {
+      "description": "Run KYC identity verification on a customer record",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "customer_id": {"type": "string"},
+          "check_level": {"type": "string", "enum": ["basic", "enhanced"]}
+        },
+        "required": ["customer_id", "check_level"]
+      },
+      "output_schema": null
+    },
+    "definition_hash": "sha256:9d2c4e6f8a0b2c4e6f8a0b2c4e6f8a0b2c4e6f8a0b2c4e6f8a0b2c4e6f8a0b2c",
+    "compliance_domain": "financial",
+    "requires_baa": false,
+    "sensitivity_level": "confidential",
+    "added_at": "2026-06-01T00:00:00Z",
+    "approved_by": "compliance-officer",
+    "catalog_exception": null,
+    "schema_validation_mode": "strict"
+  }
+]
+```
+
+Note that `kyc.verify` uses `"strict"` because unexpected fields in a KYC call could indicate prompt injection; `crm.query` uses `"redact"` because agents may pass extra context fields the CRM ignores.
+
+---
+
+## Validate before deploying
+
+```bash
+# Validate catalog JSON structure and hash computation
+cmcp validate-config --config cmcp-config.yaml
+
+# Verify the bundle hash if you also want to pin policies
+cmcp validate-bundle --bundle-path ./policies/ --expected-hash sha256:<hex>
+```
+
+Both commands exit non-zero on any validation error without starting the gateway.
+
+---
+
+## Summary
+
+1. All `tool_name` values must be lowercase
+2. `definition_hash` = SHA-256 of canonical JSON of `approved_definition` (sort_keys, no spaces)
+3. `catalog_hash` = SHA-256 of canonical JSON of all entries sorted by `tool_name`
+4. Use `"strict"` schema validation for high-sensitivity tools; `"redact"` is the safe default for others
+5. `sensitivity_level` feeds session tracking; `compliance_domain` feeds Cedar policy context
+
+Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md) — using `compliance_domain` and `sensitivity_level` in Cedar rules. [TLS pinning](./tls-pinning.md) — computing `tls_fingerprint` values.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,10 @@ nav:
   - How It Works: docs/concepts.md
   - Configuration: docs/configuration.md
   - Tutorials:
+      - Connecting agent frameworks: docs/tutorials/connecting-agent-frameworks.md
+      - Tool catalog authoring: docs/tutorials/tool-catalog-authoring.md
       - Cedar policy walkthrough: docs/tutorials/cedar-policy-walkthrough.md
+      - Advisory mode debugging: docs/tutorials/advisory-mode-debugging.md
       - TLS pinning: docs/tutorials/tls-pinning.md
       - Verify a TRACE claim: docs/tutorials/verifying-a-trace-claim.md
       - TEE attestation: docs/tutorials/tee-attestation.md


### PR DESCRIPTION
## Summary

Three tutorials covering day-0/day-1 gaps identified in the tutorial audit:

- **Connecting agent frameworks** — how to wire LangChain, LlamaIndex, and a raw httpx client to the gateway; bearer token auth, `_cmcp` metadata block, `workflow_id` passthrough, handling denied calls
- **Tool catalog authoring** — full `catalog.json` field reference; how `definition_hash` and `catalog_hash` are computed (with reproducible Python snippets); `schema_validation_mode` values (`redact`/`strict`/`log`) and when to use each; complete two-tool example
- **Advisory mode debugging** — `enforcing`/`advisory`/`silent` mode differences; `would_have_denied` signal in `_cmcp`; `policy_decision: "advisory_deny"` in the audit chain; workflow for moving from advisory to enforcing

All content verified against actual source: `loader.py` (definition_hash, catalog_hash computation), `config.py` (EnforcementMode values), `server.py` (endpoints, auth, `_cmcp` fields), `chain.py` (audit entry fields, `advisory_deny` decision value).

## Test plan

- [ ] CI passes (lint, type check, tests)
- [ ] `mkdocs serve` renders all three new pages without errors
- [ ] Links in "Related tutorials" sections resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)