### PR TITLE
fix: switch agent-manifest dependency from git to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "agentrust-trace>=0.1",
-    # Replace with a version constraint after the next SDK release exports verify_manifest.
-    "agent-manifest @ git+https://github.com/agentrust-io/agent-manifest.git@1297c223d68fdaf95ac9438d9de844597281a3c2#subdirectory=python",
+    "agent-manifest>=0.1.1",
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",
@@ -63,9 +62,6 @@ Documentation = "https://github.com/agentrust-io/cmcp/tree/main/docs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cmcp_runtime", "src/cmcp_verify"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Replaces `agent-manifest @ git+https://...@<commit>` with `agent-manifest>=0.1.1`
- Removes `[tool.hatch.metadata] allow-direct-references = true`

## Why

PyPI rejects packages with direct git dependencies (`400 Can't have direct dependency`). The comment in pyproject.toml said to do this after the next SDK release — `agent-manifest 0.1.1` (released 2026-06-21) exports `verify_manifest` and `VerificationContext` from the package root, satisfying the condition.

This unblocks the `cmcp-runtime 0.2.1` PyPI publish (the release workflow failed for this exact reason).

## Test plan

- [x] `pip install .` works with the pinned constraint
- [x] PyPI publish workflow will re-run on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)