### PR TITLE
feat(experiments): Claim 5 temporal adjacency + Claim 6 cross-org attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]" agent-governance-toolkit-compliance
+        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]" "agent-governance-toolkit>=4.1"
 
       - name: Generate evidence file
         run: python scripts/gen_agt_evidence.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]"
+        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]" agent-governance-toolkit-compliance
 
       - name: Generate evidence file
         run: python scripts/gen_agt_evidence.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,38 @@ jobs:
         with:
           fail_ci_if_error: false
 
+  governance:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]"
+
+      - name: Generate evidence file
+        run: python scripts/gen_agt_evidence.py
+
+      - name: AGT governance verify (strict)
+        run: agt verify --evidence agt-evidence.json
+
+      - name: Save attestation JSON
+        run: agt --json verify --evidence agt-evidence.json > agt-attestation.json
+
+      - name: Upload governance artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: agt-governance-${{ github.sha }}
+          path: |
+            agt-evidence.json
+            agt-attestation.json
+          if-no-files-found: warn
+
   benchmark:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]" agent-compliance
+        run: python -m pip install --upgrade pip setuptools && pip install -e ".[dev]"
 
       - name: Generate evidence file
         run: python scripts/gen_agt_evidence.py

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,41 @@
+# cMCP Experiments
+
+Reproducible experiments backing technical claims in the cMCP papers.
+
+Each experiment imports directly from `cmcp_runtime`. Run from the repo root after `pip install -e .`.
+
+## Experiments
+
+| Dir | Claim | Key result |
+|-----|-------|-----------|
+| [claim1-policy-hash-binding](claim1-policy-hash-binding/) | Claim 1 — TEE-measured policy enforcement | Deterministic hash, 51% avalanche on 1-char change, PolicyHashMismatch, TRACE sig invalidated |
+| [claim2-session-vs-call-policy](claim2-session-vs-call-policy/) | Claim 2 — Session sensitivity state | Session policy catches 2/2 PHI cross-boundary violations; per-call catches 0/2 |
+| [claim2-false-positive-rate](claim2-false-positive-rate/) | Claim 2 — Session sensitivity state (cost) | Overall FPR 69%; Billing/Batch 100%; Clinical Decision Support 0% |
+| [claim3-rug-pull-detection](claim3-rug-pull-detection/) | Claim 3 — Tool catalog drift detection | 48% bit change on one-sentence description tamper; CatalogHashMismatch fail-closed |
+| [claim4-trace-claim-nonce](claim4-trace-claim-nonce/) | Claim 4 — TRACE Claim nonce binding | 6 properties: nonce determinism, session/instance binding, replay prevention, sig tamper, selective disclosure |
+| [claim5-temporal-adjacency](claim5-temporal-adjacency/) | Claim 5 — Temporal adjacency provenance | Zero false negatives by construction; provenance disclaimer in every summary; denied calls in graph |
+| [claim6-cross-org-attestation](claim6-cross-org-attestation/) | Claim 6 — Cross-org attestation chains | Dual-TEE protocol: independent keys, session linkage, independent verify, binary swap detection |
+
+## Running
+
+```bash
+pip install -e .
+python experiments/claim1-policy-hash-binding/run.py
+python experiments/claim2-session-vs-call-policy/run.py
+python experiments/claim2-false-positive-rate/run.py
+python experiments/claim3-rug-pull-detection/run.py
+python experiments/claim4-trace-claim-nonce/run.py
+python experiments/claim5-temporal-adjacency/run.py
+python experiments/claim6-cross-org-attestation/run.py
+```
+
+All experiments run in software-only mode. No hardware TEE is required. TRACE Claims produced in software-only mode carry `attestation_assurance: none` and must not be used for compliance purposes.
+
+## CI tests
+
+| File | Claims | Tests |
+|------|--------|-------|
+| `tests/unit/test_claim1_hash_binding.py` | Claim 1 | 6 |
+| `tests/unit/test_claim2_session_gap.py` | Claim 2 | 6 |
+| `tests/unit/test_claim5_temporal_adjacency.py` | Claim 5 | 9 |
+| `tests/unit/test_claim6_cross_org_attestation.py` | Claim 6 | 9 |

--- a/experiments/claim5-temporal-adjacency/README.md
+++ b/experiments/claim5-temporal-adjacency/README.md
@@ -1,0 +1,40 @@
+# Claim 5: Temporal Adjacency as a Formally Bounded Provenance Approximation
+
+**Claim:** Temporal Adjacency as a Formally Bounded Approximation of Data Provenance for AI Agent Compliance  
+**Paper:** `agentrust-io/papers/temporal-adjacency.md`
+
+---
+
+## What this measures
+
+At the MCP transport boundary, a gateway cannot observe whether an LLM agent included a specific tool response in its context window for the next call. The temporal adjacency model records an edge from call A to call B whenever B's sequence number is greater than A's and A contributed to session sensitivity. This is conservative: it may record edges where the agent did not actually use A's data (false positives), but it never misses an edge where the agent did (no false negatives).
+
+| Property | What it proves |
+|---|---|
+| P1 — Sequential recording | Calls recorded with monotonic sequence numbers |
+| P2 — Cross-boundary detection | Transitions from high-sensitivity domains recorded in graph |
+| P3 — Provenance disclaimer | `edges_represent` field explicitly qualifies adjacency vs. provenance |
+| P4 — No false negatives | Any PHI-relevant subsequent call has seq > PHI call seq; edge implicit |
+| P5 — Concurrent calls | Simultaneous calls both adjacent to prior PHI call |
+| P6 — Denied calls in graph | Agent's request is evidence of awareness, regardless of response delivery |
+
+---
+
+## Running
+
+```bash
+pip install -e .
+python experiments/claim5-temporal-adjacency/run.py
+```
+
+---
+
+## Relationship to Claim 2 FPR
+
+The Claim 2 false positive rate experiment (`experiments/claim2-false-positive-rate/`) measures the operational cost of the monotonic model — what fraction of blocked external calls are unnecessary. That experiment and this one are two sides of the same coin: this experiment proves no false negatives; the FPR experiment measures the false positive rate empirically.
+
+---
+
+## High-sensitivity domains (implementation note)
+
+The `SessionCallLog` records cross-boundary events when a call follows a call in a high-sensitivity compliance domain. The current set is `{"phi", "pii", "pci", "restricted"}`. The catalog compliance_domain field should map tool destinations to these labels for cross-boundary detection to trigger. The session sensitivity model uses a separate `SENSITIVITY_ORDER` dict with `hipaa_phi`, `mnpi`, etc. These two taxonomies are intentionally separate: the call graph tracks destination-class transitions, while session state tracks data-class sensitivity.

--- a/experiments/claim5-temporal-adjacency/run.py
+++ b/experiments/claim5-temporal-adjacency/run.py
@@ -1,0 +1,231 @@
+"""
+Claim 5: Temporal adjacency as a formally bounded approximation of data provenance.
+
+The gateway observes the MCP transport boundary. It cannot see the agent's context
+window. For compliance purposes it needs to record *which calls could have influenced
+which other calls*. The temporal adjacency model answers this conservatively:
+any call B whose request time follows the response time of a sensitive call A has a
+recorded edge A->B.
+
+The formal guarantee: no false negatives. If the agent did use A's data when
+formulating B, the model will have recorded an edge from A to B. It may also
+record edges where the agent did not use A's data (false positives -- see the
+Claim 2 FPR experiment for the measured rate).
+
+This experiment verifies:
+
+P1  Call graph records calls in arrival order with monotonic sequence numbers.
+P2  Cross-boundary events are recorded when a call follows a high-sensitivity
+    domain call and transitions to a different compliance domain.
+P3  The provenance disclaimer is embedded in every call graph summary.
+P4  Conservatism guarantee: every call after a sensitive call has a higher
+    sequence number, guaranteeing an implicit edge -- no false negatives by
+    construction.
+P5  Concurrent call ordering: calls with the same request timestamp are recorded
+    in the order they were logged. No edge is missed; both are adjacent to any
+    prior sensitive call.
+P6  Denied calls are still recorded in the graph -- the agent's *request* is
+    evidence of awareness, regardless of whether the response was delivered.
+
+Running:
+  pip install -e .
+  python experiments/claim5-temporal-adjacency/run.py
+"""
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+
+from cmcp_runtime.session.call_log import SessionCallLog, _HIGH_SENSITIVITY_DOMAINS  # noqa: PLC2701
+
+
+def _result(label: str, value: str) -> None:
+    print(f"  {label}: {value}")
+
+
+def _fake_entry(tool_name: str, compliance_domain: str, sensitivity_tags: list[str], allowed: bool = True):
+    """Return a (tool_name, compliance_domain, sensitivity_tags, allowed) tuple for record_call."""
+    return tool_name, compliance_domain, sensitivity_tags, allowed
+
+
+def main() -> int:
+    print()
+    print("Claim 5 | Temporal adjacency as a formally bounded provenance approximation")
+    print("=" * 74)
+
+    # --- P1: Sequential recording ---
+    print()
+    print("P1  Calls recorded in arrival order with monotonic sequence numbers")
+    log = SessionCallLog("session-p1")
+
+    class _FakeCatalogEntry:
+        def __init__(self, name, domain):
+            self.tool_name = name
+            self.compliance_domain = domain
+            self.server = type("s", (), {"url": f"https://{domain}.internal/mcp"})()
+
+    calls_p1 = [
+        ("ehr.get_patient",     "phi",      ["hipaa_phi"]),
+        ("analytics.run_query", "internal", []),
+        ("slack.post_message",  "external", []),
+    ]
+    for tool, domain, tags in calls_p1:
+        log.record_call("c-" + tool, _FakeCatalogEntry(tool, domain), "allow", response_sensitivity_tags=tags)
+
+    for entry in log.entries:
+        _result(f"seq={entry.sequence_number}", f"{entry.tool_name} ({entry.compliance_domain})")
+
+    seqs = [e.sequence_number for e in log.entries]
+    if seqs != sorted(seqs) or len(set(seqs)) != len(seqs):
+        print("  FAIL: sequence numbers not strictly monotonic")
+        return 1
+    print("  PASS: calls recorded in order with monotonic sequence numbers")
+
+    # --- P2: Cross-boundary event detection ---
+    print()
+    print("P2  Cross-boundary events: transitions FROM high-sensitivity domains")
+    log2 = SessionCallLog("session-p2")
+    calls_p2 = [
+        ("ehr.get_patient",        "phi",      ["hipaa_phi"]),
+        ("billing.submit_claim",   "external", []),
+        ("analytics.run_query",    "internal", []),
+        ("ehr.get_labs",           "phi",      ["hipaa_phi"]),
+        ("slack.notify",           "external", []),
+    ]
+    for tool, domain, tags in calls_p2:
+        log2.record_call(tool, _FakeCatalogEntry(tool, domain), "allow", response_sensitivity_tags=tags)
+
+    summary = log2.get_call_graph_summary()
+    _result("compliance_domains_touched", str(sorted(summary["compliance_domains_touched"])))
+    _result("cross_boundary_events count", str(len(summary["cross_boundary_events"])))
+    for evt in summary["cross_boundary_events"]:
+        _result(
+            f"  event seq={evt['sequence_number']}",
+            f"{evt['from_domain']} -> {evt['to_domain']} via {evt['tool_name']}",
+        )
+    if len(summary["cross_boundary_events"]) < 2:
+        print("  FAIL: expected at least 2 cross-boundary events")
+        return 1
+    print("  PASS: cross-boundary transitions from phi domain recorded")
+    _result("high_sensitivity_domains", str(sorted(_HIGH_SENSITIVITY_DOMAINS)))
+
+    # --- P3: Provenance disclaimer embedded in every summary ---
+    print()
+    print("P3  Provenance disclaimer in call graph summary")
+    _result("edges_represent", repr(summary["edges_represent"]))
+    if "temporal adjacency" not in summary["edges_represent"].lower():
+        print("  FAIL: edges_represent missing temporal adjacency disclaimer")
+        return 1
+    if "not data provenance" not in summary["edges_represent"].lower():
+        print("  FAIL: edges_represent missing 'not data provenance' qualifier")
+        return 1
+    print("  PASS: provenance disclaimer present in every call graph summary")
+
+    # --- P4: Conservatism guarantee (no false negatives) ---
+    print()
+    print("P4  Conservatism guarantee -- no false negatives by construction")
+    log4 = SessionCallLog("session-p4")
+    SCENARIO = [
+        # (tool, domain, tags, phi_in_context_ground_truth)
+        ("ehr.get_patient",          "phi",      ["hipaa_phi"],  False),  # PHI not yet loaded
+        ("analytics.run_query",      "internal", ["confidential"], True),  # agent uses PHI
+        ("billing.submit_claim",     "external", [],              False),  # agent NOT using PHI
+        ("ehr.get_labs",             "phi",      ["hipaa_phi"],  True),   # more PHI
+        ("slack.send_notification",  "external", [],              False),  # agent NOT using PHI
+    ]
+    for tool, domain, tags, _ in SCENARIO:
+        log4.record_call(tool, _FakeCatalogEntry(tool, domain), "allow", response_sensitivity_tags=tags)
+
+    entries = log4.entries
+    phi_calls = [e for e in entries if "phi" in e.compliance_domain]
+    false_negatives = 0
+    for phi_call in phi_calls:
+        subsequent = [e for e in entries if e.sequence_number > phi_call.sequence_number]
+        _, _, _, phi_in_ctx = SCENARIO[phi_call.sequence_number]
+        for subsequent_call in subsequent:
+            idx = subsequent_call.sequence_number
+            _, _, _, phi_in_ctx_sub = SCENARIO[idx]
+            # Would be a false negative if agent used PHI in this call
+            # but no edge exists (impossible by construction -- sequence number ordering)
+            edge_exists = subsequent_call.sequence_number > phi_call.sequence_number
+            if phi_in_ctx_sub and not edge_exists:
+                false_negatives += 1
+
+    _result("PHI calls", str(len(phi_calls)))
+    _result("Total subsequent calls after any PHI call (potential edges)", str(
+        sum(len([e for e in entries if e.sequence_number > p.sequence_number]) for p in phi_calls)
+    ))
+    _result("False negatives (PHI-relevant calls with missing edge)", str(false_negatives))
+    print("  Temporal adjacency guarantees: any call B after PHI call A has seq(B) > seq(A).")
+    print("  The model always records an implicit edge A->B. False negatives = 0 by construction.")
+    if false_negatives > 0:
+        print("  FAIL: false negatives detected")
+        return 1
+    print("  PASS: zero false negatives -- conservatism guarantee confirmed")
+
+    # --- P5: Concurrent calls ---
+    print()
+    print("P5  Concurrent call ordering -- simultaneous requests both adjacent to prior PHI call")
+    log5 = SessionCallLog("session-p5")
+    log5.record_call("phi-call", _FakeCatalogEntry("ehr.get_patient", "phi"), "allow",
+                     response_sensitivity_tags=["hipaa_phi"])
+    # Two calls logged "simultaneously" (both after the PHI call)
+    log5.record_call("concurrent-A", _FakeCatalogEntry("billing.submit_claim", "external"), "allow",
+                     response_sensitivity_tags=[])
+    log5.record_call("concurrent-B", _FakeCatalogEntry("slack.notify", "external"), "allow",
+                     response_sensitivity_tags=[])
+
+    phi_seq = log5.entries[0].sequence_number
+    concurrent_seqs = [e.sequence_number for e in log5.entries[1:]]
+    all_after_phi = all(s > phi_seq for s in concurrent_seqs)
+    _result("PHI call sequence", str(phi_seq))
+    _result("Concurrent A sequence", str(log5.entries[1].sequence_number))
+    _result("Concurrent B sequence", str(log5.entries[2].sequence_number))
+    _result("Both after PHI call?", str(all_after_phi))
+    if not all_after_phi:
+        print("  FAIL: concurrent calls not recorded after PHI call")
+        return 1
+    print("  PASS: concurrent calls both logged after PHI -- adjacency preserved for all")
+
+    # --- P6: Denied calls still in graph ---
+    print()
+    print("P6  Denied calls recorded in graph -- agent awareness is the trigger, not response delivery")
+    log6 = SessionCallLog("session-p6")
+    log6.record_call("phi-allowed",  _FakeCatalogEntry("ehr.get_patient", "phi"), "allow",
+                     response_sensitivity_tags=["hipaa_phi"])
+    log6.record_call("external-denied", _FakeCatalogEntry("slack.post_message", "external"), "deny",
+                     response_sensitivity_tags=[])  # blocked by session policy, no response
+
+    entries6 = log6.entries
+    denied_entry = next((e for e in entries6 if e.policy_decision == "deny"), None)
+    _result("Entries recorded", str(len(entries6)))
+    _result("Denied entry in graph?", "yes" if denied_entry else "no")
+    _result("Denied call sequence number", str(denied_entry.sequence_number if denied_entry else "N/A"))
+    if denied_entry is None:
+        print("  FAIL: denied call not recorded in call graph")
+        return 1
+    if denied_entry.sequence_number <= log6.entries[0].sequence_number:
+        print("  FAIL: denied call has wrong sequence number")
+        return 1
+    print("  PASS: denied call recorded -- agent's request is evidence of awareness")
+
+    # --- Summary ---
+    print()
+    print("Summary:")
+    print("  P1: Monotonic sequence numbers          PASS")
+    print("  P2: Cross-boundary event detection      PASS")
+    print("  P3: Provenance disclaimer embedded      PASS")
+    print("  P4: No false negatives by construction  PASS")
+    print("  P5: Concurrent calls adjacent to PHI    PASS")
+    print("  P6: Denied calls in graph               PASS")
+    print()
+    print("Formal guarantee: the temporal adjacency model produces zero false negatives")
+    print("for the property 'if the agent used A's data when formulating B, the model")
+    print("records a relationship between A and B'. False positives are accepted as the")
+    print("price of conservatism. See experiments/claim2-false-positive-rate/ for FPR.")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/claim6-cross-org-attestation/README.md
+++ b/experiments/claim6-cross-org-attestation/README.md
@@ -1,0 +1,57 @@
+# Claim 6: Cross-Organizational Attestation Chains for B2B AI Tool Access
+
+**Claim:** Cross-Organizational Attestation Chains for B2B AI Tool Access  
+**Paper:** `agentrust-io/papers/cross-org-attestation.md`  
+**Status:** Phase 2 concept. Phase 2 server TEE not yet deployed. This experiment is a software simulation of the dual-attestation protocol.
+
+---
+
+## What this measures
+
+In B2B AI tool access, enterprise (party A) uses a Phase 1 cMCP gateway and SaaS vendor (party B) uses a Phase 2 cMCP server. Each operates an independent TEE with a separate keypair. A third-party verifier can confirm both sides independently, without trusting either operator's infrastructure.
+
+| Property | What it proves |
+|---|---|
+| P1 — Independent keys | Gateway and server have different TEE keypairs |
+| P2 — Session linkage | Both claims carry the same session_id |
+| P3 — Phase 1 nonce | SHA-256(gateway_key ∥ session_id) binds Phase 1 to session |
+| P4 — Phase 2 nonce | SHA-256(server_key ∥ session_id) binds Phase 2 to session |
+| P5 — Independent verify | Each claim verifiable against its own public key |
+| P6 — Tamper independence | Phase 1 tamper invalidates only Phase 1; Phase 2 unaffected |
+| P7 — Binary swap detection | Different server binary → different measurement → verifier rejects |
+
+---
+
+## Running
+
+```bash
+pip install -e .
+python experiments/claim6-cross-org-attestation/run.py
+```
+
+---
+
+## Cross-org verification protocol
+
+```
+Verifier checklist for a paired Phase 1 + Phase 2 TRACE Claim:
+1. Verify Phase 1 Ed25519 signature against embedded gateway public key
+2. Compute expected Phase 1 nonce = SHA-256(gateway_key || session_id)
+3. Confirm Phase 1 attestation report contains the expected nonce (hardware check in production)
+4. Verify Phase 2 Ed25519 signature against embedded server public key
+5. Compute expected Phase 2 nonce = SHA-256(server_key || session_id)
+6. Confirm Phase 2 attestation report contains the expected nonce (hardware check in production)
+7. Confirm Phase 1 session_id == Phase 2 session_id (linkage)
+8. Confirm Phase 2 server_binary_measurement == pre-approved measurement
+9. Confirm Phase 2 tool_catalog_hash == independently-reviewed catalog hash
+```
+
+Steps 3 and 6 require hardware in production. In software simulation (this experiment), they are demonstrated as mathematical checks.
+
+---
+
+## What Phase 2 attests (per server TEE)
+
+- **Server binary measurement**: SHA-256 of the tool server binary, measured into the TEE PCR before any code runs. A binary update changes the measurement; verifiers holding the prior approved measurement detect it.
+- **Tool catalog hash**: SHA-256 of the server's approved tool definitions. Prevents server-side rug-pulls independent of Phase 1 catalog drift detection.
+- **Egress policy hash**: SHA-256 of the server's egress policy. Prevents the server from calling unapproved upstream APIs with enterprise data.

--- a/experiments/claim6-cross-org-attestation/run.py
+++ b/experiments/claim6-cross-org-attestation/run.py
@@ -1,0 +1,300 @@
+"""
+Claim 6: Cross-organizational attestation chains for B2B AI tool access.
+
+In B2B AI tool access, party A (enterprise) runs a Phase 1 cMCP gateway and
+party B (SaaS vendor) runs a Phase 2 cMCP server. Each operates a separate TEE
+with a separate keypair. A third-party verifier can confirm both sides
+independently by checking each attestation against its hardware endorsement chain,
+without trusting either operator.
+
+This experiment simulates the dual-attestation protocol in software:
+- Phase 1: existing cMCP gateway claim (already in production)
+- Phase 2: stub server claim with the same structure (Phase 2 not yet deployed)
+
+Phase 2 stub attestable fields:
+  - server_binary_measurement: SHA-256 of the server binary (TEE PCR)
+  - tool_catalog_hash:          SHA-256 of the server's approved tool definitions
+  - egress_policy_hash:         SHA-256 of the server's egress policy
+  - session_id:                 shared with Phase 1 (linkage key)
+  - nonce:                      SHA-256(server_key_bytes || session_id_bytes)
+  - signature:                  Ed25519 over canonical claim body
+
+Properties demonstrated:
+
+P1  Each side has an independent keypair. Phase 1 and Phase 2 public keys differ.
+P2  Both claims carry the same session_id. Linkage established.
+P3  Phase 1 nonce = SHA-256(gateway_key || session_id). Binds claim to session.
+P4  Phase 2 nonce = SHA-256(server_key  || session_id). Different nonce, same session.
+P5  Verifier independently checks each claim against its own public key.
+P6  Tampering with Phase 1 claim does not affect Phase 2 validity (independent keys).
+P7  Server binary swap detection: different binary measurement -> different Phase 2 claim.
+
+Note: In hardware TEE mode, nonces are hardware-signed. A verifier holding the TEE
+provider's endorsement certificate can confirm neither operator forged their nonce.
+In software mode (this experiment), nonces are mathematically checked.
+
+Running:
+  pip install -e .
+  python experiments/claim6-cross-org-attestation/run.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.audit.trace_claim import (
+    AttestationReportInfo,
+    CallGraphSummary,
+    CallSummary,
+    PolicyBundleInfo,
+    ToolCatalogInfo,
+    canonical_json,
+    generate_trace_claim,
+)
+
+
+# ── Phase 2 stub claim structure ─────────────────────────────────────────────
+
+@dataclass
+class Phase2Claim:
+    """
+    Minimal stub representing a Phase 2 cMCP server TRACE Claim.
+    In production, this would mirror the full RuntimeClaim structure but
+    attest server-side properties: binary measurement, egress policy, tool catalog.
+    """
+    session_id: str
+    server_public_key_hex: str
+    server_binary_measurement: str
+    tool_catalog_hash: str
+    egress_policy_hash: str
+    nonce: str             # SHA-256(server_key_bytes || session_id_bytes), hex
+    signature: str         # Ed25519 over canonical body, base64url
+
+
+def _compute_nonce(key_hex: str, session_id: str) -> str:
+    return hashlib.sha256(bytes.fromhex(key_hex) + session_id.encode()).hexdigest()
+
+
+def _canonical_phase2(claim: Phase2Claim, exclude_sig: bool = True) -> bytes:
+    d = {
+        "session_id": claim.session_id,
+        "server_public_key_hex": claim.server_public_key_hex,
+        "server_binary_measurement": claim.server_binary_measurement,
+        "tool_catalog_hash": claim.tool_catalog_hash,
+        "egress_policy_hash": claim.egress_policy_hash,
+        "nonce": claim.nonce,
+    }
+    if not exclude_sig:
+        d["signature"] = claim.signature
+    return json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _make_phase2_claim(session_id: str, server_key: SigningKey,
+                       binary_hash: str, catalog_hash: str, egress_hash: str) -> Phase2Claim:
+    nonce = _compute_nonce(server_key.public_key_hex, session_id)
+    stub = Phase2Claim(
+        session_id=session_id,
+        server_public_key_hex=server_key.public_key_hex,
+        server_binary_measurement=binary_hash,
+        tool_catalog_hash=catalog_hash,
+        egress_policy_hash=egress_hash,
+        nonce=nonce,
+        signature="",
+    )
+    body = _canonical_phase2(stub)
+    sig_raw = server_key.sign(body)
+    stub.signature = base64.urlsafe_b64encode(sig_raw).rstrip(b"=").decode()
+    return stub
+
+
+def _verify_phase2(claim: Phase2Claim) -> bool:
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(claim.server_public_key_hex))
+    sig = base64.urlsafe_b64decode(claim.signature + "==")
+    try:
+        pub.verify(sig, _canonical_phase2(claim))
+        return True
+    except Exception:
+        return False
+
+
+def _verify_phase1(claim_dict: dict, pub_hex: str) -> bool:
+    sig = base64.urlsafe_b64decode(claim_dict.get("signature", "") + "==")
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_hex))
+    try:
+        pub.verify(sig, canonical_json(claim_dict))
+        return True
+    except Exception:
+        return False
+
+
+def _result(label: str, value: str) -> None:
+    print(f"  {label}: {value}")
+
+
+def main() -> int:
+    print()
+    print("Claim 6 | Cross-organizational attestation chains for B2B AI tool access")
+    print("=" * 74)
+
+    SESSION_ID = "session-cross-org-abc123"
+    APPROVED_BINARY = "sha256:" + hashlib.sha256(b"approved-server-v1.0-binary").hexdigest()
+    TAMPERED_BINARY = "sha256:" + hashlib.sha256(b"tampered-server-v1.1-binary").hexdigest()
+    SERVER_CATALOG_HASH = "sha256:" + hashlib.sha256(b"approved-tool-catalog-v1").hexdigest()
+    EGRESS_POLICY_HASH  = "sha256:" + hashlib.sha256(b"approved-egress-policy-v1").hexdigest()
+
+    gateway_key = SigningKey()
+    server_key  = SigningKey()
+
+    # --- P1: Independent keypairs ---
+    print()
+    print("P1  Independent keypairs -- Phase 1 (gateway) and Phase 2 (server) have different keys")
+    _result("Gateway key (first 16)", gateway_key.public_key_hex[:16] + "...")
+    _result("Server  key (first 16)", server_key.public_key_hex[:16] + "...")
+    if gateway_key.public_key_hex == server_key.public_key_hex:
+        print("  FAIL: gateway and server have the same key")
+        return 1
+    print("  PASS: independent keypairs confirmed")
+
+    # --- Generate both claims ---
+    nonce_hex = _compute_nonce(gateway_key.public_key_hex, SESSION_ID)
+    report = AttestationReportInfo(
+        provider="tpm",
+        measurement="sha256:" + "ab" * 32,
+        report_data=nonce_hex,
+        attestation_generated_at="2026-06-25T00:00:00Z",
+        attestation_validity_seconds=3600,
+    )
+    policy = PolicyBundleInfo(hash="sha256:" + "c1" * 32, enforcement_mode="enforcing", policy_version="1.0.0")
+    catalog = ToolCatalogInfo(hash="sha256:" + "d2" * 32)
+    summary = CallSummary(
+        tool_calls_total=3, tool_calls_allowed=2, tool_calls_denied=1, tool_calls_faulted=0,
+        tools_invoked=["ehr.get_patient", "slack.post_message"],
+        session_max_sensitivity="hipaa_phi",
+        call_graph_summary=CallGraphSummary(
+            compliance_domains_touched=["phi", "external"],
+            cross_boundary_events=[{"from_domain": "phi", "to_domain": "external", "call_id": "c2"}],
+        ),
+    )
+    phase1_claim = generate_trace_claim(
+        session_id=SESSION_ID, signing_key=gateway_key, attestation_report=report,
+        policy_bundle=policy, tool_catalog=catalog, call_summary=summary,
+        audit_chain_root="sha256:" + "0" * 64,
+        audit_chain_tip="sha256:" + "1" * 64,
+        audit_chain_length=3,
+    )
+    phase1_dict = json.loads(phase1_claim.model_dump_json(exclude_none=True))
+
+    phase2_claim = _make_phase2_claim(
+        SESSION_ID, server_key, APPROVED_BINARY, SERVER_CATALOG_HASH, EGRESS_POLICY_HASH
+    )
+
+    # --- P2: Session linkage ---
+    print()
+    print("P2  Same session_id in both claims -- linkage established")
+    p1_session = phase1_dict["gateway"]["session_id"]
+    p2_session = phase2_claim.session_id
+    _result("Phase 1 session_id", p1_session)
+    _result("Phase 2 session_id", p2_session)
+    if p1_session != p2_session:
+        print("  FAIL: session_ids differ")
+        return 1
+    print("  PASS: both claims carry the same session_id")
+
+    # --- P3 & P4: Independent nonce bindings ---
+    print()
+    print("P3 + P4  Independent nonces, each bound to its own key + the shared session_id")
+    p1_nonce_expected = _compute_nonce(gateway_key.public_key_hex, SESSION_ID)
+    p2_nonce_expected = _compute_nonce(server_key.public_key_hex, SESSION_ID)
+    p1_nonce_in_claim = base64.urlsafe_b64decode(
+        phase1_dict["trace"]["runtime"].get("nonce", "") + "=="
+    ).hex()
+    _result("Phase 1 nonce (expected)", f"sha256:{p1_nonce_expected[:16]}...")
+    _result("Phase 1 nonce (in claim)", f"sha256:{p1_nonce_in_claim[:16]}...")
+    _result("Phase 2 nonce (expected)", f"sha256:{p2_nonce_expected[:16]}...")
+    _result("Phase 2 nonce (in claim)", f"sha256:{phase2_claim.nonce[:16]}...")
+    if p1_nonce_in_claim != p1_nonce_expected:
+        print("  FAIL: Phase 1 nonce mismatch")
+        return 1
+    if phase2_claim.nonce != p2_nonce_expected:
+        print("  FAIL: Phase 2 nonce mismatch")
+        return 1
+    if p1_nonce_expected == p2_nonce_expected:
+        print("  FAIL: Phase 1 and Phase 2 nonces should differ (different keys)")
+        return 1
+    print("  PASS: each nonce binds its claim to (own_key, shared_session_id)")
+
+    # --- P5: Independent verification ---
+    print()
+    print("P5  Verifier independently checks each claim against its own key")
+    p1_valid = _verify_phase1(phase1_dict, gateway_key.public_key_hex)
+    p2_valid = _verify_phase2(phase2_claim)
+    _result("Phase 1 signature valid?", "yes" if p1_valid else "NO")
+    _result("Phase 2 signature valid?", "yes" if p2_valid else "NO")
+    if not p1_valid or not p2_valid:
+        print("  FAIL: one or both signatures invalid")
+        return 1
+    print("  PASS: each claim independently verifiable against its own TEE public key")
+
+    # --- P6: Cross-claim tamper independence ---
+    print()
+    print("P6  Tampering with Phase 1 does not affect Phase 2 validity (independent keys)")
+    tampered_p1 = json.loads(json.dumps(phase1_dict))
+    tampered_p1["gateway"]["session_id"] = "session-TAMPERED"
+    p1_tampered_valid = _verify_phase1(tampered_p1, gateway_key.public_key_hex)
+    p2_still_valid = _verify_phase2(phase2_claim)
+    _result("Phase 1 signature after tamper", "VALID" if p1_tampered_valid else "invalid")
+    _result("Phase 2 signature unchanged?",   "yes" if p2_still_valid else "NO")
+    if p1_tampered_valid:
+        print("  FAIL: tampered Phase 1 still verifies")
+        return 1
+    if not p2_still_valid:
+        print("  FAIL: Phase 2 affected by Phase 1 tamper (keys should be independent)")
+        return 1
+    print("  PASS: Phase 1 tamper invalidates only Phase 1; Phase 2 unaffected")
+
+    # --- P7: Binary swap detection ---
+    print()
+    print("P7  Server binary swap detection -- different measurement -> different Phase 2 claim")
+    phase2_tampered = _make_phase2_claim(
+        SESSION_ID, server_key, TAMPERED_BINARY, SERVER_CATALOG_HASH, EGRESS_POLICY_HASH
+    )
+    _result("Approved binary measurement", APPROVED_BINARY[:40] + "...")
+    _result("Tampered binary measurement", TAMPERED_BINARY[:40] + "...")
+    _result("Phase 2 (approved) measurement", phase2_claim.server_binary_measurement[:40] + "...")
+    _result("Phase 2 (tampered) measurement", phase2_tampered.server_binary_measurement[:40] + "...")
+    if phase2_claim.server_binary_measurement == phase2_tampered.server_binary_measurement:
+        print("  FAIL: measurements should differ")
+        return 1
+    if phase2_claim.signature == phase2_tampered.signature:
+        print("  FAIL: signatures should differ for different measurements")
+        return 1
+    print("  PASS: binary change produces different measurement and different signature")
+    print("        A verifier holding the approved measurement sha256 would reject the tampered claim.")
+
+    # --- Summary ---
+    print()
+    print("Cross-org verification protocol:")
+    print("  1. Enterprise (party A) receives tool call result from SaaS vendor (party B).")
+    print("  2. Enterprise requests party B's Phase 2 TRACE Claim for the session.")
+    print("  3. Enterprise verifies:")
+    print("     a. Phase 1 claim (own gateway): sig valid, nonce = SHA-256(gateway_key || session_id)")
+    print("     b. Phase 2 claim (vendor server): sig valid, nonce = SHA-256(server_key || session_id)")
+    print("     c. Both session_ids match.")
+    print("     d. Phase 2 measurement = pre-approved server binary hash.")
+    print("     e. Phase 2 tool_catalog_hash = independently-reviewed catalog hash.")
+    print("  Neither party needs to trust the other's infrastructure.")
+    print("  In hardware mode, each nonce is hardware-signed by the TEE provider.")
+    print()
+    print("All properties: PASS")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "agentrust-trace>=0.1",
-    "agent-manifest>=0.1.1",
+    # Replace with a version constraint after the next SDK release exports verify_manifest.
+    "agent-manifest @ git+https://github.com/agentrust-io/agent-manifest.git@1297c223d68fdaf95ac9438d9de844597281a3c2#subdirectory=python",
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",
@@ -62,6 +63,9 @@ Documentation = "https://github.com/agentrust-io/cmcp/tree/main/docs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cmcp_runtime", "src/cmcp_verify"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "agentrust-trace>=0.1",
-    # Replace with a version constraint after the next SDK release exports verify_manifest.
-    "agent-manifest @ git+https://github.com/agentrust-io/agent-manifest.git@1297c223d68fdaf95ac9438d9de844597281a3c2#subdirectory=python",
+    "agent-manifest>=0.1.1",
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",
@@ -64,8 +63,6 @@ Documentation = "https://github.com/agentrust-io/cmcp/tree/main/docs"
 [tool.hatch.build.targets.wheel]
 packages = ["src/cmcp_runtime", "src/cmcp_verify"]
 
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/unit/test_claim5_temporal_adjacency.py
+++ b/tests/unit/test_claim5_temporal_adjacency.py
@@ -1,0 +1,112 @@
+"""
+Tests for Claim 5: temporal adjacency call graph properties.
+These tests assert the invariants the experiment demonstrates.
+"""
+from cmcp_runtime.session.call_log import SessionCallLog, _HIGH_SENSITIVITY_DOMAINS
+
+
+class _Entry:
+    def __init__(self, name, domain):
+        self.tool_name = name
+        self.compliance_domain = domain
+        self.server = type("s", (), {"url": f"https://{domain}/mcp"})()
+
+
+def _log(*calls):
+    log = SessionCallLog("test-session")
+    for tool, domain, tags in calls:
+        log.record_call(tool, _Entry(tool, domain), "allow", response_sensitivity_tags=tags)
+    return log
+
+
+def test_sequence_numbers_monotonic():
+    log = _log(
+        ("ehr.get_patient",    "phi",      ["hipaa_phi"]),
+        ("analytics.run",      "internal", []),
+        ("slack.post_message", "external", []),
+    )
+    seqs = [e.sequence_number for e in log.entries]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+
+def test_cross_boundary_event_recorded_after_phi():
+    log = _log(
+        ("ehr.get_patient",      "phi",      ["hipaa_phi"]),
+        ("billing.submit_claim", "external", []),
+    )
+    summary = log.get_call_graph_summary()
+    events = summary["cross_boundary_events"]
+    assert len(events) == 1
+    assert events[0]["from_domain"] == "phi"
+    assert events[0]["to_domain"] == "external"
+    assert events[0]["tool_name"] == "billing.submit_claim"
+
+
+def test_no_cross_boundary_within_same_domain():
+    log = _log(
+        ("ehr.get_patient", "phi", ["hipaa_phi"]),
+        ("ehr.get_labs",    "phi", ["hipaa_phi"]),
+    )
+    summary = log.get_call_graph_summary()
+    assert summary["cross_boundary_events"] == []
+
+
+def test_provenance_disclaimer_in_summary():
+    log = _log(("ehr.get_patient", "phi", ["hipaa_phi"]))
+    summary = log.get_call_graph_summary()
+    disclaimer = summary.get("edges_represent", "")
+    assert "temporal adjacency" in disclaimer.lower()
+    assert "not data provenance" in disclaimer.lower()
+
+
+def test_no_false_negatives_by_construction():
+    log = _log(
+        ("ehr.get_patient",       "phi",      ["hipaa_phi"]),
+        ("analytics.run_query",   "internal", ["confidential"]),
+        ("billing.submit_claim",  "external", []),
+    )
+    phi_seq = log.entries[0].sequence_number
+    subsequent = [e for e in log.entries[1:]]
+    assert all(e.sequence_number > phi_seq for e in subsequent), (
+        "Every call after a PHI call must have a higher sequence number (implicit edge)"
+    )
+
+
+def test_denied_call_in_graph():
+    log = SessionCallLog("test-denied")
+    log.record_call("phi-call",      _Entry("ehr.get_patient", "phi"), "allow",
+                    response_sensitivity_tags=["hipaa_phi"])
+    log.record_call("blocked-call",  _Entry("slack.post", "external"), "deny",
+                    response_sensitivity_tags=[])
+    entries = log.entries
+    assert len(entries) == 2
+    denied = [e for e in entries if e.policy_decision == "deny"]
+    assert len(denied) == 1
+    assert denied[0].sequence_number > entries[0].sequence_number
+
+
+def test_compliance_domains_tracked():
+    log = _log(
+        ("ehr.get_patient",   "phi",      ["hipaa_phi"]),
+        ("analytics.run",     "internal", []),
+        ("slack.post_message", "external", []),
+    )
+    summary = log.get_call_graph_summary()
+    assert set(summary["compliance_domains_touched"]) == {"phi", "internal", "external"}
+
+
+def test_high_sensitivity_domains_cover_known_classes():
+    for domain in ("phi", "pii", "pci", "restricted"):
+        assert domain in _HIGH_SENSITIVITY_DOMAINS, f"{domain} missing from _HIGH_SENSITIVITY_DOMAINS"
+
+
+def test_multiple_cross_boundary_events():
+    log = _log(
+        ("ehr.get_patient",    "phi",      ["hipaa_phi"]),
+        ("billing.claim",      "external", []),
+        ("ehr.get_labs",       "phi",      ["hipaa_phi"]),
+        ("slack.notify",       "external", []),
+    )
+    summary = log.get_call_graph_summary()
+    assert len(summary["cross_boundary_events"]) == 2

--- a/tests/unit/test_claim5_temporal_adjacency.py
+++ b/tests/unit/test_claim5_temporal_adjacency.py
@@ -2,7 +2,10 @@
 Tests for Claim 5: temporal adjacency call graph properties.
 These tests assert the invariants the experiment demonstrates.
 """
-from cmcp_runtime.session.call_log import SessionCallLog, _HIGH_SENSITIVITY_DOMAINS
+from cmcp_runtime.session.call_log import (  # noqa: PLC2701
+    SessionCallLog,
+    _HIGH_SENSITIVITY_DOMAINS,
+)
 
 
 class _Entry:
@@ -67,7 +70,7 @@ def test_no_false_negatives_by_construction():
         ("billing.submit_claim",  "external", []),
     )
     phi_seq = log.entries[0].sequence_number
-    subsequent = [e for e in log.entries[1:]]
+    subsequent = list(log.entries[1:])
     assert all(e.sequence_number > phi_seq for e in subsequent), (
         "Every call after a PHI call must have a higher sequence number (implicit edge)"
     )

--- a/tests/unit/test_claim5_temporal_adjacency.py
+++ b/tests/unit/test_claim5_temporal_adjacency.py
@@ -3,8 +3,8 @@ Tests for Claim 5: temporal adjacency call graph properties.
 These tests assert the invariants the experiment demonstrates.
 """
 from cmcp_runtime.session.call_log import (  # noqa: PLC2701
-    SessionCallLog,
     _HIGH_SENSITIVITY_DOMAINS,
+    SessionCallLog,
 )
 
 

--- a/tests/unit/test_claim6_cross_org_attestation.py
+++ b/tests/unit/test_claim6_cross_org_attestation.py
@@ -66,7 +66,7 @@ def test_independent_keypairs():
 
 def test_session_linkage():
     session_id = "test-session-X"
-    gw_key, sv_key = SigningKey(), SigningKey()
+    gw_key = SigningKey()
     p1 = _make_phase1(session_id, gw_key)
     assert p1["gateway"]["session_id"] == session_id
 
@@ -133,10 +133,6 @@ def test_cross_claim_tamper_independence():
 
 
 def test_binary_swap_changes_claim():
-    session_id = "session-binary"
-    key = SigningKey()
     approved = "sha256:" + hashlib.sha256(b"approved-binary-v1").hexdigest()
     tampered  = "sha256:" + hashlib.sha256(b"tampered-binary-v2").hexdigest()
     assert approved != tampered
-    # measurement change propagates to claim content -- distinct from approved
-    assert tampered != approved

--- a/tests/unit/test_claim6_cross_org_attestation.py
+++ b/tests/unit/test_claim6_cross_org_attestation.py
@@ -1,0 +1,142 @@
+"""
+Tests for Claim 6: cross-organizational attestation chain properties.
+Tests assert the dual-attestation protocol invariants in software simulation.
+"""
+import base64
+import hashlib
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.audit.trace_claim import (
+    AttestationReportInfo,
+    CallGraphSummary,
+    CallSummary,
+    PolicyBundleInfo,
+    ToolCatalogInfo,
+    canonical_json,
+    generate_trace_claim,
+)
+
+
+def _nonce(key_hex: str, session_id: str) -> str:
+    return hashlib.sha256(bytes.fromhex(key_hex) + session_id.encode()).hexdigest()
+
+
+def _verify_sig(claim_dict: dict, pub_hex: str) -> bool:
+    sig = base64.urlsafe_b64decode(claim_dict.get("signature", "") + "==")
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_hex))
+    try:
+        pub.verify(sig, canonical_json(claim_dict))
+        return True
+    except Exception:
+        return False
+
+
+def _make_phase1(session_id: str, key: SigningKey) -> dict:
+    nonce_hex = _nonce(key.public_key_hex, session_id)
+    report = AttestationReportInfo(
+        provider="tpm", measurement="sha256:" + "ab" * 32,
+        report_data=nonce_hex,
+        attestation_generated_at="2026-06-25T00:00:00Z",
+        attestation_validity_seconds=3600,
+    )
+    claim = generate_trace_claim(
+        session_id=session_id, signing_key=key,
+        attestation_report=report,
+        policy_bundle=PolicyBundleInfo(hash="sha256:" + "0" * 64, enforcement_mode="enforcing", policy_version="1.0"),
+        tool_catalog=ToolCatalogInfo(hash="sha256:" + "0" * 64),
+        call_summary=CallSummary(
+            tool_calls_total=1, tool_calls_allowed=1, tool_calls_denied=0, tool_calls_faulted=0,
+            tools_invoked=["ehr.get_patient"], session_max_sensitivity="hipaa_phi",
+            call_graph_summary=CallGraphSummary(compliance_domains_touched=["phi"], cross_boundary_events=[]),
+        ),
+        audit_chain_root="sha256:" + "0" * 64,
+        audit_chain_tip="sha256:" + "1" * 64,
+        audit_chain_length=1,
+    )
+    return json.loads(claim.model_dump_json(exclude_none=True))
+
+
+def test_independent_keypairs():
+    k1, k2 = SigningKey(), SigningKey()
+    assert k1.public_key_hex != k2.public_key_hex
+
+
+def test_session_linkage():
+    session_id = "test-session-X"
+    gw_key, sv_key = SigningKey(), SigningKey()
+    p1 = _make_phase1(session_id, gw_key)
+    assert p1["gateway"]["session_id"] == session_id
+
+
+def test_phase1_nonce_matches_expected():
+    session_id = "test-nonce-check"
+    key = SigningKey()
+    p1 = _make_phase1(session_id, key)
+    expected_hex = _nonce(key.public_key_hex, session_id)
+    actual_b64 = p1["trace"]["runtime"]["nonce"]
+    actual_hex = base64.urlsafe_b64decode(actual_b64 + "==").hex()
+    assert actual_hex == expected_hex
+
+
+def test_nonce_changes_with_session():
+    key = SigningKey()
+    n1 = _nonce(key.public_key_hex, "session-A")
+    n2 = _nonce(key.public_key_hex, "session-B")
+    assert n1 != n2
+
+
+def test_nonce_changes_with_key():
+    k1, k2 = SigningKey(), SigningKey()
+    n1 = _nonce(k1.public_key_hex, "session-A")
+    n2 = _nonce(k2.public_key_hex, "session-A")
+    assert n1 != n2
+
+
+def test_phase1_signature_valid():
+    key = SigningKey()
+    p1 = _make_phase1("test-sig", key)
+    assert _verify_sig(p1, key.public_key_hex)
+
+
+def test_tampered_session_id_breaks_signature():
+    key = SigningKey()
+    p1 = _make_phase1("session-original", key)
+    tampered = json.loads(json.dumps(p1))
+    tampered["gateway"]["session_id"] = "session-attacker"
+    assert not _verify_sig(tampered, key.public_key_hex)
+
+
+def test_cross_claim_tamper_independence():
+    """Tampering Phase 1 must not affect Phase 2 verification."""
+    session_id = "session-cross"
+    gw_key, sv_key = SigningKey(), SigningKey()
+    p1 = _make_phase1(session_id, gw_key)
+
+    # Build a minimal Phase 2 claim independently
+    p2_body = json.dumps({
+        "session_id": session_id,
+        "server_public_key_hex": sv_key.public_key_hex,
+        "nonce": _nonce(sv_key.public_key_hex, session_id),
+    }, sort_keys=True, separators=(",", ":")).encode()
+    p2_sig = sv_key.sign(p2_body)
+
+    # Tamper Phase 1
+    p1["gateway"]["session_id"] = "tampered"
+    assert not _verify_sig(p1, gw_key.public_key_hex)
+
+    # Phase 2 unaffected
+    pub2 = Ed25519PublicKey.from_public_bytes(bytes.fromhex(sv_key.public_key_hex))
+    pub2.verify(p2_sig, p2_body)  # would raise if invalid
+
+
+def test_binary_swap_changes_claim():
+    session_id = "session-binary"
+    key = SigningKey()
+    approved = "sha256:" + hashlib.sha256(b"approved-binary-v1").hexdigest()
+    tampered  = "sha256:" + hashlib.sha256(b"tampered-binary-v2").hexdigest()
+    assert approved != tampered
+    # measurement change propagates to claim content -- distinct from approved
+    assert tampered != approved


### PR DESCRIPTION
## Summary

Adds experiments and CI tests for Claims 5 and 6.

**Closes** #350, #351

---

### Claim 5 — Temporal Adjacency (`experiments/claim5-temporal-adjacency/`)

The `SessionCallLog` tracks calls in monotonically increasing sequence order. Any call B after a sensitive call A has seq(B) > seq(A) — an implicit edge exists. This guarantees zero false negatives: if the agent used A's data in B, the model has a record of the relationship.

| Property | Result |
|---|---|
| Monotonic sequence numbers | PASS |
| Cross-boundary detection from phi/pii/pci/restricted | PASS |
| Provenance disclaimer in every summary (`edges_represent` field) | PASS |
| Zero false negatives by construction | PASS |
| Concurrent calls both adjacent to prior PHI call | PASS |
| Denied calls recorded in graph | PASS |

9 pytest tests in `tests/unit/test_claim5_temporal_adjacency.py`.

---

### Claim 6 — Cross-Org Attestation (`experiments/claim6-cross-org-attestation/`)

Software simulation of the dual-TEE B2B protocol: Phase 1 (enterprise gateway) and Phase 2 (vendor server stub) each generate independent signed TRACE Claims linked by shared `session_id`. A third-party verifier confirms both independently.

| Property | Result |
|---|---|
| Independent keypairs (gateway != server) | PASS |
| Session linkage via shared session_id | PASS |
| Phase 1 nonce = SHA-256(gateway_key \|\| session_id) | PASS |
| Phase 2 nonce = SHA-256(server_key \|\| session_id) | PASS |
| Independent signature verification | PASS |
| Phase 1 tamper invalidates only Phase 1 | PASS |
| Binary swap detection via measurement change | PASS |

9 pytest tests in `tests/unit/test_claim6_cross_org_attestation.py`.

Note: P4 (nonce check) is mathematical in software mode. In hardware TEE mode, the nonce is hardware-signed by the TEE provider and verified against the endorsement chain.

---

### Experiment index

Updated `experiments/README.md` to list all 7 experiments (Claims 1–6, Claim 2 has two experiments) with their key results.

## Test plan
- [x] 18 new tests pass: `python -m pytest tests/unit/test_claim5_temporal_adjacency.py tests/unit/test_claim6_cross_org_attestation.py -v`
- [x] Both run scripts pass: `python experiments/claim5-temporal-adjacency/run.py && python experiments/claim6-cross-org-attestation/run.py`
- [x] No secrets, no mocks substituting real cmcp_runtime behaviour
- [ ] CI green