### PR TITLE
docs: normalize OPAQUE casing in README config comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ from cmcp_gateway.config import TEEProvider
 # Explicit hardware selection
 # attestation.provider: sev-snp
 
-# Opaque Managed Runtime (explicit opt-in only)
+# OPAQUE Managed Runtime (explicit opt-in only)
 # OPAQUE_ATTESTATION_URL=https://... cmcp start --config cmcp-config.yaml
 ```
 


### PR DESCRIPTION
Follow-up to #361. The prose casing pass intentionally left one brand mention inside a fenced config code block (`# Opaque Managed Runtime`); per review it should be normalized too. This changes the comment text only — `OPAQUE_ATTESTATION_URL` and all config keys are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)