### PR TITLE
docs: correct brand name to AgenTrust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hardware-attested MCP runtime, TEE-enforced policy and TRACE Clai
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
-    { name = "AgentTrust Contributors", email = "oss@agentrust.io" },
+    { name = "AgenTrust Contributors", email = "oss@agentrust.io" },
 ]
 keywords = ["mcp", "tee", "attestation", "security", "ai-agents", "cedar"]
 classifiers = [


### PR DESCRIPTION
Brand display name corrected from AgentTrust to AgenTrust (single T, capital A and T). No code identifiers, slugs, emails, or URLs were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)