### PR TITLE
fix(ci): resolve agt CLI in release governance job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install package and AGT
-        run: python -m pip install --upgrade pip && pip install -e "." agent-governance-toolkit-core
+        run: python -m pip install --upgrade pip && pip install -e "." "agent-governance-toolkit>=4.1" "agent-governance-toolkit-core>=4.1"
 
       - name: Generate evidence file
         run: python scripts/gen_agt_evidence.py


### PR DESCRIPTION
The governance-release job in release.yml installed only `agent-governance-toolkit-core`, so `agt` was not on PATH and the post-publish governance step failed (`command not found`). Adds the meta package (agt CLI) + core. Cosmetic post-publish fix; did not affect the 0.3.0 PyPI upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)