### PR TITLE
test(agt): fix datetime.UTC AttributeError blocking unit CI

### DIFF
--- a/tests/unit/test_agt_evidence.py
+++ b/tests/unit/test_agt_evidence.py
@@ -161,8 +161,8 @@ def test_verify_evidence_passes(tmp_path, generator):
     # the evidence file location; the audit target is a string, not checked for existence).
     evidence_path = tmp_path / "agt-evidence.json"
     ev = generator.generate_evidence()
-    from datetime import datetime, timezone
-    ev["generated_at"] = datetime.now(timezone.utc).isoformat()
+    from datetime import UTC, datetime
+    ev["generated_at"] = datetime.now(UTC).isoformat()
     evidence_path.write_text(json.dumps(ev, indent=2), encoding="utf-8")
 
     attestation = GovernanceVerifier().verify_evidence(evidence_path, strict=True)
@@ -191,8 +191,8 @@ def test_verify_evidence_json_is_valid(tmp_path, generator):
 
     evidence_path = tmp_path / "agt-evidence.json"
     ev = generator.generate_evidence()
-    from datetime import datetime, timezone
-    ev["generated_at"] = datetime.now(timezone.utc).isoformat()
+    from datetime import UTC, datetime
+    ev["generated_at"] = datetime.now(UTC).isoformat()
     evidence_path.write_text(json.dumps(ev, indent=2), encoding="utf-8")
 
     attestation = GovernanceVerifier().verify_evidence(evidence_path)

--- a/tests/unit/test_agt_evidence.py
+++ b/tests/unit/test_agt_evidence.py
@@ -161,8 +161,8 @@ def test_verify_evidence_passes(tmp_path, generator):
     # the evidence file location; the audit target is a string, not checked for existence).
     evidence_path = tmp_path / "agt-evidence.json"
     ev = generator.generate_evidence()
-    from datetime import datetime
-    ev["generated_at"] = datetime.now(datetime.UTC).isoformat()
+    from datetime import datetime, timezone
+    ev["generated_at"] = datetime.now(timezone.utc).isoformat()
     evidence_path.write_text(json.dumps(ev, indent=2), encoding="utf-8")
 
     attestation = GovernanceVerifier().verify_evidence(evidence_path, strict=True)
@@ -191,8 +191,8 @@ def test_verify_evidence_json_is_valid(tmp_path, generator):
 
     evidence_path = tmp_path / "agt-evidence.json"
     ev = generator.generate_evidence()
-    from datetime import datetime
-    ev["generated_at"] = datetime.now(datetime.UTC).isoformat()
+    from datetime import datetime, timezone
+    ev["generated_at"] = datetime.now(timezone.utc).isoformat()
     evidence_path.write_text(json.dumps(ev, indent=2), encoding="utf-8")
 
     attestation = GovernanceVerifier().verify_evidence(evidence_path)


### PR DESCRIPTION
`tests/unit/test_agt_evidence.py` used `datetime.now(datetime.UTC)` where `datetime` is the class (imported via `from datetime import datetime`), so `datetime.UTC` raised `AttributeError`. This failed on plain `main`, leaving the unit-test job red and blocking every open PR from reaching green CI.

Fix: use `timezone.utc` (portable across supported Python versions).

Before: `2 failed, 14 passed` in test_agt_evidence.py. After: `16 passed`.

Unblocks #386 (and others) from a green merge.