### PR TITLE
fix(verify): enforce report_data binding and VCEK chain+signature in SEV-SNP verifier (#384)

### DIFF
--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -1,9 +1,20 @@
-"""AMD SEV-SNP attestation verification -- implements issue #67."""
+"""AMD SEV-SNP attestation verification -- implements issue #67, hardened per #384."""
 from __future__ import annotations
 
 import ctypes
 import hashlib
 from dataclasses import dataclass, field
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from cryptography.hazmat.primitives.hashes import SHA256, SHA384
+
+# AMD signs report bytes [0, 0x2A0); the 512-byte signature field follows.
+_SIGNED_BODY_LEN = 0x2A0
+# sig_algo value for ECDSA P-384 with SHA-384 (AMD SEV-SNP ABI).
+_SIG_ALGO_ECDSA_P384_SHA384 = 1
 
 
 class _SnpAttestationReport(ctypes.LittleEndianStructure):
@@ -53,6 +64,10 @@ assert ctypes.sizeof(_SnpAttestationReport) == 0x4A0, (
 _SNP_REPORT_MIN_SIZE = ctypes.sizeof(_SnpAttestationReport)
 
 
+class _SNPChainError(Exception):
+    """Raised when the VCEK certificate chain or report signature fails to verify."""
+
+
 @dataclass
 class SNPVerificationResult:
     verified: bool
@@ -62,10 +77,85 @@ class SNPVerificationResult:
     details: dict[str, str] = field(default_factory=dict)
 
 
+def verify_cert_chain(
+    chain: list[x509.Certificate], trusted_roots: list[x509.Certificate]
+) -> None:
+    """Verify a leaf-to-root certificate chain against a set of trusted roots.
+
+    ``chain`` is ordered leaf first (VCEK), root last (ARK). Each certificate
+    must be directly issued by the next, and the final certificate must match a
+    trusted root by SHA-256 fingerprint. Raises ``_SNPChainError`` on any failure.
+    """
+    if not chain:
+        raise _SNPChainError("empty certificate chain")
+
+    for i in range(len(chain) - 1):
+        child, issuer = chain[i], chain[i + 1]
+        try:
+            child.verify_directly_issued_by(issuer)
+        except (ValueError, TypeError, InvalidSignature) as exc:
+            raise _SNPChainError(
+                f"certificate at position {i} is not validly issued by the next: {exc}"
+            ) from exc
+
+    root = chain[-1]
+    trusted = {c.fingerprint(SHA256()) for c in trusted_roots}
+    if root.fingerprint(SHA256()) not in trusted:
+        raise _SNPChainError("chain root is not a trusted AMD root")
+
+
+def load_vcek_chain_from_evidence(pems: object) -> list[x509.Certificate] | None:
+    """Parse a list of PEM-encoded certificates (leaf VCEK first, root ARK last).
+
+    Returns None if ``pems`` is falsy or any entry fails to parse. The chain is
+    caller-supplied evidence; its trust is established only by chaining to a
+    configured trusted root in ``verify_cert_chain``.
+    """
+    if not pems or not isinstance(pems, (list, tuple)):
+        return None
+    try:
+        return [
+            x509.load_pem_x509_certificate(
+                p.encode() if isinstance(p, str) else p
+            )
+            for p in pems
+        ]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _verify_report_signature(
+    raw_evidence: bytes, report: _SnpAttestationReport, vcek_cert: x509.Certificate
+) -> None:
+    """Verify the ECDSA-P384/SHA-384 report signature against the VCEK public key.
+
+    Raises ``_SNPChainError`` on any failure.
+    """
+    if report.sig_algo != _SIG_ALGO_ECDSA_P384_SHA384:
+        raise _SNPChainError(
+            f"unsupported report signature algorithm: {report.sig_algo}"
+        )
+    pub = vcek_cert.public_key()
+    if not isinstance(pub, ec.EllipticCurvePublicKey):
+        raise _SNPChainError("VCEK does not carry an elliptic-curve public key")
+
+    # AMD stores r and s as 72-byte little-endian fields; P-384 uses the low 48.
+    sig = bytes(report.signature)
+    r = int.from_bytes(sig[0:48], "little")
+    s = int.from_bytes(sig[72:120], "little")
+    der = encode_dss_signature(r, s)
+    try:
+        pub.verify(der, raw_evidence[:_SIGNED_BODY_LEN], ec.ECDSA(SHA384()))
+    except InvalidSignature as exc:
+        raise _SNPChainError("SEV-SNP report signature failed to verify") from exc
+
+
 def verify_sev_snp_measurement(
     measurement: str,
     raw_evidence: bytes | None,
     report_data_hex: str | None = None,
+    vcek_chain: list[x509.Certificate] | None = None,
+    trusted_roots: list[x509.Certificate] | None = None,
 ) -> SNPVerificationResult:
     """
     Verify an AMD SEV-SNP attestation measurement.
@@ -74,10 +164,13 @@ def verify_sev_snp_measurement(
     - measurement string format (sha384:<96 hex chars>)
     - SNP report version (must be 2 or 3)
     - measurement field in report matches the claimed measurement
-    - report_data (nonce) if provided (mismatch is not fatal)
-
-    Signature verification via AMD KDS VCEK/VLEK cert chain is out of scope
-    and is always placed in unverified_fields.
+    - report_data binding: if report_data_hex is provided, a mismatch is FATAL
+      (it carries the confirmation-key binding / freshness nonce)
+    - VCEK -> ASK -> ARK certificate chain and report signature: verified when a
+      vcek_chain and trusted_roots are supplied. Trusted roots MUST come from the
+      verifier configuration, never from the (untrusted) claim. When not supplied,
+      vcek_cert_chain is left unverified and the report must not be treated as
+      fully rooted (the dispatcher keeps such a claim at PARTIALLY_VERIFIED).
     """
     result = SNPVerificationResult(verified=True)
 
@@ -97,9 +190,8 @@ def verify_sev_snp_measurement(
         result.details["vcek_chain"] = "requires_amd_kds_lookup"
         return result
 
-    # Step 2: raw evidence is mandatory - a claim asserting a hardware
-    # platform with no evidence to check must fail closed, not pass on
-    # string-format checks alone.
+    # Step 2: raw evidence is mandatory - a claim asserting a hardware platform
+    # with no evidence to check must fail closed, not pass on format alone.
     if raw_evidence is None:
         result.verified = False
         result.failure_reason = "no_raw_evidence"
@@ -107,60 +199,80 @@ def verify_sev_snp_measurement(
         result.details["raw_evidence"] = "not provided; SNP report cannot be checked"
         return result
 
-    if len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
-        try:
-            # Parse via ctypes struct for named field access (HW-006)
-            report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
-
-            if report.version not in (2, 3):
-                result.verified = False
-                result.failure_reason = "invalid_snp_report_version"
-                result.details["snp_report_version"] = str(report.version)
-                result.unverified_fields.append("vcek_cert_chain")
-                result.details["vcek_chain"] = "requires_amd_kds_lookup"
-                return result
-
-            result.details["snp_report_version"] = str(report.version)
-
-            # Verify measurement field using named struct access
-            m_bytes = bytes(report.measurement)
-            computed = "sha384:" + hashlib.sha384(m_bytes).hexdigest()
-            if computed == measurement:
-                result.verified_fields.append("measurement")
-            else:
-                result.verified = False
-                result.failure_reason = "measurement_mismatch"
-                result.unverified_fields.append("vcek_cert_chain")
-                result.details["vcek_chain"] = "requires_amd_kds_lookup"
-                return result
-
-            # Check report_data (nonce) using named struct access -- mismatch is not fatal
-            if report_data_hex is not None:
-                extracted_rd = bytes(report.report_data)
-                expected_rd = bytes.fromhex(report_data_hex[:128])
-                # Pad expected to 64 bytes if shorter
-                if len(expected_rd) < 64:
-                    expected_rd = expected_rd + b"\x00" * (64 - len(expected_rd))
-                if extracted_rd == expected_rd:
-                    result.verified_fields.append("report_data")
-
-        except Exception:  # noqa: BLE001
-            result.verified = False
-            result.failure_reason = "raw_evidence_parse_error"
-            result.unverified_fields.append("vcek_cert_chain")
-            result.details["vcek_chain"] = "requires_amd_kds_lookup"
-            return result
-
-    else:
-        # Truncated report -- treat as parse error
+    if len(raw_evidence) < _SNP_REPORT_MIN_SIZE:
+        # Truncated report -- treat as parse error.
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"
         result.unverified_fields.append("vcek_cert_chain")
         result.details["vcek_chain"] = "requires_amd_kds_lookup"
         return result
 
-    # Step 3: VCEK/VLEK cert chain -- always out of scope
-    result.unverified_fields.append("vcek_cert_chain")
-    result.details["vcek_chain"] = "requires_amd_kds_lookup"
+    # Parse via ctypes struct for named field access (HW-006).
+    try:
+        report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
+    except Exception:  # noqa: BLE001
+        result.verified = False
+        result.failure_reason = "raw_evidence_parse_error"
+        result.unverified_fields.append("vcek_cert_chain")
+        result.details["vcek_chain"] = "requires_amd_kds_lookup"
+        return result
+
+    if report.version not in (2, 3):
+        result.verified = False
+        result.failure_reason = "invalid_snp_report_version"
+        result.details["snp_report_version"] = str(report.version)
+        result.unverified_fields.append("vcek_cert_chain")
+        result.details["vcek_chain"] = "requires_amd_kds_lookup"
+        return result
+
+    result.details["snp_report_version"] = str(report.version)
+
+    # Verify measurement field using named struct access.
+    m_bytes = bytes(report.measurement)
+    computed = "sha384:" + hashlib.sha384(m_bytes).hexdigest()
+    if computed == measurement:
+        result.verified_fields.append("measurement")
+    else:
+        result.verified = False
+        result.failure_reason = "measurement_mismatch"
+        result.unverified_fields.append("vcek_cert_chain")
+        result.details["vcek_chain"] = "requires_amd_kds_lookup"
+        return result
+
+    # report_data binding -- a mismatch is FATAL. report_data carries the
+    # confirmation-key binding / freshness nonce; silently ignoring a mismatch
+    # would accept an SNP report for a different enclave whose measurement happens
+    # to match.
+    if report_data_hex is not None:
+        extracted_rd = bytes(report.report_data)
+        expected_rd = bytes.fromhex(report_data_hex[:128])
+        if len(expected_rd) < 64:
+            expected_rd = expected_rd + b"\x00" * (64 - len(expected_rd))
+        if extracted_rd == expected_rd:
+            result.verified_fields.append("report_data")
+        else:
+            result.verified = False
+            result.failure_reason = "report_data_mismatch"
+            result.unverified_fields.append("vcek_cert_chain")
+            return result
+
+    # VCEK -> ASK -> ARK chain + report signature. Trusted roots come from the
+    # verifier configuration, never from the claim.
+    if vcek_chain and trusted_roots:
+        try:
+            verify_cert_chain(vcek_chain, trusted_roots)
+            _verify_report_signature(raw_evidence, report, vcek_chain[0])
+        except _SNPChainError as exc:
+            result.verified = False
+            result.failure_reason = "vcek_chain_verification_failed"
+            result.details["vcek_chain"] = str(exc)
+            result.unverified_fields.append("vcek_cert_chain")
+            return result
+        result.verified_fields.extend(["vcek_cert_chain", "report_signature"])
+    else:
+        result.unverified_fields.append("vcek_cert_chain")
+        result.details["vcek_chain"] = (
+            "not provided; supply vcek_chain and configure trusted AMD roots to verify"
+        )
 
     return result

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -63,6 +63,12 @@ _KNOWN_PLATFORMS = {
     "software-only",
 }
 
+# Trusted AMD root certificate(s) (ARK) used to root the SEV-SNP VCEK chain.
+# MUST be populated from verifier configuration, never from the claim. Empty by
+# default => an SNP VCEK chain cannot be rooted, so such a claim fails closed to
+# PARTIALLY_VERIFIED rather than VERIFIED. See issue #384.
+_TRUSTED_AMD_ROOTS: list = []
+
 
 def _is_software_only(runtime: dict[str, Any]) -> bool:
     """True for dev-mode (non-attested) records.
@@ -793,19 +799,38 @@ def verify_trace_claim(
         unverified.extend(tpm_result.unverified_fields)
         details.update(tpm_result.details)
     elif platform == "amd-sev-snp":
-        from cmcp_verify.sev_snp import verify_sev_snp_measurement
+        from cmcp_verify.sev_snp import (
+            load_vcek_chain_from_evidence,
+            verify_sev_snp_measurement,
+        )
 
         raw_ev = _runtime.get("raw_evidence")
         raw_bytes = base64.b64decode(raw_ev) if raw_ev else None
         report_data_hex = _runtime.get("report_data")
+        # The VCEK leaf chain may be supplied as evidence; trusted AMD roots come
+        # from verifier config (_TRUSTED_AMD_ROOTS), never from the claim.
+        vcek_chain = load_vcek_chain_from_evidence(_runtime.get("vcek_chain"))
         snp_result = verify_sev_snp_measurement(
             measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,
             report_data_hex=report_data_hex,
+            vcek_chain=vcek_chain,
+            trusted_roots=_TRUSTED_AMD_ROOTS,
         )
-        if snp_result.verified:
+        chain_ok = "vcek_cert_chain" not in snp_result.unverified_fields
+        if snp_result.verified and chain_ok:
             verified.append("hardware_attestation")
             verified.extend(snp_result.verified_fields)
+        elif snp_result.verified and not chain_ok:
+            # Report parsed and measurement/report_data matched, but the hardware
+            # root of trust (VCEK->ASK->ARK chain + report signature) was not
+            # established: never fully VERIFIED, only partial.
+            verified.extend(snp_result.verified_fields)
+            unverified.append("hardware_attestation")
+            details["hardware_attestation"] = (
+                "SNP report checked but VCEK chain/signature not verified "
+                "(configure trusted AMD roots and supply vcek_chain)"
+            )
         else:
             unverified.append("hardware_attestation")
             failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -137,7 +137,9 @@ def test_report_data_match_adds_verified_field():
     assert "report_data" in result.verified_fields
 
 
-def test_report_data_mismatch_not_fatal():
+def test_report_data_mismatch_is_fatal():
+    """A report_data mismatch must fail closed: report_data carries the
+    confirmation-key binding / freshness nonce (issue #384)."""
     raw_m = b"\x55" * 48
     report = make_snp_report(version=2, measurement_bytes=raw_m, report_data=b"\x22" * 64)
     measurement = "sha384:" + hashlib.sha384(raw_m).hexdigest()
@@ -145,9 +147,9 @@ def test_report_data_mismatch_not_fatal():
     result = verify_sev_snp_measurement(
         measurement, raw_evidence=report, report_data_hex=wrong_report_data.hex()
     )
-    assert result.verified is True
+    assert result.verified is False
+    assert result.failure_reason == "report_data_mismatch"
     assert "report_data" not in result.verified_fields
-    assert result.failure_reason is None
 
 
 def test_truncated_report_is_parse_error():
@@ -181,10 +183,113 @@ def test_vcek_cert_chain_always_unverified_with_matching_report():
     report = make_snp_report(version=2, measurement_bytes=raw_m)
     result = verify_sev_snp_measurement(measurement, raw_evidence=report)
     assert "vcek_cert_chain" in result.unverified_fields
-    assert result.details["vcek_chain"] == "requires_amd_kds_lookup"
+    assert "not provided" in result.details["vcek_chain"]
 
 
 def test_vcek_cert_chain_unverified_on_format_failure():
     bad = "sha256:" + "z" * 64
     result = verify_sev_snp_measurement(bad, raw_evidence=None)
     assert "vcek_cert_chain" in result.unverified_fields
+
+
+# -- VCEK -> ASK -> ARK chain + report signature (issue #384) -----------------
+
+import datetime as _dt  # noqa: E402
+
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives import hashes as _hashes  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec as _ec  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.utils import (  # noqa: E402
+    decode_dss_signature,
+)
+from cryptography.x509.oid import NameOID  # noqa: E402
+
+_SIG_OFFSET = _SnpAttestationReport.signature.offset
+_SIG_ALGO_OFFSET = _SnpAttestationReport.sig_algo.offset
+
+
+def _mk_cert(subject_cn, subject_key, issuer_cn, issuer_key):
+    now = _dt.datetime(2026, 1, 1, tzinfo=_dt.UTC)
+    return (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_cn)]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn)]))
+        .public_key(subject_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + _dt.timedelta(days=3650))
+        .sign(issuer_key, _hashes.SHA384())
+    )
+
+
+def _build_chain():
+    ark_key = _ec.generate_private_key(_ec.SECP384R1())
+    ask_key = _ec.generate_private_key(_ec.SECP384R1())
+    vcek_key = _ec.generate_private_key(_ec.SECP384R1())
+    ark = _mk_cert("ARK", ark_key, "ARK", ark_key)          # self-signed root
+    ask = _mk_cert("ASK", ask_key, "ARK", ark_key)          # issued by ARK
+    vcek = _mk_cert("VCEK", vcek_key, "ASK", ask_key)       # issued by ASK
+    return [vcek, ask, ark], ark, vcek_key
+
+
+def _make_signed_report(measurement_bytes, report_data, vcek_key):
+    buf = bytearray(make_snp_report(version=2, measurement_bytes=measurement_bytes,
+                                    report_data=report_data))
+    struct.pack_into("<I", buf, _SIG_ALGO_OFFSET, 1)  # ECDSA-P384-SHA384
+    signed_body = bytes(buf[:0x2A0])
+    der = vcek_key.sign(signed_body, _ec.ECDSA(_hashes.SHA384()))
+    r, s = decode_dss_signature(der)
+    buf[_SIG_OFFSET : _SIG_OFFSET + 48] = r.to_bytes(48, "little")
+    buf[_SIG_OFFSET + 72 : _SIG_OFFSET + 120] = s.to_bytes(48, "little")
+    return bytes(buf)
+
+
+def test_chain_and_signature_verify_success():
+    chain, ark, vcek_key = _build_chain()
+    raw_m = b"\x66" * 48
+    rd = b"\x21" * 64
+    report = _make_signed_report(raw_m, rd, vcek_key)
+    measurement = "sha384:" + hashlib.sha384(raw_m).hexdigest()
+    result = verify_sev_snp_measurement(
+        measurement, raw_evidence=report, report_data_hex=rd.hex(),
+        vcek_chain=chain, trusted_roots=[ark],
+    )
+    assert result.verified is True, result.details
+    assert "vcek_cert_chain" in result.verified_fields
+    assert "report_signature" in result.verified_fields
+    assert "vcek_cert_chain" not in result.unverified_fields
+
+
+def test_chain_untrusted_root_fails():
+    chain, _ark, vcek_key = _build_chain()
+    raw_m = b"\x66" * 48
+    rd = b"\x21" * 64
+    report = _make_signed_report(raw_m, rd, vcek_key)
+    measurement = "sha384:" + hashlib.sha384(raw_m).hexdigest()
+    # A different, untrusted root.
+    _other_chain, other_root, _ = _build_chain()
+    result = verify_sev_snp_measurement(
+        measurement, raw_evidence=report, report_data_hex=rd.hex(),
+        vcek_chain=chain, trusted_roots=[other_root],
+    )
+    assert result.verified is False
+    assert result.failure_reason == "vcek_chain_verification_failed"
+    assert "vcek_cert_chain" in result.unverified_fields
+
+
+def test_report_signature_tampered_fails():
+    chain, ark, vcek_key = _build_chain()
+    raw_m = b"\x66" * 48
+    rd = b"\x21" * 64
+    report = bytearray(_make_signed_report(raw_m, rd, vcek_key))
+    # Tamper with the measurement AFTER signing; recompute the claimed measurement
+    # so the measurement check passes and we reach signature verification.
+    tampered_m = b"\x99" * 48
+    report[_MEASUREMENT_OFFSET : _MEASUREMENT_OFFSET + 48] = tampered_m
+    measurement = "sha384:" + hashlib.sha384(tampered_m).hexdigest()
+    result = verify_sev_snp_measurement(
+        measurement, raw_evidence=bytes(report), report_data_hex=rd.hex(),
+        vcek_chain=chain, trusted_roots=[ark],
+    )
+    assert result.verified is False
+    assert result.failure_reason == "vcek_chain_verification_failed"

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -340,6 +340,33 @@ def test_hardware_backed_happy_path_is_verified(monkeypatch):
     assert result.status == VerificationStatus.VERIFIED
 
 
+def test_snp_report_without_verified_chain_stays_partial(monkeypatch):
+    """Issue #384: an SNP report whose measurement/report_data check out but whose
+    VCEK chain is unverified must never be VERIFIED, only PARTIALLY_VERIFIED."""
+    import cmcp_verify.sev_snp as snp_mod
+    from cmcp_verify.sev_snp import SNPVerificationResult
+
+    def _snp_ok_but_chain_unverified(*args, **kwargs):
+        return SNPVerificationResult(
+            verified=True,
+            verified_fields=["measurement", "report_data"],
+            unverified_fields=["vcek_cert_chain"],
+        )
+
+    monkeypatch.setattr(
+        snp_mod, "verify_sev_snp_measurement", _snp_ok_but_chain_unverified
+    )
+
+    claim_dict, key = _make_signed_claim(provider="sev-snp")
+    result = verify_trace_claim(
+        claim_dict, _approved(), trusted_public_key_hex=key.public_key_hex
+    )
+    assert result.failure_reason is None, result.details
+    assert "hardware_attestation" in result.unverified_fields
+    assert "hardware_attestation" not in result.verified_fields
+    assert result.status == VerificationStatus.PARTIALLY_VERIFIED
+
+
 def test_real_failure_is_not_downgraded_to_partial():
     """A genuine failure keeps its failure status; the software-only rule never
     flips a real failure (here, a mismatched policy hash) to PARTIALLY_VERIFIED


### PR DESCRIPTION
Hardens the cmcp SEV-SNP verifier (issue #384), porting the approach already used in `ca2a_verify`.

## Changes
- **`report_data` mismatch is now fatal.** Previously a mismatch was silently ignored (`verified` stayed `True`), so an SNP report for a different enclave whose measurement happened to match would pass. `report_data` carries the confirmation-key binding / freshness nonce.
- **Real VCEK → ASK → ARK chain + report-signature verification.** Adds `verify_cert_chain` and ECDSA-P384/SHA-384 report-signature checks (adapted from `ca2a_verify`). Run when a `vcek_chain` is supplied in evidence and trusted AMD roots are configured.
- **Dispatcher guard.** `verify_trace_claim` no longer marks `hardware_attestation` verified while `vcek_cert_chain` is unverified; such a claim stays `PARTIALLY_VERIFIED`, never `VERIFIED`.

## Security note
`_TRUSTED_AMD_ROOTS` is intentionally empty and must be populated from **verifier configuration** (never from the claim) to enable full rooting. Until configured, SNP claims remain `PARTIALLY_VERIFIED` (fail-closed). Sourcing the trusted root from the claim would recreate the verify-the-trust-anchor bug this fixes.

## Tests
- New: chain+signature success, untrusted-root rejection, tampered-signature rejection (build a real P-384 ARK/ASK/VCEK chain and sign a report), `report_data`-mismatch-is-fatal, and a dispatcher test proving an SNP report with an unverified chain stays `PARTIALLY_VERIFIED`.
- `tests/unit/test_sev_snp_verify.py` + `tests/unit/test_verify.py`: all pass. Full unit suite: **770 passed**. The 2 `test_agt_evidence.py` failures are pre-existing on `origin/main` (unrelated; addressed by the separate `fix/agt-evidence-datetime-utc` branch).

## Follow-up
Apply the same treatment to the TDX (Intel PCS/DCAP) and TPM paths, and wire a production source for the trusted AMD roots.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
