### PR TITLE
fix(verify): make SNP report_data binding fatal and never report VERIFIED without a verified VCEK chain (#371)

### DIFF
--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -220,7 +220,7 @@ def verify_sev_snp_measurement(
     - measurement string format (sha384:<96 hex chars>)
     - SNP report version (must be 2 or 3)
     - measurement field in report matches the claimed measurement
-    - report_data (nonce) if provided (mismatch is not fatal)
+    - report_data binding: if provided, a mismatch is FATAL (issue #371)
 
     When cert_chain_pem (a VCEK/ASK/ARK PEM bundle) and trusted_ark_pem (the
     operator-pinned AMD ARK) are both provided, the SNP report signature and the
@@ -283,7 +283,10 @@ def verify_sev_snp_measurement(
                 result.details["vcek_chain"] = "requires_amd_kds_lookup"
                 return result
 
-            # Check report_data (nonce) using named struct access -- mismatch is not fatal
+            # Check report_data binding -- a mismatch is FATAL (issue #371).
+            # report_data carries the confirmation-key binding / freshness nonce;
+            # silently ignoring a mismatch would accept an SNP report for a
+            # different enclave whose measurement happens to match.
             if report_data_hex is not None:
                 extracted_rd = bytes(report.report_data)
                 expected_rd = bytes.fromhex(report_data_hex[:128])
@@ -292,6 +295,11 @@ def verify_sev_snp_measurement(
                     expected_rd = expected_rd + b"\x00" * (64 - len(expected_rd))
                 if extracted_rd == expected_rd:
                     result.verified_fields.append("report_data")
+                else:
+                    result.verified = False
+                    result.failure_reason = "report_data_mismatch"
+                    result.unverified_fields.append("vcek_cert_chain")
+                    return result
 
         except Exception:  # noqa: BLE001
             result.verified = False

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -812,9 +812,20 @@ def verify_trace_claim(
             cert_chain_pem=cert_chain_pem,
             trusted_ark_pem=trusted_ark_pem,
         )
-        if snp_result.verified:
+        # The VCEK chain is the SNP hardware root of trust. Even when the report
+        # parses and the measurement matches, a claim whose chain is unverified
+        # must never be reported as fully VERIFIED (issues #370/#372) -- it stays
+        # PARTIALLY_VERIFIED.
+        chain_ok = "vcek_cert_chain" not in snp_result.unverified_fields
+        if snp_result.verified and chain_ok:
             verified.append("hardware_attestation")
             verified.extend(snp_result.verified_fields)
+        elif snp_result.verified and not chain_ok:
+            verified.extend(snp_result.verified_fields)
+            unverified.append("hardware_attestation")
+            details["hardware_attestation"] = (
+                "SNP report checked but VCEK chain/signature not verified"
+            )
         else:
             unverified.append("hardware_attestation")
             failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -137,7 +137,9 @@ def test_report_data_match_adds_verified_field():
     assert "report_data" in result.verified_fields
 
 
-def test_report_data_mismatch_not_fatal():
+def test_report_data_mismatch_is_fatal():
+    """A report_data mismatch must fail closed (issue #371): report_data carries
+    the confirmation-key binding / freshness nonce."""
     raw_m = b"\x55" * 48
     report = make_snp_report(version=2, measurement_bytes=raw_m, report_data=b"\x22" * 64)
     measurement = "sha384:" + hashlib.sha384(raw_m).hexdigest()
@@ -145,9 +147,9 @@ def test_report_data_mismatch_not_fatal():
     result = verify_sev_snp_measurement(
         measurement, raw_evidence=report, report_data_hex=wrong_report_data.hex()
     )
-    assert result.verified is True
+    assert result.verified is False
+    assert result.failure_reason == "report_data_mismatch"
     assert "report_data" not in result.verified_fields
-    assert result.failure_reason is None
 
 
 def test_truncated_report_is_parse_error():

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -340,6 +340,33 @@ def test_hardware_backed_happy_path_is_verified(monkeypatch):
     assert result.status == VerificationStatus.VERIFIED
 
 
+def test_snp_report_without_verified_chain_stays_partial(monkeypatch):
+    """Issues #370/#372: an SNP report whose measurement/report_data check out but
+    whose VCEK chain is unverified must never be VERIFIED, only PARTIALLY_VERIFIED."""
+    import cmcp_verify.sev_snp as snp_mod
+    from cmcp_verify.sev_snp import SNPVerificationResult
+
+    def _snp_ok_but_chain_unverified(*args, **kwargs):
+        return SNPVerificationResult(
+            verified=True,
+            verified_fields=["measurement", "report_data"],
+            unverified_fields=["vcek_cert_chain"],
+        )
+
+    monkeypatch.setattr(
+        snp_mod, "verify_sev_snp_measurement", _snp_ok_but_chain_unverified
+    )
+
+    claim_dict, key = _make_signed_claim(provider="sev-snp")
+    result = verify_trace_claim(
+        claim_dict, _approved(), trusted_public_key_hex=key.public_key_hex
+    )
+    assert result.failure_reason is None, result.details
+    assert "hardware_attestation" in result.unverified_fields
+    assert "hardware_attestation" not in result.verified_fields
+    assert result.status == VerificationStatus.PARTIALLY_VERIFIED
+
+
 def test_real_failure_is_not_downgraded_to_partial():
     """A genuine failure keeps its failure status; the software-only rule never
     flips a real failure (here, a mismatched policy hash) to PARTIALLY_VERIFIED


### PR DESCRIPTION
Two small hardening gaps remain after the merged #386 (SNP report-signature + VCEK chain) and #387 (TDX DCAP):

1. **`report_data` mismatch is now fatal (#371).** #386 left a `report_data` mismatch non-fatal (`# ... mismatch is not fatal`), so an SNP report for a *different* enclave whose measurement happens to match would still pass the binding check. `report_data` carries the confirmation-key binding / freshness nonce; a mismatch now fails closed (`report_data_mismatch`).
2. **An SNP claim with an unverified VCEK chain is never reported as `VERIFIED` (#370/#372).** When the cert chain / pinned ARK is not supplied, `verify_sev_snp_measurement` returns `verified=True` (measurement-level) with `vcek_cert_chain` in `unverified_fields`; the dispatcher previously marked `hardware_attestation` verified anyway, yielding overall `VERIFIED`. It now stays `PARTIALLY_VERIFIED` unless the chain (the SNP hardware root of trust) is actually verified.

## Tests
- `test_report_data_mismatch_is_fatal` (flipped from the old not-fatal test).
- `test_snp_report_without_verified_chain_stays_partial` (dispatcher guard).
- Full unit suite: **778 passed, 3 skipped**.

## Scope note
#371 also asks for the same `report_data`-fatal treatment on the TDX path plus a TDX `report_data` offset check; this PR covers **SNP only**. TDX/TPM `report_data`-fatal can follow the same pattern.

Refs #371, #370, #372. Supersedes the SNP-specific portion of #384 (the chain/signature work there is already covered by merged #386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
