### PR TITLE
ci: sign published images (cosign) + attest SLSA build provenance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # keyless cosign signing + provenance attestation (OIDC)
+      attestations: write   # actions/attest-build-provenance
 
     steps:
       - name: Checkout
@@ -31,6 +33,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -38,3 +41,18 @@ jobs:
           tags: |
             ghcr.io/agentrust-io/cmcp-gateway:${{ steps.tag.outputs.tag }}
             ghcr.io/agentrust-io/cmcp-gateway:latest
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the image (keyless, by digest)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes ghcr.io/agentrust-io/cmcp-gateway@${DIGEST}
+
+      - name: Attest build provenance (SLSA)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/agentrust-io/cmcp-gateway
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
The `Docker publish` workflow pushed the release image to `ghcr.io` with no signature and no provenance. This adds supply-chain attestation to the published image:

- **Keyless cosign signing** of the pushed image by digest (Sigstore / Fulcio / Rekor via GitHub OIDC, no long-lived keys).
- **SLSA build provenance** via `actions/attest-build-provenance`, pushed to the registry as an attestation.

Adds `id-token: write` + `attestations: write` permissions and signs the immutable digest (not the mutable tag). Consumers can verify with `cosign verify` / `gh attestation verify`.

Note: the new actions use major-version tags to match this workflow's existing convention (`@v7`, `@v4`); pinning all actions to commit SHAs is a repo-wide follow-up.

Closes part of the agentrust-io supply-chain hardening (catalog Appendix B, "artifact signing / SLSA provenance").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
