### PR TITLE
feat(verify): add embodied action evidence fixtures

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -128,7 +128,7 @@ Network position: sits between agent host and MCP servers. The gateway is the on
 ## 5. TRACE Claim Schema
 
 The unit of proof handed to an auditor, produced per session (or per call, configurable).
-The normative schema is [`schemas/trace-claim.schema.json`](../schemas/trace-claim.schema.json),
+The normative schema is `schemas/trace-claim.schema.json`,
 and a full worked example is in [the quickstart](quickstart.md). The envelope is a
 `GatewayClaim`: canonical TRACE v0.1 fields live under `trace`, cMCP-specific addenda live
 under `gateway`, and `signature` is detached (computed over every other field).

--- a/docs/spec/embodied-action-evidence.md
+++ b/docs/spec/embodied-action-evidence.md
@@ -223,10 +223,36 @@ Profile-aware verifiers SHOULD classify receipt state as:
 | `accepted` | Receipt verifies and issuer verdict is accepted. |
 | `rejected` | Receipt verifies and issuer verdict is rejected. |
 
-The v0.1 cMCP verifier already validates the evidence envelope signature and
-`linked_call_id` when `external_evidence_keys` are provided. A future
-profile-aware verifier can add detached-payload checks without changing the base
-audit bundle verification contract.
+The base cMCP audit bundle verifier validates the evidence envelope signature and
+`linked_call_id` when `external_evidence_keys` are provided. The profile-aware
+`verify_embodied_action_evidence()` helper adds detached-payload checks without
+changing the base audit bundle verification contract.
+
+## ROS 2 Action Fixture
+
+The repository includes a ROS 2 Kilted `rclpy` fixture at
+`tests/fixtures/embodied-action-evidence/ros2-fibonacci-aborted.json`.
+
+The fixture is based on a tutorial-scope `example_interfaces/action/Fibonacci`
+action run where:
+
+- the client-side and server-side serialized goal preimage hashes matched;
+- the ROS action goal UUID matched on both sides;
+- the server reported a terminal `aborted` outcome;
+- the receipt uses `physical_completion_claim: none`.
+
+The fixture exercises profile fields for:
+
+- `ros2.goal_uuid`;
+- `ros2.goal_preimage_hash`;
+- `ros2.goal_preimage_method`;
+- ROS distribution and RMW implementation;
+- terminal controller state;
+- receipt issuer role and issuer independence.
+
+It is intentionally a binding fixture, not a live ROS dependency in CI. It does
+not prove physical completion, controller honesty, functional safety,
+cross-RMW stability, or arbitrary ROS interface compatibility.
 
 ## Verifier Flow
 

--- a/docs/spec/verification-library.md
+++ b/docs/spec/verification-library.md
@@ -82,6 +82,22 @@ class AuditBundleResult:
     entry_count: int
     failures: list[str]
 
+class ReceiptState(Enum):
+    ABSENT = "absent"
+    UNTRUSTED = "untrusted"
+    INVALID = "invalid"
+    STALE = "stale"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+@dataclass
+class EmbodiedActionEvidenceResult:
+    verified: bool
+    receipt_state: ReceiptState
+    verified_fields: list[str]
+    failures: list[str]
+    warnings: list[str]
+
 def verify_audit_bundle(
     bundle_json: dict,
     claim_json: Optional[dict] = None,
@@ -92,6 +108,24 @@ def verify_audit_bundle(
     Verify an exported audit bundle. When external_evidence_keys is supplied,
     each key is issuer_key_id -> raw 32-byte Ed25519 public key. issuer_key_id
     is lowercase hex SHA-256(public_key_bytes).
+    """
+    ...
+
+def verify_embodied_action_evidence(
+    audit_entry: dict,
+    detached_payload: dict,
+    claim_json: Optional[dict] = None,
+    *,
+    require_receipt: bool = False,
+) -> EmbodiedActionEvidenceResult:
+    """
+    Verify the detached payload for the embodied action evidence profile.
+
+    This helper assumes verify_audit_bundle() has already been used when
+    issuer signature verification is required. It checks profile-specific
+    binding between the audit entry, external_execution_evidence.evidence_hash,
+    action_ref, governance decision, optional TRACE Claim context, ROS 2 action
+    binding fields when present, and receipt classification.
     """
     ...
 ```
@@ -115,6 +149,13 @@ The verifier computes the receipt signing input as canonical JSON over the recei
 5. The Ed25519 signature verifies over the canonical receipt signing input.
 
 If any external evidence check fails, the audit bundle result is `verified=False` and the failure string includes `EXTERNAL_EVIDENCE_VERIFICATION_FAILED`.
+
+`verify_embodied_action_evidence()` is the profile-aware follow-up for detached
+payloads that use `cmcp.embodied_action_evidence.v0`. It does not replace
+`verify_audit_bundle()`: callers still use the base bundle verifier for audit-chain
+integrity and external issuer signatures, then use the profile helper to classify
+payload-level evidence such as missing receipts, mismatched ROS 2 goal IDs, and
+unsupported physical-completion claims.
 
 ## Per-Provider Verification Steps
 

--- a/src/cmcp_verify/__init__.py
+++ b/src/cmcp_verify/__init__.py
@@ -1,5 +1,13 @@
 """cmcp-verify - verify cMCP Runtime TRACE Claims without trusting the operator."""
 
+from cmcp_verify.embodied_action import (
+    EMBODIED_ACTION_PROFILE,
+    EmbodiedActionEvidenceResult,
+    ReceiptState,
+    compute_action_ref,
+    hash_embodied_action_payload,
+    verify_embodied_action_evidence,
+)
 from cmcp_verify.verify import (
     ApprovedHashes,
     AuditBundleResult,
@@ -14,9 +22,15 @@ __version__ = "0.1.0"
 __all__ = [
     "ApprovedHashes",
     "AuditBundleResult",
+    "EMBODIED_ACTION_PROFILE",
+    "EmbodiedActionEvidenceResult",
+    "ReceiptState",
     "VerificationError",
     "VerificationResult",
     "VerificationStatus",
+    "compute_action_ref",
+    "hash_embodied_action_payload",
     "verify_audit_bundle",
+    "verify_embodied_action_evidence",
     "verify_trace_claim",
 ]

--- a/src/cmcp_verify/embodied_action.py
+++ b/src/cmcp_verify/embodied_action.py
@@ -1,0 +1,300 @@
+"""Profile-aware verification for embodied action evidence payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+EMBODIED_ACTION_PROFILE = "cmcp.embodied_action_evidence.v0"
+
+_HASH_RE = re.compile(r"^sha(256|384):([0-9a-f]+)$")
+_ACTION_REF_FIELDS = ("agent_id", "action_type", "action_scope", "action_timestamp")
+_REQUIRED_PAYLOAD_FIELDS = (
+    "profile",
+    "call_id",
+    "action_ref",
+    "agent_id",
+    "action_type",
+    "action_scope",
+    "action_timestamp",
+    "governance_decision",
+    "policy_bundle_hash",
+    "tool_catalog_hash",
+    "controller_target",
+    "handoff_timestamp",
+)
+_ROS2_REQUIRED_FIELDS = (
+    "distribution",
+    "action_name",
+    "action_type",
+    "goal_uuid",
+    "goal_preimage_hash",
+    "goal_preimage_method",
+)
+
+
+class ReceiptState(StrEnum):
+    """Detached payload receipt classification."""
+
+    ABSENT = "absent"
+    UNTRUSTED = "untrusted"
+    INVALID = "invalid"
+    STALE = "stale"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+@dataclass
+class EmbodiedActionEvidenceResult:
+    """Result of verifying a detached embodied-action evidence payload."""
+
+    verified: bool
+    receipt_state: ReceiptState
+    verified_fields: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def canonical_json_bytes(value: dict[str, Any]) -> bytes:
+    """Return the canonical JSON byte form used by cMCP evidence hashes."""
+
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode()
+
+
+def hash_embodied_action_payload(payload: dict[str, Any], *, algorithm: str = "sha256") -> str:
+    """Hash a detached embodied-action evidence payload."""
+
+    if algorithm == "sha256":
+        digest = hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+    elif algorithm == "sha384":
+        digest = hashlib.sha384(canonical_json_bytes(payload)).hexdigest()
+    else:
+        raise ValueError("algorithm must be sha256 or sha384")
+    return f"{algorithm}:{digest}"
+
+
+def compute_action_ref(payload: dict[str, Any]) -> str:
+    """Compute the profile action_ref from the v0.1 canonical action preimage."""
+
+    preimage = {field: payload[field] for field in _ACTION_REF_FIELDS}
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(preimage)).hexdigest()
+
+
+def _claim_policy_hash(claim_json: dict[str, Any]) -> str | None:
+    policy = claim_json.get("trace", {}).get("policy", {})
+    value = policy.get("bundle_hash")
+    return value if isinstance(value, str) else None
+
+
+def _claim_catalog_hash(claim_json: dict[str, Any]) -> str | None:
+    catalog = claim_json.get("gateway", {}).get("catalog", {})
+    value = catalog.get("hash")
+    return value if isinstance(value, str) else None
+
+
+def _claim_agent_id(claim_json: dict[str, Any]) -> str | None:
+    identity = claim_json.get("gateway", {}).get("agent_identity")
+    if not isinstance(identity, dict):
+        return None
+    value = identity.get("agent_id")
+    return value if isinstance(value, str) else None
+
+
+def _verify_hash_value(hash_value: str, payload: dict[str, Any]) -> bool:
+    match = _HASH_RE.match(hash_value)
+    if not match:
+        return False
+    algorithm = f"sha{match.group(1)}"
+    return hmac.compare_digest(hash_value, hash_embodied_action_payload(payload, algorithm=algorithm))
+
+
+def _record_receipt_state(
+    receipt: dict[str, Any] | None,
+    failures: list[str],
+) -> ReceiptState:
+    if receipt is None:
+        return ReceiptState.ABSENT
+    verdict = receipt.get("verdict")
+    if verdict == "accepted":
+        return ReceiptState.ACCEPTED
+    if verdict == "rejected":
+        return ReceiptState.REJECTED
+    failures.append("receipt.verdict must be accepted or rejected")
+    return ReceiptState.INVALID
+
+
+def verify_embodied_action_evidence(
+    audit_entry: dict[str, Any],
+    detached_payload: dict[str, Any],
+    claim_json: dict[str, Any] | None = None,
+    *,
+    require_receipt: bool = False,
+) -> EmbodiedActionEvidenceResult:
+    """Verify the detached payload for the embodied action evidence profile.
+
+    This helper assumes the caller has already run ``verify_audit_bundle`` when
+    issuer signature verification is required. It checks the profile-specific
+    binding between an audit entry, the detached evidence payload, and optional
+    TRACE Claim context.
+    """
+
+    verified_fields: list[str] = []
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    evidence = audit_entry.get("external_execution_evidence")
+    if not isinstance(evidence, dict):
+        failures.append("audit entry has no external_execution_evidence object")
+        return EmbodiedActionEvidenceResult(
+            verified=False,
+            receipt_state=ReceiptState.INVALID,
+            verified_fields=verified_fields,
+            failures=failures,
+            warnings=warnings,
+        )
+
+    missing = [field for field in _REQUIRED_PAYLOAD_FIELDS if field not in detached_payload]
+    if missing:
+        failures.append(f"detached payload missing required fields: {', '.join(missing)}")
+
+    if detached_payload.get("profile") != EMBODIED_ACTION_PROFILE:
+        failures.append(f"detached payload profile must be {EMBODIED_ACTION_PROFILE}")
+    else:
+        verified_fields.append("profile")
+
+    call_id = audit_entry.get("call_id")
+    if detached_payload.get("call_id") != call_id:
+        failures.append("detached payload call_id does not match audit entry call_id")
+    else:
+        verified_fields.append("call_id")
+
+    if evidence.get("linked_call_id") != call_id:
+        failures.append("external_execution_evidence linked_call_id does not match audit entry call_id")
+    else:
+        verified_fields.append("external_execution_evidence.linked_call_id")
+
+    evidence_hash = evidence.get("evidence_hash")
+    if not isinstance(evidence_hash, str) or not _verify_hash_value(evidence_hash, detached_payload):
+        failures.append("external_execution_evidence evidence_hash does not match detached payload")
+    else:
+        verified_fields.append("external_execution_evidence.evidence_hash")
+
+    if all(isinstance(detached_payload.get(field), str) for field in _ACTION_REF_FIELDS):
+        expected_action_ref = compute_action_ref(detached_payload)
+        if detached_payload.get("action_ref") != expected_action_ref:
+            failures.append("action_ref does not match canonical action preimage")
+        else:
+            verified_fields.append("action_ref")
+    else:
+        failures.append("action_ref preimage fields must be strings")
+
+    policy_decision = audit_entry.get("policy_decision")
+    if policy_decision is not None:
+        if detached_payload.get("governance_decision") != policy_decision:
+            failures.append("governance_decision does not match audit entry policy_decision")
+        else:
+            verified_fields.append("governance_decision")
+
+    if claim_json is not None:
+        policy_hash = _claim_policy_hash(claim_json)
+        if policy_hash is not None:
+            if detached_payload.get("policy_bundle_hash") != policy_hash:
+                failures.append("policy_bundle_hash does not match TRACE Claim policy hash")
+            else:
+                verified_fields.append("policy_bundle_hash")
+
+        catalog_hash = _claim_catalog_hash(claim_json)
+        if catalog_hash is not None:
+            if detached_payload.get("tool_catalog_hash") != catalog_hash:
+                failures.append("tool_catalog_hash does not match TRACE Claim catalog hash")
+            else:
+                verified_fields.append("tool_catalog_hash")
+
+        agent_id = _claim_agent_id(claim_json)
+        if agent_id is not None:
+            if detached_payload.get("agent_id") != agent_id:
+                failures.append("agent_id does not match TRACE Claim agent identity")
+            else:
+                verified_fields.append("agent_id")
+
+    ros2 = detached_payload.get("ros2")
+    if ros2 is not None:
+        if not isinstance(ros2, dict):
+            failures.append("ros2 must be an object when present")
+        else:
+            ros_missing = [field for field in _ROS2_REQUIRED_FIELDS if field not in ros2]
+            if ros_missing:
+                failures.append(f"ros2 missing required fields: {', '.join(ros_missing)}")
+            else:
+                verified_fields.append("ros2.goal_preimage_hash")
+                verified_fields.append("ros2.goal_uuid")
+
+    receipt = detached_payload.get("receipt")
+    if receipt is not None and not isinstance(receipt, dict):
+        failures.append("receipt must be an object when present")
+        receipt_state = ReceiptState.INVALID
+    else:
+        receipt_state = _record_receipt_state(receipt, failures)
+
+    if require_receipt and receipt_state == ReceiptState.ABSENT:
+        failures.append("receipt is required by verifier policy")
+
+    if isinstance(receipt, dict):
+        if receipt.get("receipt_type") != evidence.get("evidence_type"):
+            failures.append("receipt.receipt_type does not match evidence_type")
+        else:
+            verified_fields.append("receipt.receipt_type")
+
+        if receipt.get("call_id") is not None:
+            if receipt.get("call_id") != detached_payload.get("call_id"):
+                failures.append("receipt.call_id does not match detached payload call_id")
+            else:
+                verified_fields.append("receipt.call_id")
+
+        if receipt.get("action_ref") is not None:
+            if receipt.get("action_ref") != detached_payload.get("action_ref"):
+                failures.append("receipt.action_ref does not match detached payload action_ref")
+            else:
+                verified_fields.append("receipt.action_ref")
+
+        if isinstance(ros2, dict):
+            if receipt.get("goal_uuid") is not None:
+                if receipt.get("goal_uuid") != ros2.get("goal_uuid"):
+                    failures.append("receipt.goal_uuid does not match ros2.goal_uuid")
+                else:
+                    verified_fields.append("receipt.goal_uuid")
+            if receipt.get("goal_preimage_hash") is not None:
+                if receipt.get("goal_preimage_hash") != ros2.get("goal_preimage_hash"):
+                    failures.append(
+                        "receipt.goal_preimage_hash does not match ros2.goal_preimage_hash"
+                    )
+                else:
+                    verified_fields.append("receipt.goal_preimage_hash")
+
+        physical_claim = receipt.get("physical_completion_claim")
+        if physical_claim is not None:
+            if physical_claim != "none":
+                failures.append("physical completion claims are not verified by this profile")
+            else:
+                verified_fields.append("receipt.physical_completion_claim")
+
+        if receipt.get("issuer_independence") == "gateway_self_report":
+            warnings.append("receipt is same-party gateway self-report evidence")
+
+    return EmbodiedActionEvidenceResult(
+        verified=not failures,
+        receipt_state=receipt_state,
+        verified_fields=verified_fields,
+        failures=failures,
+        warnings=warnings,
+    )

--- a/tests/fixtures/embodied-action-evidence/ros2-fibonacci-aborted.json
+++ b/tests/fixtures/embodied-action-evidence/ros2-fibonacci-aborted.json
@@ -1,0 +1,80 @@
+{
+  "audit_entry": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "external_execution_evidence": {
+      "evidence_hash": "sha256:a0ab9c8b8c9faef21ae5f691aad71fb649d85d69ebd7b0dacc03947f32218da7",
+      "evidence_type": "controller-execution-receipt/v1",
+      "issuer": "spiffe://factory.example/controller/ros2/abort-fibonacci",
+      "issuer_key_id": "10ba682c8ad13513971e8b56881aab8bd702bb807796eca81932c735a94d6e6d",
+      "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+      "signature": "HO6mi1LpnQeGWIGM9IyBa9n-lpT1td2lK_w82a5s8ibQqzdGa-PeA2op7sNm3cghgf9DIqS1uXq-w5CA6pgBDA"
+    },
+    "policy_decision": "allow"
+  },
+  "description": "ROS 2 Kilted rclpy Fibonacci action fixture with matching goal hash and terminal aborted outcome.",
+  "detached_payload": {
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "controller_target": "spiffe://factory.example/controller/ros2/abort-fibonacci",
+    "governance_decision": "allow",
+    "handoff_timestamp": "2026-07-06T15:22:13Z",
+    "limitations": [
+      "receipt binds a ROS 2 action goal and terminal server outcome",
+      "receipt does not prove physical completion or safety certification",
+      "fixture is based on a tutorial-scope rclpy action run"
+    ],
+    "policy_bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "profile": "cmcp.embodied_action_evidence.v0",
+    "receipt": {
+      "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+      "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+      "completeness_claim": "not_proven",
+      "goal_preimage_hash": "sha256:8076970a7e5a672e4a22ec446626938d4ef8d16569a0050ccf38496578a92d24",
+      "goal_uuid": "379f9292500049849c17762d15bee166",
+      "issuer_independence": "separate_process_test_fixture",
+      "outcome_issuer_role": "action_server_process",
+      "physical_completion_claim": "none",
+      "receipt_hash": "sha256:86ff346a51a7412404d1df29f7a0a7de29f272c70ceb4c2becea765b3151b002",
+      "receipt_type": "controller-execution-receipt/v1",
+      "terminal_state": "aborted",
+      "verdict": "rejected"
+    },
+    "request_receipt_hash": "sha256:c1f8a101c3d210a943b615e3cedf603eef230f7cb7fdb1a2706d3a3a763a9a01",
+    "ros2": {
+      "action_name": "/abort_fibonacci_process",
+      "action_type": "example_interfaces/action/Fibonacci",
+      "distribution": "kilted",
+      "goal_preimage_hash": "sha256:8076970a7e5a672e4a22ec446626938d4ef8d16569a0050ccf38496578a92d24",
+      "goal_preimage_len": 8,
+      "goal_preimage_method": "rclpy type-support serialization of example_interfaces/action/Fibonacci.Goal",
+      "goal_uuid": "379f9292500049849c17762d15bee166",
+      "rmw_implementation": "rmw_fastrtps_cpp-default"
+    },
+    "tool_catalog_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "expected": {
+    "physical_completion_claim": "none",
+    "receipt_state": "rejected"
+  },
+  "name": "ros2-fibonacci-aborted",
+  "trace_claim": {
+    "gateway": {
+      "agent_identity": {
+        "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev"
+      },
+      "catalog": {
+        "hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    },
+    "trace": {
+      "policy": {
+        "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    }
+  },
+  "trusted_issuer_public_key_hex": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737"
+}

--- a/tests/unit/test_embodied_action_evidence.py
+++ b/tests/unit/test_embodied_action_evidence.py
@@ -7,6 +7,7 @@ import copy
 import json
 from pathlib import Path
 
+import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from cmcp_verify import (
@@ -36,6 +37,14 @@ def _rebind_payload_hash(fixture: dict) -> None:
     )
 
 
+def _verify_fixture(fixture: dict):
+    return verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        fixture["detached_payload"],
+        fixture["trace_claim"],
+    )
+
+
 def test_ros2_fibonacci_aborted_fixture_verifies():
     fixture = _fixture()
 
@@ -53,6 +62,15 @@ def test_ros2_fibonacci_aborted_fixture_verifies():
     assert "receipt.goal_uuid" in result.verified_fields
     assert "receipt.goal_preimage_hash" in result.verified_fields
     assert "receipt.physical_completion_claim" in result.verified_fields
+
+
+def test_payload_hash_helper_supports_sha384_and_rejects_unknown_algorithm():
+    fixture = _fixture()
+    payload = fixture["detached_payload"]
+
+    assert hash_embodied_action_payload(payload, algorithm="sha384").startswith("sha384:")
+    with pytest.raises(ValueError, match="algorithm must be sha256 or sha384"):
+        hash_embodied_action_payload(payload, algorithm="sha512")
 
 
 def test_ros2_fixture_external_evidence_signature_is_valid():
@@ -76,6 +94,40 @@ def test_ros2_fixture_external_evidence_signature_is_valid():
     public_key.verify(signature_bytes, signing_input)
 
 
+def test_missing_external_execution_evidence_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["audit_entry"]["external_execution_evidence"] = None
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert result.receipt_state == ReceiptState.INVALID
+    assert any("no external_execution_evidence" in failure for failure in result.failures)
+
+
+def test_accepted_receipt_classifies_as_accepted():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"]["verdict"] = "accepted"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert result.verified, result.failures
+    assert result.receipt_state == ReceiptState.ACCEPTED
+
+
+def test_invalid_receipt_verdict_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"]["verdict"] = "pending"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert result.receipt_state == ReceiptState.INVALID
+    assert any("receipt.verdict" in failure for failure in result.failures)
+
+
 def test_action_ref_mismatch_fails():
     fixture = copy.deepcopy(_fixture())
     payload = fixture["detached_payload"]
@@ -91,6 +143,158 @@ def test_action_ref_mismatch_fails():
 
     assert not result.verified
     assert any("action_ref" in failure for failure in result.failures)
+
+
+def test_missing_required_payload_field_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"].pop("controller_target")
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("missing required fields" in failure for failure in result.failures)
+
+
+def test_wrong_profile_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["profile"] = "cmcp.other_profile.v0"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("profile must be" in failure for failure in result.failures)
+
+
+def test_payload_call_id_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["call_id"] = "01986d7c-6b2f-7c68-9ff8-000000000000"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("payload call_id" in failure for failure in result.failures)
+
+
+def test_evidence_linked_call_id_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["audit_entry"]["external_execution_evidence"]["linked_call_id"] = (
+        "01986d7c-6b2f-7c68-9ff8-000000000000"
+    )
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("linked_call_id" in failure for failure in result.failures)
+
+
+def test_evidence_hash_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["audit_entry"]["external_execution_evidence"]["evidence_hash"] = "sha256:" + "0" * 64
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("evidence_hash" in failure for failure in result.failures)
+
+
+def test_malformed_evidence_hash_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["audit_entry"]["external_execution_evidence"]["evidence_hash"] = "sha512:not-a-digest"
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("evidence_hash" in failure for failure in result.failures)
+
+
+def test_non_string_action_ref_preimage_field_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["action_timestamp"] = 123
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("preimage fields must be strings" in failure for failure in result.failures)
+
+
+def test_governance_decision_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["governance_decision"] = "deny"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("governance_decision" in failure for failure in result.failures)
+
+
+def test_policy_bundle_hash_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["policy_bundle_hash"] = "sha256:" + "0" * 64
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("policy_bundle_hash" in failure for failure in result.failures)
+
+
+def test_tool_catalog_hash_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["tool_catalog_hash"] = "sha256:" + "0" * 64
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("tool_catalog_hash" in failure for failure in result.failures)
+
+
+def test_agent_identity_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["trace_claim"]["gateway"]["agent_identity"]["agent_id"] = (
+        "spiffe://factory.example/agent/other/dev"
+    )
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("agent_id" in failure for failure in result.failures)
+
+
+def test_non_object_agent_identity_is_ignored():
+    fixture = copy.deepcopy(_fixture())
+    fixture["trace_claim"]["gateway"]["agent_identity"] = "not-an-object"
+
+    result = _verify_fixture(fixture)
+
+    assert result.verified, result.failures
+
+
+def test_ros2_must_be_object_when_present():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["ros2"] = "not-an-object"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("ros2 must be an object" in failure for failure in result.failures)
+
+
+def test_ros2_missing_required_field_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["ros2"].pop("action_name")
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("ros2 missing required fields" in failure for failure in result.failures)
 
 
 def test_ros2_goal_uuid_mismatch_fails():
@@ -123,6 +327,51 @@ def test_ros2_goal_preimage_hash_mismatch_fails():
 
     assert not result.verified
     assert any("receipt.goal_preimage_hash" in failure for failure in result.failures)
+
+
+def test_receipt_must_be_object_when_present():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"] = "not-an-object"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert result.receipt_state == ReceiptState.INVALID
+    assert any("receipt must be an object" in failure for failure in result.failures)
+
+
+def test_receipt_type_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"]["receipt_type"] = "other-receipt/v1"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("receipt.receipt_type" in failure for failure in result.failures)
+
+
+def test_receipt_call_id_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"]["call_id"] = "01986d7c-6b2f-7c68-9ff8-000000000000"
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("receipt.call_id" in failure for failure in result.failures)
+
+
+def test_receipt_action_ref_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    fixture["detached_payload"]["receipt"]["action_ref"] = "sha256:" + "0" * 64
+    _rebind_payload_hash(fixture)
+
+    result = _verify_fixture(fixture)
+
+    assert not result.verified
+    assert any("receipt.action_ref" in failure for failure in result.failures)
 
 
 def test_missing_receipt_is_absent_unless_policy_requires_it():

--- a/tests/unit/test_embodied_action_evidence.py
+++ b/tests/unit/test_embodied_action_evidence.py
@@ -1,0 +1,182 @@
+"""Tests for embodied action evidence profile verification."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from cmcp_verify import (
+    ReceiptState,
+    hash_embodied_action_payload,
+    verify_embodied_action_evidence,
+)
+
+_FIXTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "embodied-action-evidence"
+    / "ros2-fibonacci-aborted.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _rebind_payload_hash(fixture: dict) -> None:
+    """Keep fixture mutations focused on profile checks, not stale evidence hashes."""
+
+    payload = fixture["detached_payload"]
+    fixture["audit_entry"]["external_execution_evidence"]["evidence_hash"] = (
+        hash_embodied_action_payload(payload)
+    )
+
+
+def test_ros2_fibonacci_aborted_fixture_verifies():
+    fixture = _fixture()
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        fixture["detached_payload"],
+        fixture["trace_claim"],
+        require_receipt=True,
+    )
+
+    assert result.verified, result.failures
+    assert result.receipt_state == ReceiptState.REJECTED
+    assert "external_execution_evidence.evidence_hash" in result.verified_fields
+    assert "action_ref" in result.verified_fields
+    assert "receipt.goal_uuid" in result.verified_fields
+    assert "receipt.goal_preimage_hash" in result.verified_fields
+    assert "receipt.physical_completion_claim" in result.verified_fields
+
+
+def test_ros2_fixture_external_evidence_signature_is_valid():
+    fixture = _fixture()
+    evidence = fixture["audit_entry"]["external_execution_evidence"]
+    signature = evidence["signature"]
+    padding = 4 - (len(signature) % 4)
+    signature_bytes = base64.urlsafe_b64decode(
+        signature + ("=" * padding if padding != 4 else "")
+    )
+    signing_input = json.dumps(
+        {k: v for k, v in evidence.items() if k != "signature"},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode()
+    public_key = Ed25519PublicKey.from_public_bytes(
+        bytes.fromhex(fixture["trusted_issuer_public_key_hex"])
+    )
+
+    public_key.verify(signature_bytes, signing_input)
+
+
+def test_action_ref_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload["action_ref"] = "sha256:" + "0" * 64
+    payload["receipt"]["action_ref"] = payload["action_ref"]
+    _rebind_payload_hash(fixture)
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+
+    assert not result.verified
+    assert any("action_ref" in failure for failure in result.failures)
+
+
+def test_ros2_goal_uuid_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload["receipt"]["goal_uuid"] = "00000000000000000000000000000000"
+    _rebind_payload_hash(fixture)
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+
+    assert not result.verified
+    assert any("receipt.goal_uuid" in failure for failure in result.failures)
+
+
+def test_ros2_goal_preimage_hash_mismatch_fails():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload["receipt"]["goal_preimage_hash"] = "sha256:" + "0" * 64
+    _rebind_payload_hash(fixture)
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+
+    assert not result.verified
+    assert any("receipt.goal_preimage_hash" in failure for failure in result.failures)
+
+
+def test_missing_receipt_is_absent_unless_policy_requires_it():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload.pop("receipt")
+    _rebind_payload_hash(fixture)
+
+    optional_result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+    required_result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+        require_receipt=True,
+    )
+
+    assert optional_result.verified, optional_result.failures
+    assert optional_result.receipt_state == ReceiptState.ABSENT
+    assert not required_result.verified
+    assert required_result.receipt_state == ReceiptState.ABSENT
+    assert any("receipt is required" in failure for failure in required_result.failures)
+
+
+def test_physical_completion_claim_fails_closed():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload["receipt"]["physical_completion_claim"] = "completed"
+    _rebind_payload_hash(fixture)
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+
+    assert not result.verified
+    assert any("physical completion" in failure for failure in result.failures)
+
+
+def test_gateway_self_report_is_verified_but_warned():
+    fixture = copy.deepcopy(_fixture())
+    payload = fixture["detached_payload"]
+    payload["receipt"]["issuer_independence"] = "gateway_self_report"
+    _rebind_payload_hash(fixture)
+
+    result = verify_embodied_action_evidence(
+        fixture["audit_entry"],
+        payload,
+        fixture["trace_claim"],
+    )
+
+    assert result.verified, result.failures
+    assert any("self-report" in warning for warning in result.warnings)


### PR DESCRIPTION
## Summary

Refs #337. Follows #339.

Adds the first profile-aware verifier helper and ROS 2 action fixture for the embodied action evidence profile.

What changed:
- added `verify_embodied_action_evidence()` for detached `cmcp.embodied_action_evidence.v0` payload checks;
- added helper APIs for canonical payload hashing and `action_ref` recomputation;
- added a ROS 2 Kilted `rclpy` Fibonacci action fixture with matching goal UUID, matching goal preimage hash, terminal `aborted` outcome, and `physical_completion_claim: none`;
- added negative verifier coverage for mismatched `action_ref`, mismatched ROS goal UUID, mismatched goal preimage hash, missing receipt under a required-receipt policy, unsupported physical-completion claims, and same-party gateway self-report warnings;
- documented the helper in the verification-library spec and linked the ROS 2 fixture from the embodied-action evidence profile.

## Scope and non-goals

This PR keeps ROS 2 as a static fixture. It does not add a live ROS dependency to CI.

The fixture is intentionally scoped to evidence binding. It does not claim physical completion, controller honesty, functional safety, cross-RMW stability, or arbitrary ROS interface compatibility.

## Validation

- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/unit/ -q`
- `uv run --extra dev --with-requirements requirements-docs.txt mkdocs build --strict`
- `git diff --check --cached`
- `uv run --extra dev mypy src/cmcp_verify/embodied_action.py`
