### PR TITLE
docs: persist custom domain via docs/CNAME (fix cmcp.agentrust-io.com 404)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cmcp.agentrust-io.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+cmcp.agentrust-io.com


### PR DESCRIPTION
## What
- Adds `docs/CNAME` containing `cmcp.agentrust-io.com`.
- Removes the now-redundant repo-root `CNAME`.

## Why
`cmcp.agentrust-io.com` was returning GitHub Pages 404 ("There isn't a GitHub Pages site here"). cmcp was the only project missing its Pages custom domain; ca2a / manifest / trace all have theirs set.

Root cause: `mkdocs gh-deploy --force --clean` (in `.github/workflows/docs.yml`) publishes only files under `docs/`. The custom domain value lived solely in the repo-root `CNAME`, which mkdocs does not copy, so a clean deploy dropped the CNAME from `gh-pages` and GitHub unset the custom domain.

## Fix
- Immediate (already applied out-of-band): set the Pages custom domain back to `cmcp.agentrust-io.com` via the Pages API. Site is live again (HTTP 200, HTTPS cert approved).
- Durable (this PR): put `CNAME` inside `docs/` so every `mkdocs gh-deploy` republishes it and the domain cannot be wiped again, matching the sibling docs sites. The repo-root `CNAME` is removed since the Pages source is the `gh-pages` branch and mkdocs never used it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)