### PR TITLE
docs: add cross-project top navigation (supernav)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,3 +193,6 @@ nav:
       - Governance: https://github.com/agentrust-io/cmcp/blob/main/GOVERNANCE.md
       - Roadmap: https://github.com/agentrust-io/cmcp/blob/main/ROADMAP.md
 
+extra_javascript:
+  # Shared cross-project top navigation (TRACE / Manifest / cMCP / cA2A / ...)
+  - https://agentrust-io.com/supernav.js


### PR DESCRIPTION
Adds the shared cross-project top nav to the cmcp docs site by loading `https://agentrust-io.com/supernav.js` via `extra_javascript`.

## Why
Readers could not switch between the project docs sites (TRACE / Manifest / cMCP / cA2A). `agent-manifest` already loads this shared supernav; `cmcp`, `ca2a`, and `trace-spec` were missing it. This brings them in line.

The script is centrally hosted on the org site and already handles Material for MkDocs instant navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)