### PR TITLE
fix(cli): force UTF-8 CLI output so status glyphs do not crash on Windows (#396)

### DIFF
--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import sys
 from typing import TYPE_CHECKING
 
@@ -69,8 +70,9 @@ def main() -> None:
     # encoding (e.g. Windows cp1252, which cannot encode the check/cross
     # marks and would otherwise raise UnicodeEncodeError). See #396.
     for _stream in (sys.stdout, sys.stderr):
-        with contextlib.suppress(AttributeError, ValueError):
-            _stream.reconfigure(encoding="utf-8", errors="replace")
+        if isinstance(_stream, io.TextIOWrapper):
+            with contextlib.suppress(ValueError):
+                _stream.reconfigure(encoding="utf-8", errors="replace")
 
 
 @main.command()

--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import click
@@ -63,6 +64,14 @@ def build_server(ctx: RuntimeContext) -> MCPServer:
 @click.version_option(__version__, prog_name="cmcp")
 def main() -> None:
     """cMCP Runtime: hardware-attested MCP runtime."""
+    # Ensure the CLI status glyphs print regardless of the ambient console
+    # encoding (e.g. Windows cp1252, which cannot encode the check/cross
+    # marks and would otherwise raise UnicodeEncodeError). See #396.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
 
 
 @main.command()

--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from typing import TYPE_CHECKING
 
@@ -68,10 +69,8 @@ def main() -> None:
     # encoding (e.g. Windows cp1252, which cannot encode the check/cross
     # marks and would otherwise raise UnicodeEncodeError). See #396.
     for _stream in (sys.stdout, sys.stderr):
-        try:
+        with contextlib.suppress(AttributeError, ValueError):
             _stream.reconfigure(encoding="utf-8", errors="replace")
-        except (AttributeError, ValueError):
-            pass
 
 
 @main.command()


### PR DESCRIPTION
## What
Reconfigures the CLI's `stdout`/`stderr` to UTF-8 at the `main` group entry point.

## Why
The CLI prints check/cross status glyphs. Under a non-UTF-8 console (Windows cp1252) writing them raises `UnicodeEncodeError`, so `cmcp validate-config` / `start` crash before doing anything (only `PYTHONUTF8=1` works around it today). Surfaced while verifying the `agentrust-io/examples` quickstarts on Windows.

The fix is guarded (`AttributeError`/`ValueError`) for streams that cannot be reconfigured, and keeps the nicer glyphs where the terminal supports them.

Fixes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)