### PR TITLE
docs(tee): clarify in-tree appraisal is aTLS fallback, not primary gate

### DIFF
--- a/src/cmcp_runtime/tee/nras.py
+++ b/src/cmcp_runtime/tee/nras.py
@@ -183,6 +183,12 @@ def try_appraise(report: AttestationReport) -> AppraisalResult | None:
     get_attestation_report() succeeds. It must never raise -- a missing or
     failed appraisal is non-fatal per issue #125.
 
+    Layering: this in-tree appraisal is the standalone fallback for deployments
+    with no attested-TLS (aTLS) peer. When cMCP is composed with a platform that
+    performs attestation in the aTLS handshake, the platform verdict is
+    authoritative and this path stands down -- it is a fallback, not the primary
+    gate. Do not wire it up as the enforcing check.
+
     Phase 2 / v0.2 -- implements issue #125.
     """
     api_key = os.environ.get(_ENV_API_KEY)


### PR DESCRIPTION
@
## What

Two-line addition to the `try_appraise` docstring in `tee/nras.py` recording the layering intent for NRAS post-attestation appraisal.

## Why

When cMCP is composed with a platform that performs attestation in the aTLS handshake, the platform verdict is authoritative and the in-tree appraisal path stands down. It stays as the standalone fallback for deployments with no aTLS peer. Nothing in the repo said this, so the note stops anyone from later treating the opt-in/non-fatal NRAS path as the enforcing gate.

## Scope

- Docstring only. No behavior change.
- No enforcement/gating change (still non-fatal, still opt-in via `CMCP_NRAS_API_KEY`).
- No refactor to a platform-verdict interface -- that is the aTLS work, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@