### PR TITLE
docs: disallow /cdn-cgi/ in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,6 +3,8 @@
 
 User-agent: *
 Allow: /
+# Cloudflare email-obfuscation endpoint: not real pages, only 404s to crawlers
+Disallow: /cdn-cgi/
 
 # AI and answer-engine crawlers (explicitly welcomed)
 User-agent: GPTBot


### PR DESCRIPTION
## What

Add `Disallow: /cdn-cgi/` to `robots.txt`.

## Why

Search Console reports `https://cmcp.agentrust-io.com/cdn-cgi/l/email-protection` under **Not found (404)**. That path is Cloudflare's Scrape Shield "Email Address Obfuscation" endpoint, auto-generated when Cloudflare rewrites email addresses found in the docs. Googlebot follows the link and 404s on it.

The docs contain only `@example.com` placeholder addresses (quickstart, cedar-policy, deploy guides), so there is nothing to protect and the endpoint is not a real page. Blocking `/cdn-cgi/` stops the crawl noise.

Optional follow-up (dashboard, not code): disable "Email Address Obfuscation" in the Cloudflare zone's Scrape Shield.

## Scope

One line in `robots.txt`. No site content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)