### PR TITLE
docs: cmcp verify in CLI table, correct autodetect order, policies/ naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ Agent -> cMCP Runtime -> Cedar Policy Engine (TEE) -> Tool
 | `gpu-cc` _(v0.2)_ | NVIDIA H100/H200/Blackwell (CC mode) | High | NVIDIA Remote Attestation Service (NRAS) |
 | `opaque` _(opt-in)_ | OPAQUE Confidential Runtime | n/a _(not yet implemented)_ | Placeholder: excluded from auto-detect; selecting it explicitly raises a not-implemented error |
 
-Provider auto-detect probe order: `tpm -> sev-snp -> tdx` — the first provider whose `detect()` succeeds is selected. `opaque` is a not-yet-implemented placeholder: it is excluded from auto-detect, and selecting it explicitly raises `ATTESTATION_PROVIDER_NOT_IMPLEMENTED` rather than falling through silently. If no hardware provider is detected, the gateway starts only under `CMCP_DEV_MODE=1` (a non-attested software-only fallback) and otherwise refuses to start.
+Provider auto-detect probe order: `azure-cvm -> tpm -> sev-snp -> tdx` — the first provider whose `detect()` succeeds is selected. `opaque` is a not-yet-implemented placeholder: it is excluded from auto-detect, and selecting it explicitly raises `ATTESTATION_PROVIDER_NOT_IMPLEMENTED` rather than falling through silently. If no hardware provider is detected, the gateway starts only under `CMCP_DEV_MODE=1` (a non-attested software-only fallback) and otherwise refuses to start.
 
 ```python
 from cmcp_runtime.config import TEEProvider
 
 # Auto-detect (default)
-# attestation.provider: auto  ->  tpm -> sev-snp -> tdx
+# attestation.provider: auto  ->  azure-cvm -> tpm -> sev-snp -> tdx
 # (software-only is used only under CMCP_DEV_MODE=1)
 
 # Explicit hardware selection
@@ -159,7 +159,7 @@ attestation:
   staleness_policy: fail_closed     # fail_closed | warn_only
   expected_measurement: ~           # pin a specific PCR/measurement (optional)
 
-policy_bundle_path: policy/         # directory containing .cedar files and manifest.json
+policy_bundle_path: policies/       # directory containing .cedar files and manifest.json
 catalog_path: catalog.json          # approved tool catalog
 
 listen_addr: "0.0.0.0:8443"
@@ -184,6 +184,7 @@ Environment variables:
 | `cmcp start` | `--config PATH` (required) | Start the gateway |
 | `cmcp validate-config` | `--config PATH` (required) | Validate `cmcp-config.yaml` without starting |
 | `cmcp validate-bundle` | `--bundle-path PATH` (required), `--expected-hash sha256:<hex>` (required) | Verify a Cedar bundle hash before deployment |
+| `cmcp verify` | `CLAIM_FILE` (required); `--policy-hash`, `--catalog-hash`, `--max-age`, `--trusted-key`, `--audit-bundle`, `--agent-manifest`, `--agent-manifest-trust-anchor` | Verify a signed TRACE Claim (signature, schema, freshness, audit chain, and pinned hashes) |
 
 ---
 
@@ -269,7 +270,7 @@ A TRACE Claim (a `GatewayClaim`) is a signed, hardware-attested artifact produce
 
 ### Which TEE providers are supported?
 
-TPM 2.0 / vTPM, AMD SEV-SNP, and Intel TDX, with NVIDIA GPU confidential computing planned for v0.2 and OPAQUE Confidential Runtime available as explicit opt-in. Auto-detection order is SEV-SNP, then TDX, then TPM, then software.
+TPM 2.0 / vTPM, AMD SEV-SNP, and Intel TDX, with NVIDIA GPU confidential computing planned for v0.2 and OPAQUE Confidential Runtime available as explicit opt-in. Auto-detection order is Azure confidential VM, then TPM 2.0 / vTPM, then AMD SEV-SNP, then Intel TDX; the software-only provider is used only under CMCP_DEV_MODE=1.
 
 ### What license is cMCP under?
 
@@ -303,7 +304,7 @@ MIT.
     {
       "@type": "Question",
       "name": "Which TEE providers does cMCP support?",
-      "acceptedAnswer": { "@type": "Answer", "text": "TPM 2.0 / vTPM, AMD SEV-SNP, and Intel TDX, with NVIDIA GPU confidential computing planned for v0.2 and OPAQUE Confidential Runtime available as explicit opt-in. Auto-detection order is SEV-SNP, then TDX, then TPM, then software." }
+      "acceptedAnswer": { "@type": "Answer", "text": "TPM 2.0 / vTPM, AMD SEV-SNP, and Intel TDX, with NVIDIA GPU confidential computing planned for v0.2 and OPAQUE Confidential Runtime available as explicit opt-in. Auto-detection order is Azure confidential VM, then TPM 2.0 / vTPM, then AMD SEV-SNP, then Intel TDX; the software-only provider is used only under CMCP_DEV_MODE=1." }
     },
     {
       "@type": "Question",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ agent_manifest:
 # Path to the directory containing .cedar policy files and manifest.json.
 # Must not contain '..' components. Relative paths are resolved from the
 # working directory at startup.
-policy_bundle_path: policy/
+policy_bundle_path: policies/
 
 # Path to the JSON tool catalog file.
 # Must not contain '..' components.
@@ -96,7 +96,7 @@ All fields are optional as a group. If `path` is set, `trust_anchor_path` must a
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `policy_bundle_path` | string | `policy/` | Path to the Cedar policy bundle directory. Must contain `.cedar` files and a `manifest.json`. Path traversal (`..` components) is rejected. |
+| `policy_bundle_path` | string | `policies/` | Path to the Cedar policy bundle directory. Must contain `.cedar` files and a `manifest.json`. Path traversal (`..` components) is rejected. |
 | `catalog_path` | string | `catalog.json` | Path to the JSON tool catalog. Path traversal (`..` components) is rejected. |
 | `listen_addr` | string | `0.0.0.0:8443` | Address and port the gateway binds to. |
 | `max_response_size_bytes` | integer | `2097152` | Maximum tool response size in bytes (2MB). Must be a positive integer. Responses exceeding this limit are rejected before inspection. |
@@ -132,7 +132,7 @@ Environment variables control secrets and mode flags that must not appear in con
 attestation:
   provider: auto
   enforcement_mode: enforcing
-policy_bundle_path: policy/
+policy_bundle_path: policies/
 catalog_path: catalog.json
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@
 # cmcp-config.yaml - annotated full example
 
 attestation:
-  # TEE provider. auto detects in order: tpm -> sev-snp -> tdx.
+  # TEE provider. auto detects in order: azure-cvm -> tpm -> sev-snp -> tdx.
   # opaque requires explicit opt-in via OPAQUE_ATTESTATION_URL env var.
   # Use software-only only with CMCP_DEV_MODE=1.
   provider: auto
@@ -76,7 +76,7 @@ policy_reload_interval_seconds: 0
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider` | string | `auto` | TEE provider. Valid values: `auto`, `tpm`, `sev-snp`, `tdx`, `opaque`, `software-only`. `auto` detects in order: tpm then sev-snp then tdx. `opaque` requires `OPAQUE_ATTESTATION_URL` to be set. `software-only` requires `CMCP_DEV_MODE=1`. |
+| `provider` | string | `auto` | TEE provider. Valid values: `auto`, `tpm`, `sev-snp`, `tdx`, `opaque`, `software-only`. `auto` detects in order: azure-cvm, then tpm, then sev-snp, then tdx. `opaque` requires `OPAQUE_ATTESTATION_URL` to be set. `software-only` requires `CMCP_DEV_MODE=1`. |
 | `enforcement_mode` | string | `enforcing` | Policy enforcement mode. Valid values: `enforcing`, `advisory`, `silent`. |
 | `validity_seconds` | integer | `86400` | Attestation report validity period in seconds. Must be a positive integer. At expiry, behavior is controlled by `staleness_policy`. |
 | `staleness_policy` | string | `fail_closed` | Action when attestation validity expires. Valid values: `fail_closed` (terminate sessions), `warn_only` (allow sessions, mark claims as stale). |


### PR DESCRIPTION
Documentation fixes from the release-party QA pass. Independent of the code/examples PRs.

- **`cmcp verify` in the CLI table**: the README CLI reference omitted `cmcp verify`, the command the quickstart uses to check a signed claim. Added with its flags.
- **Autodetect order**: the README body said `tpm -> sev-snp -> tdx` and the FAQ (both prose and the JSON-LD block) said `SEV-SNP -> TDX -> TPM`. The code does `azure-cvm -> tpm -> sev-snp -> tdx`. Corrected all three to match, with software-only noted as dev-mode only.
- **`policies/` naming**: the README config reference and `docs/configuration.md` said `policy/` while the examples and quickstart use `policies/`. Normalized to `policies/` so docs, examples, and the code default all agree.

Pure documentation. No code or example changes here (those are in the paired PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)