### PR TITLE
docs: stop claiming hardware attestation unconditionally; move identifiers off agentrust.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved every `agentrust.io` identifier to `agentrust-io.com`: the JSON Schema `$id` values for `trace-claim`, `audit-entry`, and `catalog-entry`, the `@context` URL in test fixtures, and the maintainer email. `agentrust.io` is not ours and resolves to parked AWS addresses, so these identifiers pointed at a domain we do not control. They never resolved, so nothing that worked stops working. The `tag:agentrust.io,2026:trace-v0.1` EAT profile identifier is deliberately unchanged; it is a cross-repo identifier inside signed payloads and needs a transition decision, not a rename.
+
+### Fixed
+
+- README no longer claims hardware attestation unconditionally. "Each session produces a signed, hardware-attested TRACE Claim" contradicted the TL;DR two paragraphs below it, which tells you to `pip install cmcp-runtime` and start in software mode with no hardware. It now reads "hardware-attested when the gateway runs in a TEE and signed-only in software mode", which is what the runtime actually does.
+
 ### Fixed
 
 - Raised the `agent-manifest` floor to `>=0.6.1` and made an unappraisable manifest fail closed with a diagnostic message. `verify_agent_manifest_binding` runs the SDK verifier over a peer-supplied manifest, and before 0.6.1 a manifest declaring `ML-DSA-65` or `hybrid-Ed25519-ML-DSA-65` crashed the SDK with an uncaught `RuntimeError` on any install without the optional `[pq]` extra, so this path answered a crash instead of a rejection. The SDK now returns `UNVERIFIABLE`, which cMCP already rejects; the `UNVERIFIABLE` message now distinguishes "could not be verified" (missing trusted key or unavailable algorithm) from "verification failed" (a bad signature) and surfaces the verifier's own reason, because those call for different operator responses.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > **Developer Preview** - launched at the Confidential Computing Summit, June 23 2026. May have breaking changes before v1.0. See [STATUS.md](STATUS.md) for exactly what ships today versus what is on the roadmap.
 
-**cMCP (Confidential MCP Runtime) is the secure, confidential way to run MCP: an open-source gateway that enforces MCP tool-call policy inside a hardware Trusted Execution Environment (TEE).** Every tool call is intercepted, evaluated against a Cedar policy bundle, and enforced where the process it governs cannot reach it. Each session produces a signed, hardware-attested TRACE Claim that a verifier checks without trusting the operator. If you are looking for a secure version of MCP, this is the AgenTrust runtime for it.
+**cMCP (Confidential MCP Runtime) is the secure, confidential way to run MCP: an open-source gateway that enforces MCP tool-call policy inside a hardware Trusted Execution Environment (TEE).** Every tool call is intercepted, evaluated against a Cedar policy bundle, and enforced where the process it governs cannot reach it. Each session produces a signed TRACE Claim that a verifier checks without trusting the operator, hardware-attested when the gateway runs in a TEE and signed-only in software mode. If you are looking for a secure version of MCP, this is the AgenTrust runtime for it.
 
 > **TL;DR** - Point your agent at the cMCP Gateway. It evaluates every tool call against a Cedar policy inside a TEE, blocks or redacts what the policy denies, and emits a tamper-evident TRACE Claim as proof. Run `pip install cmcp-runtime` and start in software mode with no hardware required.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hardware-attested MCP runtime, TEE-enforced policy and TRACE Clai
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
-    { name = "AgenTrust Contributors", email = "oss@agentrust.io" },
+    { name = "AgenTrust Contributors", email = "oss@agentrust-io.com" },
 ]
 keywords = ["mcp", "tee", "attestation", "security", "ai-agents", "cedar"]
 classifiers = [

--- a/schemas/audit-entry.schema.json
+++ b/schemas/audit-entry.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://cmcp.agentrust.io/schemas/audit-entry.schema.json",
+  "$id": "https://cmcp.agentrust-io.com/schemas/audit-entry.schema.json",
   "title": "cMCP Audit Chain Entry",
   "description": "A single entry in the append-only audit chain maintained inside the cMCP Gateway TEE.",
   "type": "object",

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://cmcp.agentrust.io/schemas/catalog-entry.schema.json",
+  "$id": "https://cmcp.agentrust-io.com/schemas/catalog-entry.schema.json",
   "title": "cMCP Catalog Entry",
   "description": "A single entry in the cMCP Gateway approved tool catalog, representing one tool from one MCP server.",
   "type": "object",

--- a/schemas/trace-claim.schema.json
+++ b/schemas/trace-claim.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cmcp.agentrust.io/schemas/trace-claim.schema.json",
+  "$id": "https://cmcp.agentrust-io.com/schemas/trace-claim.schema.json",
   "title": "cMCP GatewayClaim",
   "description": "TRACE profile envelope emitted by the cMCP Gateway TEE at session close. The 'trace' sub-object contains canonical TRACE v0.1 fields; 'gateway' contains cmcp-specific addenda.",
   "type": "object",

--- a/tests/unit/test_agent_manifest.py
+++ b/tests/unit/test_agent_manifest.py
@@ -46,7 +46,7 @@ def _signed_manifest(
     expires_at: str = "2099-09-10T00:00:00Z",
 ) -> dict:
     manifest = {
-        "@context": "https://agentmanifest.agentrust.io/v0.1/context.json",
+        "@context": "https://agentmanifest.agentrust-io.com/v0.1/context.json",
         "@type": "AgentManifest",
         "manifest_id": "0197739a-8c00-7000-8000-000000000001",
         "agent_id": agent_id,

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -62,7 +62,7 @@ def _write_agent_manifest_files(
     pub = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
     key_id = hashlib.sha256(pub).hexdigest()
     manifest = {
-        "@context": "https://agentmanifest.agentrust.io/v0.1/context.json",
+        "@context": "https://agentmanifest.agentrust-io.com/v0.1/context.json",
         "@type": "AgentManifest",
         "manifest_id": "0197739a-8c00-7000-8000-000000000001",
         "agent_id": AGENT_ID,

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -126,7 +126,7 @@ def _b64url(data: bytes) -> str:
 
 def _signed_manifest(priv: Ed25519PrivateKey, key_id: str) -> dict:
     manifest = {
-        "@context": "https://agentmanifest.agentrust.io/v0.1/context.json",
+        "@context": "https://agentmanifest.agentrust-io.com/v0.1/context.json",
         "@type": "AgentManifest",
         "manifest_id": MANIFEST_ID,
         "agent_id": AGENT_ID,


### PR DESCRIPTION
Two accuracy fixes.

## 1. The README contradicted itself

Line 29 said, unconditionally:

> Each session produces a signed, **hardware-attested** TRACE Claim that a verifier checks without trusting the operator.

Two paragraphs below, the TL;DR says:

> Run `pip install cmcp-runtime` and start in **software mode with no hardware required**.

Both cannot be true. In software mode the claim is signed but not hardware-attested. Now reads "hardware-attested when the gateway runs in a TEE and signed-only in software mode", which is what the runtime does.

This is a positioning call as much as a wording one: the honest version is still a strong claim, and it is the one that survives someone running the quickstart and inspecting what they got.

## 2. Identifiers moved off `agentrust.io`

`agentrust.io` is not ours; it resolves to parked AWS addresses. These pointed at it:

- JSON Schema `$id` for `trace-claim`, `audit-entry`, `catalog-entry`
- `@context` in two test fixtures
- the maintainer email in `pyproject.toml`

All now `agentrust-io.com`. They never resolved, so nothing that worked stops working, but publishing schema `$id`s on a domain a third party could register is not a position to hold.

**Deliberately unchanged:** `tag:agentrust.io,2026:trace-v0.1`. That EAT profile identifier appears in 125 files across the org and sits inside signed payloads. An RFC 4151 tag URI is only valid if the minter controlled the domain on the stated date, so it is wrong rather than misspelled, but changing it is a cross-repo transition with a verifier-compatibility question attached. Raising separately.

## Note on the test environment

The suite initially failed on `test_post_quantum_manifest_without_pq_extra_fails_closed_cleanly`. Not a regression: this clone's venv had agent-manifest **0.5.0** installed while `pyproject.toml` requires `>=0.6.1`, so it was reproducing the exact `RuntimeError` that 0.6.1 fixed. Upgrading the venv to 0.7.0 resolved it. CI installs from `pyproject.toml` so it was never affected, but anyone with a stale local env will hit it.

893 passed, 8 skipped.