### PR TITLE
feat(trace): emit the TRACE v0.2 profile URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved every `agentrust.io` identifier to `agentrust-io.com`: the JSON Schema `$id` values for `trace-claim`, `audit-entry`, and `catalog-entry`, the `@context` URL in test fixtures, and the maintainer email. `agentrust.io` is not ours and resolves to parked AWS addresses, so these identifiers pointed at a domain we do not control. They never resolved, so nothing that worked stops working. The `tag:agentrust.io,2026:trace-v0.1` EAT profile identifier is deliberately unchanged; it is a cross-repo identifier inside signed payloads and needs a transition decision, not a rename.
+- **BREAKING: TRACE Claims now carry the v0.2 profile** `tag:agentrust-io.com,2026:trace-v0.2`, and `agentrust-trace` is pinned to `>=0.5`. The v0.1 URI named `agentrust.io`, a domain this project never controlled, which RFC 4151 does not permit for a tag URI (agentrust-io/trace-spec#107). A verifier on the v0.2 suite rejects a v0.1 claim, so producers and verifiers move together. Nothing else about the claim format changed.
+
+### Changed
+
+- Moved every `agentrust.io` identifier to `agentrust-io.com`: the JSON Schema `$id` values for `trace-claim`, `audit-entry`, and `catalog-entry`, the `@context` URL in test fixtures, and the maintainer email. `agentrust.io` is not ours and resolves to parked AWS addresses, so these identifiers pointed at a domain we do not control. They never resolved, so nothing that worked stops working. The `tag:agentrust-io.com,2026:trace-v0.2` EAT profile identifier is deliberately unchanged; it is a cross-repo identifier inside signed payloads and needs a transition decision, not a rename.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A `GatewayClaim` is the unit of proof handed to an auditor, regulator, or downst
 
 | Field | Description |
 |---|---|
-| `trace.eat_profile` | EAT profile URI: `tag:agentrust.io,2026:trace-v0.1` |
+| `trace.eat_profile` | EAT profile URI: `tag:agentrust-io.com,2026:trace-v0.2` |
 | `trace.runtime` | TEE platform and hardware measurement recorded at enclave boot |
 | `trace.policy.bundle_hash` | SHA-256 of the Cedar bundle loaded at startup; changing any policy file changes this value |
 | `trace.cnf.jwk` | Ed25519 public key bound to the TEE signing key |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -130,14 +130,14 @@ Network position: sits between agent host and MCP servers. The gateway is the on
 The unit of proof handed to an auditor, produced per session (or per call, configurable).
 The normative schema is `schemas/trace-claim.schema.json`,
 and a full worked example is in [the quickstart](quickstart.md). The envelope is a
-`GatewayClaim`: canonical TRACE v0.1 fields live under `trace`, cMCP-specific addenda live
+`GatewayClaim`: canonical TRACE v0.2 fields live under `trace`, cMCP-specific addenda live
 under `gateway`, and `signature` is detached (computed over every other field).
 
 ```json
 {
   "cmcp_version": "1.0",
   "trace": {
-    "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
     "iat": 1730000000,
     "subject": "spiffe://cmcp.gateway/tee/<key-prefix>",
     "runtime": {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -33,7 +33,7 @@ The key difference:
 | Can the operator forge it? | Yes | No: signing key never leaves the TEE |
 | Who can verify it? | Anyone with read access | Anyone with the public key (no trust in operator) |
 
-A TRACE Claim is a [TRACE Trust Record](https://trace.agentrust-io.com) with a `GatewayClaim` envelope. The envelope adds the session summary and audit chain. The inner trust record follows the TRACE v0.1 spec.
+A TRACE Claim is a [TRACE Trust Record](https://trace.agentrust-io.com) with a `GatewayClaim` envelope. The envelope adds the session summary and audit chain. The inner trust record follows the TRACE v0.2 spec.
 
 ### What a TRACE Claim asserts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "agentrust-trace>=0.4",
+    "agentrust-trace>=0.5",
     # 0.6.1 is the floor, not merely a compatible version: verify_manifest()
     # is called on a peer-supplied manifest below, and before 0.6.1 a manifest
     # declaring ML-DSA-65 or hybrid crashed the verifier with an uncaught

--- a/schemas/trace-claim.schema.json
+++ b/schemas/trace-claim.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cmcp.agentrust-io.com/schemas/trace-claim.schema.json",
   "title": "cMCP GatewayClaim",
-  "description": "TRACE profile envelope emitted by the cMCP Gateway TEE at session close. The 'trace' sub-object contains canonical TRACE v0.1 fields; 'gateway' contains cmcp-specific addenda.",
+  "description": "TRACE profile envelope emitted by the cMCP Gateway TEE at session close. The 'trace' sub-object contains canonical TRACE v0.2 fields; 'gateway' contains cmcp-specific addenda.",
   "type": "object",
   "additionalProperties": false,
   "required": ["cmcp_version", "trace", "gateway", "signature"],
@@ -16,11 +16,11 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["eat_profile", "iat", "subject", "runtime", "policy", "data_class", "cnf"],
-      "description": "Canonical TRACE v0.1 fields for this gateway session.",
+      "description": "Canonical TRACE v0.2 fields for this gateway session.",
       "properties": {
         "eat_profile": {
           "type": "string",
-          "const": "tag:agentrust.io,2026:trace-v0.1"
+          "const": "tag:agentrust-io.com,2026:trace-v0.2"
         },
         "iat": {
           "type": "integer",

--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -184,7 +184,7 @@ class GatewayTrace(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    eat_profile: Literal["tag:agentrust.io,2026:trace-v0.1"]
+    eat_profile: Literal["tag:agentrust-io.com,2026:trace-v0.2"]
     iat: Annotated[int, Field(ge=1700000000)]
     subject: Annotated[str, Field(pattern=r"^spiffe://")]
     runtime: RuntimeInfo
@@ -376,7 +376,7 @@ def generate_trace_claim(
     )
 
     trace = GatewayTrace(
-        eat_profile="tag:agentrust.io,2026:trace-v0.1",
+        eat_profile="tag:agentrust-io.com,2026:trace-v0.2",
         iat=int(datetime.now(tz=UTC).timestamp()),
         subject=_build_subject(signing_key),
         runtime=_build_runtime(attestation_report),


### PR DESCRIPTION
Downstream of agentrust-io/trace-spec#107 and agentrust-io/trace-tests#44.

TRACE Claims now carry `tag:agentrust-io.com,2026:trace-v0.2`, and `agentrust-trace` moves to `>=0.5`.

The v0.1 URI named `agentrust.io`, a domain this project never controlled. RFC 4151 permits a tag URI only where the minting authority controlled the named domain on the stated date, so it was invalid rather than misspelled.

The conformance suite cut over rather than dual-accepting, so a v0.2 verifier rejects a v0.1 claim. Producers have to move with it, which is what this does. Nothing else about the claim format changed.

Also moved the schema `$id` host and the remaining doc links off `agentrust.io`.

## Verification

893 passed, 8 skipped, against `agentrust-trace` 0.5.0 installed from PyPI. I checked for JSON fixtures carrying `eat_profile` with an embedded `signature` first, since changing the profile would invalidate a signature over the record: there are none in this repo.