### PR TITLE
fix: refuse to issue trace claim when hardware TEE session report is missing

### DIFF
--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -26,7 +26,7 @@ from cmcp_runtime.audit.trace_claim import (
     generate_trace_claim,
 )
 from cmcp_runtime.config import KillSwitchConfig
-from cmcp_runtime.errors import KillSwitchTripped
+from cmcp_runtime.errors import KillSwitchTripped, TeeFault
 from cmcp_runtime.kill_switch import KillSwitchEvaluator
 from cmcp_runtime.session.call_log import CallLog, SessionCallLog
 from cmcp_runtime.session.state import SessionState
@@ -158,7 +158,23 @@ class SessionManager:
         # chain's root.  Fall back to the shared startup report only if the
         # per-session TEE call failed at create_session() time (a warning was
         # already emitted there); in that case the chain root is not bound into
-        # report_data and a strict verifier will reject the claim.
+        # report_data.
+        #
+        # #372: on a hardware platform that fallback report carries no
+        # chain-root commitment, and the verifier fail-closes on it anyway - so
+        # issuing the claim only misleads a caller who does not run the
+        # verifier's stricter check.  Refuse to issue it here instead.  In
+        # software-only (dev) mode the per-session binding is best-effort by
+        # design (see create_session()'s docstring), so the fallback is not a
+        # regression there and is left to succeed as before.
+        if chain.session_report is None and ctx.attestation_report.provider != "software-only":
+            raise TeeFault(
+                f"Refusing to issue a TRACE Claim for session {session_id}: the "
+                "per-session TEE attestation call failed, so the claim would fall "
+                "back to the startup report, which carries no chain-root "
+                "commitment. A hardware-attested claim must not be issued unbound.",
+                detail=session_id,
+            )
         report = chain.session_report or ctx.attestation_report
 
         # Convert AttestationReport (datetime) to AttestationReportInfo (str).

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -13,6 +13,7 @@ import pytest
 from cmcp_runtime.agent_manifest import AgentManifestBinding
 from cmcp_runtime.audit.chain import AuditChain
 from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.errors import TeeFault
 from cmcp_runtime.session.manager import SessionManager
 from cmcp_runtime.session.state import SessionState
 
@@ -349,8 +350,10 @@ def test_close_session_uses_per_session_report_committing_chain_root() -> None:
 
 
 def test_close_session_falls_back_to_startup_report_when_tee_fails() -> None:
-    """If the per-session TEE call fails, close_session() falls back to the shared
-    startup report (no chain-root commitment) and the chain still anchors locally.
+    """In software-only (dev) mode, a per-session TEE failure falls back to the
+    shared startup report (no chain-root commitment) and the chain still anchors
+    locally. The dev-mode binding is best-effort by design, so this is not a
+    regression and close_session() must still succeed (see #372).
     """
     ctx = _make_ctx()
     ctx.tee_provider.get_attestation_report.side_effect = RuntimeError("TEE down")
@@ -363,3 +366,21 @@ def test_close_session_falls_back_to_startup_report_when_tee_fails() -> None:
     claim = mgr.close_session(state.session_id, state, chain)
     # Falls back to the startup (software-only) report.
     assert claim["trace"]["runtime"]["platform"] == "software-only"
+
+
+def test_close_session_fails_closed_on_hardware_platform_when_tee_fails() -> None:
+    """#372: on a hardware platform, a per-session TEE failure must NOT fall
+    through to issuing a claim off the startup report. That report carries no
+    chain-root commitment, so the runtime must refuse to issue it instead of
+    handing the caller a claim the verifier will reject anyway.
+    """
+    ctx = _make_ctx()
+    ctx.attestation_report.provider = "sev-snp"
+    ctx.tee_provider.get_attestation_report.side_effect = RuntimeError("TEE down")
+
+    mgr = SessionManager(ctx)
+    state, chain = mgr.create_session()
+    assert chain.session_report is None
+
+    with pytest.raises(TeeFault, match="chain-root commitment"):
+        mgr.close_session(state.session_id, state, chain)


### PR DESCRIPTION
## Summary

Closes #372.

When the per session TEE attestation call failed inside create_session, close_session still fell back to the shared startup report and signed a claim off of it. That startup report carries no chain root commitment, so a strict verifier already rejects it, but the runtime handed the claim out anyway as if nothing was wrong.

This change makes close_session raise TeeFault instead of issuing that unbound claim, but only when the platform is a real hardware TEE. In software only dev mode the fallback still succeeds, since that binding was already best effort there and this is not a regression for that path.

## Changes

- src/cmcp_runtime/session/manager.py: close_session now checks whether the per session report is missing and the startup report provider is not software only, and raises TeeFault before building the claim.
- tests/unit/test_session_manager.py: added a test asserting TeeFault is raised on a hardware platform, and clarified the existing dev mode fallback test.

## Test plan

- [x] pytest tests/unit/ passes locally, 837 passed, 7 skipped
- [x] ruff check src/ tests/ clean
- [x] mypy on the changed module clean
- [x] bandit -r src/ clean