### PR TITLE
fix(tee): correct PCR hex parsing that corrupted the measurement

### DIFF
--- a/src/cmcp_runtime/tee/tpm.py
+++ b/src/cmcp_runtime/tee/tpm.py
@@ -110,7 +110,12 @@ class TPMProvider(TEEProvider):
                     pcrselect=pcr_sel_quote,
                 )
                 raw_evidence = bytes(quoted.attestationData)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "TPM quote unavailable (%s); the report will carry an unsigned "
+                    "PCR read as its only evidence.",
+                    exc,
+                )
                 raw_evidence = None
 
         effective_provider = (
@@ -194,15 +199,24 @@ def _parse_tpm2_pcrread_output(output: str) -> list[bytes]:
     Expected format (per PCR):
       sha256:
         0 : 0xABCD...
+
+    ``lstrip("0x")`` cannot be used to drop the prefix: it strips a character set,
+    so a value whose digits begin with 0 loses those digits as well.
     """
     pcr_values: list[bytes] = []
     for line in output.splitlines():
         line = line.strip()
         if ":" in line and line.split(":")[0].strip().isdigit():
             _, _, hex_val = line.partition(":")
-            hex_val = hex_val.strip().lstrip("0x").lstrip("0X")
+            hex_val = hex_val.strip()
+            if hex_val[:2].lower() == "0x":
+                hex_val = hex_val[2:]
+            if not hex_val:
+                raise RuntimeError(f"TPM PCR read returned an empty value: {line!r}")
             try:
-                pcr_values.append(bytes.fromhex(hex_val or "00"))
-            except ValueError:
-                continue
+                pcr_values.append(bytes.fromhex(hex_val))
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"TPM PCR read returned an unparseable value: {line!r}"
+                ) from exc
     return pcr_values

--- a/tests/unit/test_tpm_parser.py
+++ b/tests/unit/test_tpm_parser.py
@@ -1,0 +1,53 @@
+"""Unit tests for tpm2_pcrread output parsing."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from cmcp_runtime.tee.tpm import _parse_tpm2_pcrread_output
+
+# A realistic tpm2_pcrread block. PCR0 is all zeros (the common case for an unused
+# PCR) and PCR1 and PCR3 begin with a zero digit.
+PCRREAD_SAMPLE = """sha256:
+  0 : 0x0000000000000000000000000000000000000000000000000000000000000000
+  1 : 0x0AF7C1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E
+  2 : 0xB1F2E3D4C5A697887766554433221100FFEEDDCCBBAA99887766554433221100
+  3 : 0x00A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F
+  4 : 0xC3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2
+  5 : 0xD4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3
+  6 : 0xE5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4
+  7 : 0xF60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5
+"""
+
+EXPECTED_PCRS = [bytes.fromhex(m) for m in re.findall(r"0x([0-9A-Fa-f]{64})", PCRREAD_SAMPLE)]
+
+
+def test_parser_returns_every_pcr_in_order() -> None:
+    """Regression: stripping the 0x prefix with lstrip also removed leading zero
+    digits, which dropped PCRs and shifted every later value into the wrong index."""
+    parsed = _parse_tpm2_pcrread_output(PCRREAD_SAMPLE)
+
+    assert len(parsed) == 8
+    assert parsed == EXPECTED_PCRS
+
+
+def test_parser_preserves_all_zero_and_leading_zero_values() -> None:
+    parsed = _parse_tpm2_pcrread_output(PCRREAD_SAMPLE)
+
+    # An all-zero PCR is a full-width digest, not a single 0x00 byte.
+    assert parsed[0] == bytes(32)
+    assert all(len(value) == 32 for value in parsed)
+    assert parsed[1].hex().startswith("0af7")
+    assert parsed[3].hex().startswith("00a1")
+
+
+def test_parser_rejects_an_unparseable_value_instead_of_dropping_it() -> None:
+    with pytest.raises(RuntimeError, match="unparseable"):
+        _parse_tpm2_pcrread_output("sha256:\n  0 : 0xZZZZ\n")
+
+
+def test_parser_rejects_an_empty_value() -> None:
+    with pytest.raises(RuntimeError, match="empty"):
+        _parse_tpm2_pcrread_output("sha256:\n  0 : 0x\n")


### PR DESCRIPTION
`_parse_tpm2_pcrread_output` stripped the `0x` prefix with `lstrip("0x")`. `lstrip` strips a character set, not a prefix, so any PCR whose digits begin with `0` lost those digits too.

The effect is larger than a mangled value. Reproduced against a realistic `tpm2_pcrread` block:

```
expected PCR count: 8
OLD (main)   count=7 all32B=[1, 31, 32] matches_expected=False
    PCR0: got 00...                       expected 000000000000000000000000...
    PCR1: got b1f2e3d4c5a6978877665544...  expected 0af7c1b2c3d4e5f60718293a...
    PCR2: got a1b2c3d4e5f60718293a4b5c...  expected b1f2e3d4c5a6978877665544...
NEW (fixed)  count=8 all32B=[32] matches_expected=True
```

An all-zero PCR0 strips to the empty string and becomes a single `0x00` byte via the `or "00"` fallback. PCR1 begins `0x0A`, loses its leading zero, becomes odd-length, raises, and is dropped by the `continue`. Every later PCR then sits at the wrong index and only seven survive.

Because the measurement is `sha256(PCR0 || ... || PCR7)` over that list, the measurement produced by the subprocess path is wrong whenever any PCR has a leading zero, which is the normal case. It is stable per machine, so it looks correct in testing, but it is not a digest of the real PCR values and will never match an independently computed one.

The fix removes the prefix explicitly and raises on an empty or unparseable value instead of silently dropping it, so a parse failure no longer surfaces as a misleading "could not read PCRs" error.

Also logs the exception when `TPM2_Quote` fails instead of swallowing it. That silence is what made #430 invisible.

Existing tests in `tests/unit/test_tee_providers.py` use PCR values with no leading zeros (`ab`\*20, `cd`\*32) and assert no fixed digest, so they are unaffected.

Closes #434
Refs #430

**Scope change from the first push of this PR.** It originally also downgraded unsigned PCR reads to `software-only` (#436). That contradicts `test_tpm_sha256_success_subprocess_keeps_tpm_provider`, which deliberately asserts the subprocess path keeps `provider == "tpm"`. That is a policy decision, not a bug fix, so it moved to its own PR to be decided alongside the RFC in #439.
