### PR TITLE
fix(ci): repoint CODEOWNERS at the directories that exist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,10 @@
 * @agentrust-io/maintainers
 
 # Security-sensitive paths require security-reviewers sign-off
-src/cmcp_gateway/audit/ @agentrust-io/security-reviewers @agentrust-io/maintainers
-src/cmcp_gateway/tee/ @agentrust-io/security-reviewers @agentrust-io/maintainers
-src/cmcp_gateway/policy/ @agentrust-io/security-reviewers @agentrust-io/maintainers
+src/cmcp_runtime/audit/ @agentrust-io/security-reviewers @agentrust-io/maintainers
+src/cmcp_runtime/tee/ @agentrust-io/security-reviewers @agentrust-io/maintainers
+src/cmcp_runtime/policy/ @agentrust-io/security-reviewers @agentrust-io/maintainers
+src/cmcp_verify/ @agentrust-io/security-reviewers @agentrust-io/maintainers
 
 # CI/CD workflow changes
 .github/workflows/ @agentrust-io/maintainers


### PR DESCRIPTION
`.github/CODEOWNERS` referenced `src/cmcp_gateway/audit/`, `src/cmcp_gateway/tee/`, and `src/cmcp_gateway/policy/`. No `src/cmcp_gateway/` directory exists; the tree is `src/cmcp_runtime/` and `src/cmcp_verify/`.

All three security rules therefore matched nothing, and `@agentrust-io/security-reviewers` was never auto-requested on TEE, audit, or policy changes. They fell through to the catch-all `*` rule instead.

Repointed to the directories that exist, verified against the tree: `src/cmcp_runtime/` contains audit, catalog, inspection, mcp, policy, session, and tee. Added `src/cmcp_verify/` since verification logic is security-sensitive and had no rule at all.

Closes #435

Worth a follow-up: a CI check that fails when a CODEOWNERS path matches no files would have caught this at the point it broke.
