### PR TITLE
fix(tee): stop labelling unsigned PCR reads as hardware-attested

### DIFF
--- a/src/cmcp_runtime/tee/tpm.py
+++ b/src/cmcp_runtime/tee/tpm.py
@@ -118,8 +118,9 @@ class TPMProvider(TEEProvider):
                 )
                 raw_evidence = None
 
+        measurement_note = self._downgrade_note(measurement_note, raw_evidence)
         effective_provider = (
-            "software-only" if measurement_note == "sha1-bank-fallback" else self.provider_name()
+            self.provider_name() if measurement_note is None else "software-only"
         )
         return AttestationReport(
             provider=effective_provider,
@@ -130,6 +131,25 @@ class TPMProvider(TEEProvider):
             attestation_validity_seconds=3600,
             measurement_note=measurement_note,
         )
+
+    @staticmethod
+    def _downgrade_note(measurement_note: str | None, raw_evidence: bytes | None) -> str | None:
+        """
+        Return the note that decides whether this report may present as hardware-attested.
+
+        A PCR read on its own carries no signature and nothing binds it to a TPM, so a
+        report without quote evidence is reported as software-only. This mirrors the
+        existing SHA-1 bank downgrade rather than inventing a second policy.
+        """
+        if measurement_note is not None:
+            return measurement_note
+        if raw_evidence is None:
+            logger.warning(
+                "TPM PCR read produced no quote evidence. Downgrading attestation to "
+                "software-only. TRACE Claim will not present as hardware-attested."
+            )
+            return "tpm-pcr-read-unsigned"
+        return None
 
     # ── subprocess fallback ───────────────────────────────────────────────────
 
@@ -178,8 +198,9 @@ class TPMProvider(TEEProvider):
         concatenated = b"".join(pcr_values[:8])
         measurement = "sha256:" + hashlib.sha256(concatenated).hexdigest()
 
+        measurement_note = self._downgrade_note(measurement_note, None)
         effective_provider = (
-            "software-only" if measurement_note == "sha1-bank-fallback" else self.provider_name()
+            self.provider_name() if measurement_note is None else "software-only"
         )
         return AttestationReport(
             provider=effective_provider,

--- a/tests/unit/test_tee_providers.py
+++ b/tests/unit/test_tee_providers.py
@@ -245,10 +245,12 @@ def test_tpm_sha1_fallback_subprocess_produces_software_only_provider(
     assert report.measurement.startswith("sha256:")
 
 
-def test_tpm_sha256_success_subprocess_keeps_tpm_provider(
+def test_tpm_sha256_subprocess_downgrades_without_quote_evidence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When SHA-256 PCR bank is available, provider must remain 'tpm'."""
+    """The subprocess path reads PCRs but cannot produce a quote, so the report has no
+    signature and nothing binds it to a TPM. It must not present as hardware-attested,
+    even though the SHA-256 bank was available."""
     monkeypatch.setattr("cmcp_runtime.tee.tpm._TSS2_AVAILABLE", False)
 
     sha256_pcr_output = "\n".join(
@@ -266,5 +268,18 @@ def test_tpm_sha256_success_subprocess_keeps_tpm_provider(
 
     report = TPMProvider().get_attestation_report(b"\x00" * 32)
 
-    assert report.provider == "tpm"
-    assert report.measurement_note is None
+    assert report.provider == "software-only"
+    assert report.measurement_note == "tpm-pcr-read-unsigned"
+    assert report.measurement.startswith("sha256:")
+
+
+def test_downgrade_note_keeps_hardware_tier_when_quote_evidence_is_present() -> None:
+    assert TPMProvider._downgrade_note(None, b"\xffTCG-quote-bytes") is None
+
+
+def test_downgrade_note_marks_an_unsigned_pcr_read() -> None:
+    assert TPMProvider._downgrade_note(None, None) == "tpm-pcr-read-unsigned"
+
+
+def test_downgrade_note_preserves_the_sha1_fallback_note() -> None:
+    assert TPMProvider._downgrade_note("sha1-bank-fallback", None) == "sha1-bank-fallback"


### PR DESCRIPTION
Implements the claim tiering described in section 4.7 of `docs/spec/tpm-security-model.md`.

**This is a behaviour change, not a bug fix, which is why it is separate from #437.**

The SHA-1 bank fallback already downgrades the reported provider to `software-only` and records a `measurement_note`. The unsigned case did not. When the quote fails, and today it always does because of #430, the provider still reported `provider="tpm"` even though the evidence carries no signature and nothing binds it to a TPM. The subprocess path never produces a quote at all, so it always reported a hardware tier for a plain PCR read.

`_downgrade_note` applies one policy to both cases. Without quote evidence the report is `software-only` with note `tpm-pcr-read-unsigned`. The SHA-1 note still wins when both apply.

Nothing that was genuinely hardware-attested stops being so. Only reporting changes.

## The existing assertion this contradicts

`test_tpm_sha256_success_subprocess_keeps_tpm_provider` asserts the opposite, with the docstring "When SHA-256 PCR bank is available, provider must remain 'tpm'". That was a deliberate decision, so it deserves an explicit call rather than a silent flip.

The argument for changing it: the SHA-256 bank being available says the PCR values are strong digests. It says nothing about whether the report is signed. Those are different properties, and only the second one supports a hardware-attested claim.

The test is renamed to `test_tpm_sha256_subprocess_downgrades_without_quote_evidence` and asserts the new behaviour, with three added cases covering the tier decision directly.

Closes #436
Refs #429, #430, #439

If reviewers prefer to keep the current reporting until the signature work in #429 lands, close this and mark section 4.7 rejected. The RFC is the right place for that decision.
