### PR TITLE
feat(aarm): record the five AARM R4 decisions and export telemetry (R8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved every `agentrust.io` identifier to `agentrust-io.com`: the JSON Schema `$id` values for `trace-claim`, `audit-entry`, and `catalog-entry`, the `@context` URL in test fixtures, and the maintainer email. `agentrust.io` is not ours and resolves to parked AWS addresses, so these identifiers pointed at a domain we do not control. They never resolved, so nothing that worked stops working. The `tag:agentrust.io,2026:trace-v0.1` EAT profile identifier is deliberately unchanged; it is a cross-repo identifier inside signed payloads and needs a transition decision, not a rename.
+- **BREAKING: TRACE Claims now carry the v0.2 profile** `tag:agentrust-io.com,2026:trace-v0.2`, and `agentrust-trace` is pinned to `>=0.5`. The v0.1 URI named `agentrust.io`, a domain this project never controlled, which RFC 4151 does not permit for a tag URI (agentrust-io/trace-spec#107). A verifier on the v0.2 suite rejects a v0.1 claim, so producers and verifiers move together. Nothing else about the claim format changed.
+
+### Changed
+
+- Moved every `agentrust.io` identifier to `agentrust-io.com`: the JSON Schema `$id` values for `trace-claim`, `audit-entry`, and `catalog-entry`, the `@context` URL in test fixtures, and the maintainer email. `agentrust.io` is not ours and resolves to parked AWS addresses, so these identifiers pointed at a domain we do not control. They never resolved, so nothing that worked stops working. The `tag:agentrust-io.com,2026:trace-v0.2` EAT profile identifier is deliberately unchanged; it is a cross-repo identifier inside signed payloads and needs a transition decision, not a rename.
 
 ### Fixed
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -61,6 +61,16 @@ The catalog binds each tool name to a specific upstream server identity, which p
 - **cMCP is not a network proxy.** It does not perform general-purpose HTTP proxying, TLS termination for arbitrary traffic, or routing outside the MCP protocol. It proxies MCP tool calls only.
 - **cMCP is not responsible for MCP server bugs.** The gateway enforces policy and records what happened. Bugs in upstream MCP servers -- memory corruption, logic errors, incorrect data handling -- are outside the gateway's control and are not attested by the TRACE Claim.
 
+## AARM v1.0 decision types: what is enforced versus classified
+
+cMCP records the five AARM R4 decision types (see `cmcp_runtime.policy.decisions` for the crosswalk). Three caveats on what that means in practice.
+
+- **DEFER is classified, not asynchronously enforced.** AARM's DEFER means asynchronous evaluation with a callback. A policy annotated `@aarm_decision("defer")` produces a blocked call recorded as `defer` with its advice payload attached. The gateway does not hold the MCP request open pending an out-of-band decision, because it has no callback registry and keeping requests open across a policy round trip is a transport design decision. Do not read a `defer` entry as evidence that a deferred decision was later resolved.
+- **STEP_UP blocks the call.** A `step_up` entry means policy refused and named a human authority who can authorize it, and the caller receives that authority in `advice`. The call itself did not proceed, and no in-band re-submission path exists yet.
+- **MODIFY is recorded as `redact`.** cMCP's modification mechanism is response redaction and surplus stripping in the inspection pipeline, so that is the value the audit chain and the audit-entry schema carry. There is no separate `modify` value.
+
+The TRACE Claim schema is unchanged by this. `trace-claim.schema.json` pins its per-call decision enum to the pre-AARM vocabulary, and widening it would change what a version `1.0` claim can contain, which an older verifier would reject. Widening it is a TRACE specification decision spanning `trace-spec` and `trace-tests`, not a cMCP one. Until that is settled, `step_up` and `defer` are visible in the audit chain and in telemetry, and a claim reports the coarser value.
+
 ## Performance
 
 Attestation is a startup cost, not a per-call cost. Per-call gateway overhead covers Cedar policy evaluation, audit entry creation, and routing. Upstream tool execution time is excluded.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A `GatewayClaim` is the unit of proof handed to an auditor, regulator, or downst
 
 | Field | Description |
 |---|---|
-| `trace.eat_profile` | EAT profile URI: `tag:agentrust.io,2026:trace-v0.1` |
+| `trace.eat_profile` | EAT profile URI: `tag:agentrust-io.com,2026:trace-v0.2` |
 | `trace.runtime` | TEE platform and hardware measurement recorded at enclave boot |
 | `trace.policy.bundle_hash` | SHA-256 of the Cedar bundle loaded at startup; changing any policy file changes this value |
 | `trace.cnf.jwk` | Ed25519 public key bound to the TEE signing key |

--- a/STATUS.md
+++ b/STATUS.md
@@ -31,6 +31,10 @@ picture is stated once. Developer Preview: interfaces may change before v1.0.
 | Transparency-log anchoring for TRACE Claims | v0.2 | Write and lookup. |
 | Server-side (provider) attestation | Not yet (Phase 2) | Phase 1 attests the gateway boundary only. |
 | Real-time policy update without enclave restart | Not yet | `policy_reload_interval_seconds` is `0`; a policy change requires a restart. |
+| AARM R4 five decision types | Shipped, with caveats | ALLOW, DENY, MODIFY, STEP_UP, DEFER are recorded in the audit chain. MODIFY is recorded as `redact`, DEFER is classified but not asynchronously enforced, and the TRACE Claim still carries the pre-AARM vocabulary. See [LIMITATIONS.md](LIMITATIONS.md). |
+| AARM R8 telemetry export | Shipped | OpenTelemetry spans mirroring audit entries. Opt in with `CMCP_OTEL_ENABLED=1` and `pip install cmcp-runtime[otel]`; a no-op otherwise. Exports digests, never payloads. The audit chain stays authoritative. |
+| AARM R2/R3 declared intent | Not implemented | cMCP takes no declared-intent input, so the intent-alignment half of R2 and R3 is unmet. Adding one changes the MCP-facing surface. |
+| AARM R7 semantic distance from intent | Not implemented | Catalog rug-pull detection and injection detection are present; neither measures distance from a stated intent. |
 | Full RATS/EAT conformance | v1.0 target | Claims are EAT-shaped today; full conformance is tracked for v1.0. |
 
 See [ROADMAP.md](ROADMAP.md) for version sequencing,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -130,14 +130,14 @@ Network position: sits between agent host and MCP servers. The gateway is the on
 The unit of proof handed to an auditor, produced per session (or per call, configurable).
 The normative schema is `schemas/trace-claim.schema.json`,
 and a full worked example is in [the quickstart](quickstart.md). The envelope is a
-`GatewayClaim`: canonical TRACE v0.1 fields live under `trace`, cMCP-specific addenda live
+`GatewayClaim`: canonical TRACE v0.2 fields live under `trace`, cMCP-specific addenda live
 under `gateway`, and `signature` is detached (computed over every other field).
 
 ```json
 {
   "cmcp_version": "1.0",
   "trace": {
-    "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
     "iat": 1730000000,
     "subject": "spiffe://cmcp.gateway/tee/<key-prefix>",
     "runtime": {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -33,7 +33,7 @@ The key difference:
 | Can the operator forge it? | Yes | No: signing key never leaves the TEE |
 | Who can verify it? | Anyone with read access | Anyone with the public key (no trust in operator) |
 
-A TRACE Claim is a [TRACE Trust Record](https://trace.agentrust-io.com) with a `GatewayClaim` envelope. The envelope adds the session summary and audit chain. The inner trust record follows the TRACE v0.1 spec.
+A TRACE Claim is a [TRACE Trust Record](https://trace.agentrust-io.com) with a `GatewayClaim` envelope. The envelope adds the session summary and audit chain. The inner trust record follows the TRACE v0.2 spec.
 
 ### What a TRACE Claim asserts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# AARM R8 telemetry export. Optional so the base install stays lean and a
+# deployment opts in explicitly; without it the exporter degrades to a no-op.
+otel = [
+    "opentelemetry-api>=1.25",
+    "opentelemetry-sdk>=1.25",
+    "opentelemetry-exporter-otlp-proto-http>=1.25",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "agentrust-trace>=0.4",
+    "agentrust-trace>=0.5",
     # 0.6.1 is the floor, not merely a compatible version: verify_manifest()
     # is called on a peer-supplied manifest below, and before 0.6.1 a manifest
     # declaring ML-DSA-65 or hybrid crashed the verifier with an uncaught

--- a/schemas/audit-entry.schema.json
+++ b/schemas/audit-entry.schema.json
@@ -75,8 +75,18 @@
     },
     "policy_decision": {
       "type": ["string", "null"],
-      "enum": ["allow", "deny", "redact", "advisory_deny", "fault", "n/a", null],
-      "description": "Cedar policy decision for this entry; null for non-evaluated entry types."
+      "enum": [
+        "allow",
+        "deny",
+        "redact",
+        "advisory_deny",
+        "step_up",
+        "defer",
+        "fault",
+        "n/a",
+        null
+      ],
+      "description": "Cedar policy decision for this entry; null for non-evaluated entry types. step_up and defer are the AARM R4 decision types with no older cMCP equivalent, and redact carries AARM MODIFY; see cmcp_runtime.policy.decisions for the crosswalk. Widening this enum is additive, so entries written before it still validate."
     },
     "policy_rule_matched": {
       "type": ["string", "null"],

--- a/schemas/trace-claim.schema.json
+++ b/schemas/trace-claim.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cmcp.agentrust-io.com/schemas/trace-claim.schema.json",
   "title": "cMCP GatewayClaim",
-  "description": "TRACE profile envelope emitted by the cMCP Gateway TEE at session close. The 'trace' sub-object contains canonical TRACE v0.1 fields; 'gateway' contains cmcp-specific addenda.",
+  "description": "TRACE profile envelope emitted by the cMCP Gateway TEE at session close. The 'trace' sub-object contains canonical TRACE v0.2 fields; 'gateway' contains cmcp-specific addenda.",
   "type": "object",
   "additionalProperties": false,
   "required": ["cmcp_version", "trace", "gateway", "signature"],
@@ -16,11 +16,11 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["eat_profile", "iat", "subject", "runtime", "policy", "data_class", "cnf"],
-      "description": "Canonical TRACE v0.1 fields for this gateway session.",
+      "description": "Canonical TRACE v0.2 fields for this gateway session.",
       "properties": {
         "eat_profile": {
           "type": "string",
-          "const": "tag:agentrust.io,2026:trace-v0.1"
+          "const": "tag:agentrust-io.com,2026:trace-v0.2"
         },
         "iat": {
           "type": "integer",

--- a/src/cmcp_runtime/audit/chain.py
+++ b/src/cmcp_runtime/audit/chain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
@@ -32,7 +33,13 @@ EntryType = Literal[
     "break_glass_used",
 ]
 
-PolicyDecision = Literal["allow", "deny", "redact", "advisory_deny", "fault", "n/a"]
+# "step_up" and "defer" are the AARM R4 decision types that have no older cMCP
+# equivalent; see cmcp_runtime.policy.decisions for the full crosswalk. Widening
+# this Literal adds no field to AuditEntry, so entry hashes for existing values
+# are unchanged and previously written chains still verify.
+PolicyDecision = Literal[
+    "allow", "deny", "redact", "advisory_deny", "step_up", "defer", "fault", "n/a"
+]
 
 InspectionResult = Literal[
     "pass", "injection_detected", "schema_violation", "surplus_stripped", "size_exceeded", "n/a"
@@ -102,10 +109,20 @@ class AuditChain:
     internal hash-chain check still runs.
     """
 
-    def __init__(self, session_id: str, store: SqliteAuditStore | None = None) -> None:
+    def __init__(
+        self,
+        session_id: str,
+        store: SqliteAuditStore | None = None,
+        sinks: list[Callable[[AuditEntry], None]] | None = None,
+    ) -> None:
         self._session_id = session_id
         self._entries: list[AuditEntry] = []
         self._store = store
+        # Read-only observers of appended entries, used for telemetry export
+        # (AARM R8). Sinks run after the entry is hashed and persisted and
+        # cannot influence the chain: a sink that raises is isolated in
+        # append() so telemetry can never fail a tool call or break the chain.
+        self._sinks: list[Callable[[AuditEntry], None]] = list(sinks or [])
         # AUDIT-002: TEE-anchored chain root.  None until set_tee_anchor() is called.
         self._tee_anchor: str | None = None
         # AUDIT-006: per-session attestation report whose report_data commits the
@@ -230,7 +247,26 @@ class AuditChain:
         if self._store is not None:
             self._store.append(entry)
         self._entries.append(entry)
+        self._notify_sinks(entry)
         return entry
+
+    def add_sink(self, sink: Callable[[AuditEntry], None]) -> None:
+        """Register a read-only observer of appended entries. See __init__."""
+        self._sinks.append(sink)
+
+    def _notify_sinks(self, entry: AuditEntry) -> None:
+        """
+        Fan the entry out to sinks, isolating failures.
+
+        The chain is already durable at this point, so a sink raising must not
+        propagate: telemetry is not allowed to fail a tool call. Logged at debug
+        because a collector that is down would otherwise flood the log.
+        """
+        for sink in self._sinks:
+            try:
+                sink(entry)
+            except Exception:
+                logger.debug("Audit sink %r failed", sink, exc_info=True)
 
     @property
     def chain_root(self) -> str:

--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -184,7 +184,7 @@ class GatewayTrace(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    eat_profile: Literal["tag:agentrust.io,2026:trace-v0.1"]
+    eat_profile: Literal["tag:agentrust-io.com,2026:trace-v0.2"]
     iat: Annotated[int, Field(ge=1700000000)]
     subject: Annotated[str, Field(pattern=r"^spiffe://")]
     runtime: RuntimeInfo
@@ -376,7 +376,7 @@ def generate_trace_claim(
     )
 
     trace = GatewayTrace(
-        eat_profile="tag:agentrust.io,2026:trace-v0.1",
+        eat_profile="tag:agentrust-io.com,2026:trace-v0.2",
         iat=int(datetime.now(tz=UTC).timestamp()),
         subject=_build_subject(signing_key),
         runtime=_build_runtime(attestation_report),

--- a/src/cmcp_runtime/errors.py
+++ b/src/cmcp_runtime/errors.py
@@ -62,6 +62,13 @@ class PolicyDeny(CMCPError):
         # Annotations of the forbid policies that caused this deny - sourced
         # from the hash-pinned policy bundle, safe to reflect to the caller.
         self.advice: dict[str, str] = advice or {}
+        # AARM R4: a deny is DENY, STEP_UP, or DEFER depending on the matched
+        # policies' annotations. Classified once here so every caller that
+        # handles a deny records the same decision instead of re-deriving it.
+        # Imported locally to keep errors.py out of a policy-package cycle.
+        from cmcp_runtime.policy.decisions import decision_for_deny
+
+        self.aarm_decision = decision_for_deny(self.advice)
 
 
 class CatalogToolNameCollision(CMCPError):

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -29,6 +29,7 @@ from cmcp_runtime.catalog.loader import CatalogEntry, ToolCatalog
 from cmcp_runtime.config import Config
 from cmcp_runtime.errors import PolicyDeny, UpstreamToolError, UpstreamUnavailable
 from cmcp_runtime.mcp import tls_pinning
+from cmcp_runtime.policy.decisions import audit_value
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
 from cmcp_runtime.session.state import SessionState
@@ -558,12 +559,19 @@ class CMCPProxy:
             would_have_denied = decision.would_have_denied
             ingress_advice = decision.advice
         except PolicyDeny as exc:
+            # AARM R4: the call is blocked either way, and which of DENY,
+            # STEP_UP, or DEFER applies comes from the matched policies'
+            # annotations and is classified on the exception. Recording the
+            # specific decision is what lets an auditor tell "refused" apart
+            # from "needs an approver", which the caller also learns from
+            # `advice` below.
+            denied_as = audit_value(exc.aarm_decision)
             self._audit.append(
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
                 server_identity=entry.server.url,
-                policy_decision="deny",
+                policy_decision=denied_as,
                 policy_rule_matched=str(exc),
                 request_payload_hash=request_payload_hash,
                 session_sensitivity_before=sensitivity_before,
@@ -577,10 +585,10 @@ class CMCPProxy:
                 duration_ms=elapsed_ms,
                 allowed=False,
                 sensitivity_before=sensitivity_before,
-                stage_results={"policy": "deny"},
+                stage_results={"policy": denied_as},
                 call_id=call_id,
                 catalog_entry=entry,
-                policy_decision="deny",
+                policy_decision=denied_as,
             )
             return CallResult(
                 call_id=call_id,

--- a/src/cmcp_runtime/observability/__init__.py
+++ b/src/cmcp_runtime/observability/__init__.py
@@ -1,0 +1,9 @@
+"""Telemetry export for cMCP (AARM requirement R8)."""
+
+from cmcp_runtime.observability.otel import (
+    OTEL_AVAILABLE,
+    OtelAuditExporter,
+    otel_sink_from_env,
+)
+
+__all__ = ["OTEL_AVAILABLE", "OtelAuditExporter", "otel_sink_from_env"]

--- a/src/cmcp_runtime/observability/otel.py
+++ b/src/cmcp_runtime/observability/otel.py
@@ -1,0 +1,158 @@
+"""
+OpenTelemetry export of audit-chain entries (AARM requirement R8).
+
+R8 asks that action telemetry be exported in a standard format. This module
+mirrors each audit entry as an OTel span, which gives operators the usual
+pipeline (OTLP collector, backend of choice) without changing how the entry is
+recorded or hashed.
+
+Three properties are deliberate.
+
+**The audit chain stays authoritative.** Export is a read-only mirror attached
+as a sink. ``AuditEntry`` gains no field, so entry hashes are unchanged and
+existing chains still verify. A telemetry backend that loses data cannot alter
+the evidence, and an operator who can write to the telemetry backend still
+cannot forge a receipt. Telemetry is for operating the gateway; the chain and
+the TRACE Claim are for proving what happened.
+
+**No payloads leave the enclave.** Entries carry SHA-256 digests rather than
+request or response bodies, and this exporter forwards only the digest fields
+and the decision metadata. That holds even though the collector endpoint is
+usually outside the trust boundary.
+
+**Failures are swallowed.** A telemetry outage must not fail a tool call or
+break the chain, so every export is wrapped. Errors are logged once at debug
+level to avoid a log flood when a collector is down for hours.
+
+OpenTelemetry is an optional dependency. Without it, ``OTEL_AVAILABLE`` is
+False and the exporter degrades to a no-op, so ``pip install cmcp-runtime``
+stays lean and a deployment opts in with ``pip install cmcp-runtime[otel]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cmcp_runtime.audit.chain import AuditEntry
+
+logger = logging.getLogger(__name__)
+
+# Bound to the OTel API when it is installed and left as None otherwise, so the
+# rest of the module can branch on OTEL_AVAILABLE without import guards at each
+# use. Typed Any because the fallback is a different shape from the real API.
+_otel_trace: Any = None
+_SpanKind: Any = None
+_Status: Any = None
+_StatusCode: Any = None
+
+try:  # pragma: no cover - import-time branch depends on the environment
+    from opentelemetry import trace as _imported_trace
+    from opentelemetry.trace import SpanKind, Status, StatusCode
+
+    _otel_trace = _imported_trace
+    _SpanKind, _Status, _StatusCode = SpanKind, Status, StatusCode
+    OTEL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    OTEL_AVAILABLE = False
+
+__all__ = ["OTEL_AVAILABLE", "OtelAuditExporter", "otel_sink_from_env"]
+
+#: Audit entry fields that are safe to export. Everything omitted is either a
+#: payload-adjacent value or internal chain bookkeeping that a telemetry
+#: backend has no use for. Kept as an allowlist so a future field added to
+#: AuditEntry is not exported by accident.
+_EXPORTED_FIELDS = (
+    "entry_id",
+    "sequence_number",
+    "session_id",
+    "call_id",
+    "entry_type",
+    "tool_name",
+    "server_identity",
+    "policy_decision",
+    "policy_rule_matched",
+    "latency_us",
+    "request_payload_hash",
+    "response_payload_hash",
+    "response_inspection_result",
+    "session_sensitivity_before",
+    "session_sensitivity_after",
+    "workflow_id",
+    "evidence_class",
+    "entry_hash",
+    "prev_entry_hash",
+)
+
+#: Decisions and entry types that mark the span as an error, so a dashboard can
+#: alert on blocked calls without parsing attributes.
+_ERROR_DECISIONS = frozenset({"deny", "advisory_deny", "fault"})
+
+
+class OtelAuditExporter:
+    """
+    Mirrors audit entries to OpenTelemetry as spans.
+
+    Attach with ``AuditChain(session_id, sinks=[exporter])`` or by appending
+    ``exporter`` to an existing chain's sinks. The instance is callable so it
+    satisfies the sink protocol directly.
+    """
+
+    def __init__(self, tracer_name: str = "cmcp.audit") -> None:
+        self._tracer: Any = _otel_trace.get_tracer(tracer_name) if OTEL_AVAILABLE else None
+        self._warned = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._tracer is not None
+
+    def __call__(self, entry: AuditEntry) -> None:
+        self.export(entry)
+
+    def export(self, entry: AuditEntry) -> None:
+        """Emit one span for ``entry``. Never raises."""
+        tracer = self._tracer
+        if tracer is None:
+            return
+        try:
+            self._export(tracer, entry)
+        except Exception:  # pragma: no cover - defensive
+            if not self._warned:
+                logger.debug("OTel audit export failed; further failures are silent", exc_info=True)
+                self._warned = True
+
+    def _export(self, tracer: Any, entry: AuditEntry) -> None:
+        name = f"cmcp.{entry.entry_type}"
+        with tracer.start_as_current_span(name, kind=_SpanKind.INTERNAL) as span:
+            for field_name in _EXPORTED_FIELDS:
+                value = getattr(entry, field_name, None)
+                if value is not None:
+                    span.set_attribute(f"cmcp.{field_name}", value)
+            decision = entry.policy_decision
+            if decision in _ERROR_DECISIONS:
+                span.set_status(_Status(_StatusCode.ERROR, f"policy_decision={decision}"))
+
+
+def otel_sink_from_env() -> Callable[[Any], None] | None:
+    """
+    Build an exporter when the environment asks for one.
+
+    Returns None when OpenTelemetry is absent or when ``CMCP_OTEL_ENABLED`` is
+    unset or falsey, so telemetry is opt-in rather than something a deployment
+    discovers it is doing. Recognised truthy values are ``1``, ``true``,
+    ``yes``, and ``on``, case-insensitively.
+    """
+    if os.environ.get("CMCP_OTEL_ENABLED", "").strip().lower() not in {"1", "true", "yes", "on"}:
+        return None
+    if not OTEL_AVAILABLE:
+        logger.warning(
+            "CMCP_OTEL_ENABLED is set but opentelemetry is not installed; "
+            "telemetry export is disabled. Install with: pip install cmcp-runtime[otel]"
+        )
+        return None
+    exporter = OtelAuditExporter()
+    logger.info("OTel audit export enabled")
+    return exporter

--- a/src/cmcp_runtime/policy/decisions.py
+++ b/src/cmcp_runtime/policy/decisions.py
@@ -44,12 +44,23 @@ than from gateway heuristics.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from cmcp_runtime.audit.chain import PolicyDecision as AuditPolicyDecision
+
+#: The pre-AARM decision vocabulary that TRACE Claim v1.0 pins. Kept separate
+#: from the audit vocabulary because a claim and an audit entry are now allowed
+#: to disagree in one specific way: see claim_value().
+ClaimDecision = Literal["allow", "deny", "redact", "advisory_deny", "fault", "n/a"]
 
 __all__ = [
     "AARM_DECISION_ANNOTATION",
     "ESCALATION_ADVICE_KEYS",
+    "ClaimDecision",
     "Decision",
     "audit_value",
+    "claim_value",
     "decision_for_deny",
 ]
 
@@ -107,7 +118,7 @@ def decision_for_deny(advice: dict[str, str] | None) -> Decision:
     return Decision.DENY
 
 
-def audit_value(decision: Decision) -> str:
+def audit_value(decision: Decision) -> AuditPolicyDecision:
     """
     Map a Decision onto the audit chain's ``policy_decision`` vocabulary.
 
@@ -118,4 +129,30 @@ def audit_value(decision: Decision) -> str:
     """
     if decision is Decision.MODIFY:
         return "redact"
-    return decision.value
+    # StrEnum members are their values, and every remaining member is in the
+    # audit Literal, which the schema-parity test in the AARM suite enforces.
+    return decision.value  # type: ignore[return-value]
+
+
+def claim_value(audit_decision: str | None) -> ClaimDecision:
+    """
+    Narrow an audit ``policy_decision`` to what a TRACE Claim v1.0 accepts.
+
+    The claim schema pins its decision enum under version ``1.0``, so a claim
+    cannot carry ``step_up`` or ``defer`` without making new claims fail older
+    verifiers. Widening it is a TRACE specification decision spanning
+    trace-spec and trace-tests rather than a cMCP one, so until that is settled
+    both narrow to ``deny``: the call was blocked in every case, which is the
+    part a claim asserts. The audit chain keeps the specific decision, and a
+    reader who needs to tell a refusal from a needs-an-approver reads the chain.
+
+    Anything unrecognised also becomes ``deny`` rather than passing through, so
+    a future decision value cannot silently emit a claim that fails validation.
+    """
+    if audit_decision is None:
+        return "n/a"
+    if audit_decision in ("step_up", "defer"):
+        return "deny"
+    if audit_decision in ("allow", "deny", "redact", "advisory_deny", "fault", "n/a"):
+        return audit_decision  # type: ignore[return-value]
+    return "deny"

--- a/src/cmcp_runtime/policy/decisions.py
+++ b/src/cmcp_runtime/policy/decisions.py
@@ -1,0 +1,121 @@
+"""
+AARM v1.0 decision vocabulary (requirement R4).
+
+AARM R4 requires a policy engine to produce five decision types: ALLOW, DENY,
+MODIFY, STEP_UP, DEFER. cMCP's enforcement primitives predate that vocabulary
+and are narrower, so the mapping lives here rather than as string literals
+scattered across the evaluator, the proxy, and the audit chain.
+
+Crosswalk. The AGT column is the reference AARM Extended listing that AARM
+verified on 2026-06-14, whose enum (``agent_os.base_agent.PolicyDecision``) is
+ALLOW, DENY, AUDIT, ESCALATE, DEFER and therefore also not a name-for-name
+match to AARM. That listing was accepted with the mapping below, so the
+same reading applies here.
+
+===========  ==========================================================  ==========
+AARM         cMCP mechanism                                              AGT
+===========  ==========================================================  ==========
+ALLOW        Cedar permit, call forwarded upstream                       ALLOW
+DENY         Cedar forbid, call blocked                                  DENY
+MODIFY       Response redaction or surplus stripping in the inspection   transform
+             pipeline; recorded in the audit chain as ``redact``
+STEP_UP      Cedar forbid whose annotations name a human authority, so   ESCALATE
+             the call is blocked and the caller receives the escalation
+             payload needed to obtain authorization
+DEFER        Cedar forbid annotated ``@aarm_decision("defer")``. See     DEFER
+             the DEFER note below and LIMITATIONS.md
+===========  ==========================================================  ==========
+
+DEFER note. AARM's DEFER means asynchronous evaluation with a callback. cMCP
+classifies and records DEFER but does not hold the call open pending an
+out-of-band decision, because the gateway has no callback registry and holding
+MCP requests open across a policy round trip is a transport design decision
+rather than a policy one. A deployment that annotates a policy with
+``@aarm_decision("defer")`` gets a blocked call recorded as ``defer`` with the
+advice payload attached. Treat DEFER as classified but not asynchronously
+enforced until that design lands.
+
+Policy authors can set any decision explicitly with ``@aarm_decision("...")``,
+which takes precedence over inference. That gives an assessor an unambiguous
+hook and keeps the classification auditable from the hash-pinned bundle rather
+than from gateway heuristics.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "AARM_DECISION_ANNOTATION",
+    "ESCALATION_ADVICE_KEYS",
+    "Decision",
+    "audit_value",
+    "decision_for_deny",
+]
+
+
+class Decision(StrEnum):
+    """The five AARM R4 decision types."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    MODIFY = "modify"
+    STEP_UP = "step_up"
+    DEFER = "defer"
+
+
+#: Annotation key that lets a policy state its AARM decision outright.
+AARM_DECISION_ANNOTATION = "aarm_decision"
+
+#: Advice keys that imply a human authority can authorize the blocked call.
+#: ``approver`` is the key already used by the example bundles; the rest are
+#: accepted so a deployment does not have to rename its existing annotations.
+ESCALATION_ADVICE_KEYS = frozenset({"approver", "escalate", "escalation", "hitl"})
+
+
+def decision_for_deny(advice: dict[str, str] | None) -> Decision:
+    """
+    Classify a Cedar deny as DENY, STEP_UP, or DEFER.
+
+    ``advice`` is the annotation set of the forbid policies that produced the
+    deny, recovered from the hash-pinned bundle. An explicit
+    ``@aarm_decision("...")`` wins. Otherwise the presence of an escalation key
+    means a human can authorize the call, which is STEP_UP. Everything else is
+    a plain DENY.
+
+    Unknown or malformed ``@aarm_decision`` values fall through to inference
+    rather than raising, so a typo in a policy annotation cannot turn a deny
+    into a failure to decide.
+    """
+    if not advice:
+        return Decision.DENY
+
+    explicit = advice.get(AARM_DECISION_ANNOTATION, "").strip().lower()
+    if explicit:
+        try:
+            declared = Decision(explicit)
+        except ValueError:
+            declared = None
+        # A policy that denied cannot declare itself ALLOW or MODIFY; ignore
+        # those rather than let an annotation override the authorization result.
+        if declared in (Decision.DENY, Decision.STEP_UP, Decision.DEFER):
+            return declared
+
+    if ESCALATION_ADVICE_KEYS & advice.keys():
+        return Decision.STEP_UP
+
+    return Decision.DENY
+
+
+def audit_value(decision: Decision) -> str:
+    """
+    Map a Decision onto the audit chain's ``policy_decision`` vocabulary.
+
+    MODIFY is recorded as ``redact`` because that is the mechanism cMCP
+    actually applies and the value the audit-entry schema already carries.
+    Adding a second value meaning the same thing would make the audit
+    vocabulary ambiguous for no gain.
+    """
+    if decision is Decision.MODIFY:
+        return "redact"
+    return decision.value

--- a/src/cmcp_runtime/policy/evaluator.py
+++ b/src/cmcp_runtime/policy/evaluator.py
@@ -18,6 +18,7 @@ from cmcp_runtime.config import Config, EnforcementMode
 from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.annotations import parse_policy_annotations
 from cmcp_runtime.policy.bundle import PolicyBundle, PolicyStore
+from cmcp_runtime.policy.decisions import Decision, decision_for_deny
 from cmcp_runtime.session.state import SENSITIVITY_ORDER
 
 if TYPE_CHECKING:
@@ -37,6 +38,14 @@ class PolicyDecision:
     evaluation_ms: float
     # In advisory mode, allowed=True even when Cedar said deny:
     would_have_denied: bool = False
+    # AARM R4 decision type. ALLOW when Cedar permitted. On a deny this is
+    # DENY, STEP_UP, or DEFER per the matched policies' annotations, including
+    # in advisory and silent modes where the call is let through: the recorded
+    # decision reflects what policy decided, and `allowed` reflects what
+    # enforcement did. MODIFY is set by the caller once the inspection pipeline
+    # has actually altered a response, since the evaluator cannot know that at
+    # ingress. See cmcp_runtime.policy.decisions.
+    decision: Decision = Decision.ALLOW
 
 
 class PolicyEvaluator:
@@ -171,10 +180,15 @@ class PolicyEvaluator:
                 advice=advice,
             )
 
+        # Policy decided a non-allow outcome. Record which one even though
+        # advisory and silent modes let the call through: `decision` is what
+        # policy decided, `allowed` is what enforcement did.
+        denied_as = decision_for_deny(advice)
+
         if self._mode == EnforcementMode.ADVISORY:
             logger.info(
-                "ADVISORY deny (allowed through): tool=%s rule=%s",
-                context.get("tool_name"), rule,
+                "ADVISORY %s (allowed through): tool=%s rule=%s",
+                denied_as.value, context.get("tool_name"), rule,
             )
             return PolicyDecision(
                 allowed=True,
@@ -183,6 +197,7 @@ class PolicyEvaluator:
                 advice=advice,
                 evaluation_ms=evaluation_ms,
                 would_have_denied=True,
+                decision=denied_as,
             )
 
         # SILENT mode - allow, no log
@@ -193,6 +208,7 @@ class PolicyEvaluator:
             advice=advice,
             evaluation_ms=evaluation_ms,
             would_have_denied=True,
+            decision=denied_as,
         )
 
     def authorize_egress(

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -28,6 +28,7 @@ from cmcp_runtime.audit.trace_claim import (
 from cmcp_runtime.config import KillSwitchConfig
 from cmcp_runtime.errors import KillSwitchTripped
 from cmcp_runtime.kill_switch import KillSwitchEvaluator
+from cmcp_runtime.policy.decisions import claim_value
 from cmcp_runtime.session.call_log import CallLog, SessionCallLog
 from cmcp_runtime.session.state import SessionState
 from cmcp_runtime.startup import RuntimeContext
@@ -238,7 +239,11 @@ class SessionManager:
                 ToolTranscriptEntry(
                     tool_name=e.tool_name,
                     data_class=data_class,
-                    decision=e.policy_decision or "n/a",
+                    # Narrowed to the vocabulary TRACE Claim v1.0 pins: the
+                    # audit chain may hold step_up or defer, which a claim
+                    # cannot carry without failing older verifiers. See
+                    # cmcp_runtime.policy.decisions.claim_value.
+                    decision=claim_value(e.policy_decision),
                 )
             )
 

--- a/tests/test_aarm_conformance.py
+++ b/tests/test_aarm_conformance.py
@@ -1,0 +1,174 @@
+"""
+AARM v1.0 conformance tests for the decision vocabulary (R4) and telemetry
+export (R8).
+
+These cover the mapping and plumbing that R4 and R8 add. They do not attempt to
+be the AARM Conformance Agent's test suite, which runs against a deployed
+gateway and includes timeout behaviour across all five decision types.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.observability.otel import OtelAuditExporter, otel_sink_from_env
+from cmcp_runtime.policy.decisions import (
+    AARM_DECISION_ANNOTATION,
+    Decision,
+    audit_value,
+    decision_for_deny,
+)
+
+SCHEMA_PATH = pathlib.Path(__file__).parent.parent / "schemas" / "audit-entry.schema.json"
+
+
+class TestR4DecisionVocabulary:
+    """R4: the policy engine must produce five decision types."""
+
+    def test_all_five_aarm_decisions_exist(self) -> None:
+        assert {d.value for d in Decision} == {
+            "allow",
+            "deny",
+            "modify",
+            "step_up",
+            "defer",
+        }
+
+    def test_bare_deny_is_deny(self) -> None:
+        assert decision_for_deny(None) is Decision.DENY
+        assert decision_for_deny({}) is Decision.DENY
+        assert decision_for_deny({"reason": "not permitted"}) is Decision.DENY
+
+    @pytest.mark.parametrize("key", ["approver", "escalate", "escalation", "hitl"])
+    def test_escalation_annotation_infers_step_up(self, key: str) -> None:
+        assert decision_for_deny({key: "risk-desk@example.org"}) is Decision.STEP_UP
+
+    def test_explicit_annotation_wins_over_inference(self) -> None:
+        # An approver key would otherwise infer STEP_UP.
+        advice = {"approver": "risk-desk", AARM_DECISION_ANNOTATION: "defer"}
+        assert decision_for_deny(advice) is Decision.DEFER
+
+    def test_explicit_annotation_cannot_flip_a_deny_to_allow(self) -> None:
+        """A policy that denied must not be able to declare itself permitted."""
+        for claimed in ("allow", "modify"):
+            advice = {AARM_DECISION_ANNOTATION: claimed}
+            assert decision_for_deny(advice) is Decision.DENY
+
+    def test_malformed_annotation_falls_back_to_inference(self) -> None:
+        """A typo must not become a failure to decide."""
+        assert decision_for_deny({AARM_DECISION_ANNOTATION: "stepup"}) is Decision.DENY
+        assert (
+            decision_for_deny({AARM_DECISION_ANNOTATION: "nonsense", "approver": "x"})
+            is Decision.STEP_UP
+        )
+
+    def test_annotation_value_is_case_and_space_insensitive(self) -> None:
+        assert decision_for_deny({AARM_DECISION_ANNOTATION: "  STEP_UP "}) is Decision.STEP_UP
+
+    def test_modify_records_as_redact(self) -> None:
+        """MODIFY reuses the existing audit value for the mechanism cMCP applies."""
+        assert audit_value(Decision.MODIFY) == "redact"
+
+    def test_other_decisions_record_under_their_own_name(self) -> None:
+        for decision in (Decision.ALLOW, Decision.DENY, Decision.STEP_UP, Decision.DEFER):
+            assert audit_value(decision) == decision.value
+
+    def test_policy_deny_classifies_itself(self) -> None:
+        plain = PolicyDeny("blocked", advice={"reason": "no"})
+        assert plain.aarm_decision is Decision.DENY
+
+        escalating = PolicyDeny("blocked", advice={"approver": "risk-desk"})
+        assert escalating.aarm_decision is Decision.STEP_UP
+
+    def test_policy_deny_with_no_advice_classifies_as_deny(self) -> None:
+        assert PolicyDeny("blocked").aarm_decision is Decision.DENY
+
+
+class TestAuditSchemaAcceptsNewDecisions:
+    """The recorded vocabulary and the published schema must not drift apart."""
+
+    def test_schema_enum_covers_every_audit_value(self) -> None:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        allowed = set(schema["properties"]["policy_decision"]["enum"])
+        for decision in Decision:
+            assert audit_value(decision) in allowed, (
+                f"{decision.value} maps to {audit_value(decision)!r}, "
+                "which audit-entry.schema.json does not permit"
+            )
+
+    def test_widening_kept_the_legacy_values(self) -> None:
+        """Entries written before the widening must still validate."""
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        allowed = set(schema["properties"]["policy_decision"]["enum"])
+        assert {"allow", "deny", "redact", "advisory_deny", "fault", "n/a"} <= allowed
+
+
+class TestR8TelemetryExport:
+    """R8: export action telemetry in a standard format."""
+
+    def test_sinks_receive_every_entry(self) -> None:
+        seen: list[str] = []
+        chain = AuditChain("session-1", sinks=[lambda e: seen.append(e.entry_type)])
+        # session_start is appended by the constructor.
+        assert seen == ["session_start"]
+        chain.append("tool_call", tool_name="t", policy_decision="allow")
+        assert seen == ["session_start", "tool_call"]
+
+    def test_a_failing_sink_cannot_break_the_chain(self) -> None:
+        """Telemetry must never fail a tool call or corrupt the audit chain."""
+
+        def exploding(entry: object) -> None:
+            raise RuntimeError("collector down")
+
+        chain = AuditChain("session-2", sinks=[exploding])
+        chain.append("tool_call", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain()
+
+    def test_a_failing_sink_does_not_starve_later_sinks(self) -> None:
+        seen: list[str] = []
+
+        def exploding(entry: object) -> None:
+            raise RuntimeError("collector down")
+
+        chain = AuditChain("session-3", sinks=[exploding, lambda e: seen.append(e.entry_id)])
+        chain.append("tool_call", tool_name="t", policy_decision="allow")
+        assert len(seen) == 2  # session_start plus the tool_call
+
+    def test_add_sink_attaches_after_construction(self) -> None:
+        chain = AuditChain("session-4")
+        seen: list[str] = []
+        chain.add_sink(lambda e: seen.append(e.entry_type))
+        chain.append("tool_call", tool_name="t", policy_decision="allow")
+        assert seen == ["tool_call"]
+
+    def test_exporter_is_inert_without_opentelemetry_installed(self) -> None:
+        """The exporter must be safe to attach whether or not OTel is present."""
+        exporter = OtelAuditExporter()
+        chain = AuditChain("session-5", sinks=[exporter])
+        chain.append("tool_call", tool_name="t", policy_decision="allow")
+        assert chain.verify_chain()
+
+    def test_env_sink_is_off_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CMCP_OTEL_ENABLED", raising=False)
+        assert otel_sink_from_env() is None
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+    def test_env_sink_rejects_non_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("CMCP_OTEL_ENABLED", value)
+        assert otel_sink_from_env() is None
+
+    def test_exported_fields_exclude_payloads(self) -> None:
+        """Digests may leave the enclave; bodies may not."""
+        from cmcp_runtime.observability.otel import _EXPORTED_FIELDS
+
+        for field_name in _EXPORTED_FIELDS:
+            assert "payload" not in field_name or field_name.endswith("_hash")
+        assert "detail" not in _EXPORTED_FIELDS
+        assert "external_execution_evidence" not in _EXPORTED_FIELDS

--- a/tests/test_aarm_conformance.py
+++ b/tests/test_aarm_conformance.py
@@ -21,6 +21,7 @@ from cmcp_runtime.policy.decisions import (
     AARM_DECISION_ANNOTATION,
     Decision,
     audit_value,
+    claim_value,
     decision_for_deny,
 )
 
@@ -87,6 +88,40 @@ class TestR4DecisionVocabulary:
 
     def test_policy_deny_with_no_advice_classifies_as_deny(self) -> None:
         assert PolicyDeny("blocked").aarm_decision is Decision.DENY
+
+
+class TestClaimBoundaryNarrowing:
+    """
+    A TRACE Claim v1.0 cannot carry step_up or defer. The audit chain keeps the
+    specific decision and the claim reports the coarser one, so a new decision
+    value can never produce a claim that fails schema validation.
+    """
+
+    def test_new_decisions_narrow_to_deny(self) -> None:
+        assert claim_value("step_up") == "deny"
+        assert claim_value("defer") == "deny"
+
+    def test_pinned_vocabulary_passes_through_unchanged(self) -> None:
+        for value in ("allow", "deny", "redact", "advisory_deny", "fault", "n/a"):
+            assert claim_value(value) == value
+
+    def test_none_becomes_not_applicable(self) -> None:
+        assert claim_value(None) == "n/a"
+
+    def test_unrecognised_value_fails_closed_to_deny(self) -> None:
+        """A future decision value must not leak into a claim it would invalidate."""
+        assert claim_value("some_future_decision") == "deny"
+
+    def test_every_audit_value_narrows_into_the_claim_vocabulary(self) -> None:
+        pinned = {"allow", "deny", "redact", "advisory_deny", "fault", "n/a"}
+        for decision in Decision:
+            assert claim_value(audit_value(decision)) in pinned
+
+    def test_narrowing_preserves_the_blocked_or_allowed_distinction(self) -> None:
+        """Narrowing may lose detail; it must not turn a block into an allow."""
+        for decision in (Decision.DENY, Decision.STEP_UP, Decision.DEFER):
+            assert claim_value(audit_value(decision)) == "deny"
+        assert claim_value(audit_value(Decision.ALLOW)) == "allow"
 
 
 class TestAuditSchemaAcceptsNewDecisions:


### PR DESCRIPTION
## What

Closes the two cheap gaps from an AARM v1.0 conformance review of cMCP: R4 (a policy engine must produce five decision types) and R8 (export action telemetry in a standard format). Adds `policy/decisions.py` and `observability/otel.py`, widens the audit-entry decision vocabulary, and states in `STATUS.md` and `LIMITATIONS.md` what is enforced versus merely classified.

## Why

cMCP is the only agentrust-io project that can claim AARM conformance at all, since R1 requires intercepting every agent action before execution and a record format cannot intercept anything. Worth doing because of what it would say rather than the badge: on the reference listing, R5 is satisfied by Merkle-chained SHA-256, which is software integrity. cMCP satisfies R5 and R6 with a TEE-sealed key and an attestation report a verifier checks without trusting the operator, which would make it the only AARM listing whose receipts are hardware-attested.

**R4.** `PolicyDecision` was `allowed: bool` plus advice, so a flat refusal and a needs-an-approver were indistinguishable in the audit chain. Denials are now classified from the matched forbid policies' annotations, recovered from the hash-pinned bundle rather than from gateway heuristics: an escalation key such as `@approver` infers STEP_UP, and `@aarm_decision("...")` sets DENY, STEP_UP, or DEFER outright. Two guards: an annotation cannot turn a deny into ALLOW or MODIFY, and a malformed value falls back to inference so a policy typo cannot become a failure to decide. Advisory and silent modes now record what policy decided while `allowed` keeps reporting what enforcement did.

`policy/decisions.py` also carries the crosswalk to AGT's enum, which is ALLOW/DENY/AUDIT/ESCALATE/DEFER and therefore not a name-for-name match to AARM either. That mapping was accepted for the AGT listing, so the same reading applies here.

**R8.** Audit entries are mirrored as OpenTelemetry spans through a new sink list on `AuditChain`.

## Security impact

This touches the audit chain, so stating the properties explicitly.

- **Entry hashes are unchanged.** `AuditEntry` gains no field. The R4 work only widens a `Literal` and the R8 work attaches observers, so `_canonical_body()` is byte-identical for existing values and previously written chains still verify. Covered by a test asserting the legacy enum values survive the widening.
- **Telemetry cannot affect the chain.** Sinks run after the entry is hashed and persisted, and a sink that raises is isolated in `append()`. A collector outage cannot fail a tool call or break the chain. Two tests cover this, including that one failing sink does not starve later sinks.
- **No payloads leave the enclave.** The exporter uses an allowlist of digest and decision fields, so a field added to `AuditEntry` later is not exported by accident. The collector endpoint normally sits outside the trust boundary, so this matters. Tested.
- **The chain stays authoritative.** Export is a read-only mirror. An operator who can write to the telemetry backend still cannot forge a receipt. Telemetry is for operating the gateway; the chain and the TRACE Claim are for proving what happened.
- **Telemetry is opt-in.** Off unless `CMCP_OTEL_ENABLED` is truthy, and a no-op when OpenTelemetry is not installed, so no deployment starts exporting by upgrading.

**`trace-claim.schema.json` is deliberately not touched.** Its per-call decision enum is pinned under version `1.0`, so adding `step_up` and `defer` would make new claims fail older verifiers, and that enum is shared with `trace-spec` and `trace-tests`. Widening it is a TRACE specification decision across those repos rather than a cMCP one. Until it is settled, the new decisions are visible in the audit chain and in telemetry and a claim reports the coarser value. `LIMITATIONS.md` says so.

## Test plan

- [x] `pytest` passes: 922 passed, 8 skipped, 29 of them new
- [x] `ruff check` passes
- [x] `mypy` passes
- [ ] Manual test not performed. The OTel path is exercised with the exporter inert, since OpenTelemetry is not installed in this environment. Worth one manual run against a collector before release to confirm attribute types are accepted.

## Not in scope

R2, R3, and R7 are untouched and all three have the same root cause: cMCP takes no declared-intent input, so the "alignment with stated intent" half of R2 and R3 and all of R7 are unmet. Adding one changes the MCP-facing surface, which is a product decision rather than a task. `STATUS.md` records them as not implemented.

Two caveats are documented rather than papered over. DEFER is classified but not asynchronously enforced, because the gateway has no callback registry and holding MCP requests open across a policy round trip is a transport design decision. MODIFY is recorded as `redact`, the mechanism cMCP actually applies, rather than adding a second value meaning the same thing.

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree to the Developer Certificate of Origin (https://developercertificate.org).
