### PR TITLE
feat(verify): replay TCG event logs against reported PCR values

### DIFF
--- a/src/cmcp_verify/tcg_event_log.py
+++ b/src/cmcp_verify/tcg_event_log.py
@@ -1,0 +1,229 @@
+"""TCG event log parsing and PCR replay.
+
+A PCR digest on its own is opaque: a verifier can tell that platform state differs
+from a known-good value but not what changed. The TCG event log is the record of
+every measurement that produced those PCRs, so replaying it turns an opaque digest
+into an auditable list of components.
+
+Format reference: TCG PC Client Platform Firmware Profile, the crypto-agile log.
+The first entry is a legacy ``TCG_PCClientPCREvent`` carrying a Spec ID event that
+declares which digest algorithms the rest of the log uses. Every later entry is a
+``TCG_PCR_EVENT2`` with one digest per declared algorithm.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from dataclasses import dataclass, field
+
+# Event types that record information without extending a PCR.
+EV_NO_ACTION = 0x00000003
+
+# TPM2_ALG_ID values we can replay.
+ALG_SHA1 = 0x0004
+ALG_SHA256 = 0x000B
+ALG_SHA384 = 0x000C
+ALG_SHA512 = 0x000D
+
+_HASHES = {
+    ALG_SHA1: hashlib.sha1,
+    ALG_SHA256: hashlib.sha256,
+    ALG_SHA384: hashlib.sha384,
+    ALG_SHA512: hashlib.sha512,
+}
+
+_ALG_NAMES = {
+    ALG_SHA1: "sha1",
+    ALG_SHA256: "sha256",
+    ALG_SHA384: "sha384",
+    ALG_SHA512: "sha512",
+}
+
+_SPEC_ID_SIGNATURE = b"Spec ID Event03\x00"
+
+# SRTM PCRs start at zero. DRTM PCRs 17 through 22 start at 0xFF and are only
+# reset by a measured launch, so a replay that starts them at zero is wrong.
+_DRTM_PCRS = range(17, 23)
+
+
+class EventLogError(ValueError):
+    """The event log could not be parsed."""
+
+
+@dataclass(frozen=True)
+class EventLogEntry:
+    """One measurement record."""
+
+    pcr_index: int
+    event_type: int
+    digests: dict[int, bytes]
+    event_data: bytes
+
+    @property
+    def extends(self) -> bool:
+        """EV_NO_ACTION entries are informational and never extend a PCR."""
+        return self.event_type != EV_NO_ACTION
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Outcome of replaying a log against reported PCR values."""
+
+    algorithm: str
+    computed: dict[int, bytes]
+    matched: list[int] = field(default_factory=list)
+    mismatched: list[int] = field(default_factory=list)
+    absent_from_log: list[int] = field(default_factory=list)
+
+    @property
+    def verified(self) -> bool:
+        return not self.mismatched and not self.absent_from_log
+
+
+def _starting_value(pcr_index: int, digest_size: int) -> bytes:
+    if pcr_index in _DRTM_PCRS:
+        return b"\xff" * digest_size
+    return b"\x00" * digest_size
+
+
+def _parse_spec_id(event_data: bytes) -> dict[int, int]:
+    """Return {algorithm_id: digest_size} declared by the Spec ID event."""
+    if not event_data.startswith(_SPEC_ID_SIGNATURE):
+        raise EventLogError("first event is not a Spec ID Event03 header")
+    # signature(16) platformClass(4) minor(1) major(1) errata(1) uintnSize(1)
+    offset = 16 + 4 + 1 + 1 + 1 + 1
+    if len(event_data) < offset + 4:
+        raise EventLogError("Spec ID event truncated before algorithm count")
+    (count,) = struct.unpack_from("<I", event_data, offset)
+    offset += 4
+    if count == 0:
+        raise EventLogError("Spec ID event declares no digest algorithms")
+    sizes: dict[int, int] = {}
+    for _ in range(count):
+        if len(event_data) < offset + 4:
+            raise EventLogError("Spec ID event truncated inside the algorithm list")
+        alg_id, digest_size = struct.unpack_from("<HH", event_data, offset)
+        offset += 4
+        sizes[alg_id] = digest_size
+    return sizes
+
+
+def parse_event_log(data: bytes) -> tuple[list[EventLogEntry], dict[int, int]]:
+    """
+    Parse a crypto-agile TCG event log.
+
+    Returns the entries and the {algorithm_id: digest_size} map from the header.
+    Raises EventLogError on any truncation rather than returning a partial log: a
+    silently truncated log replays to the wrong PCR values.
+    """
+    if len(data) < 32:
+        raise EventLogError("event log too short to contain a header event")
+
+    # Legacy header event: pcrIndex(4) eventType(4) digest(20) eventDataSize(4)
+    pcr_index, event_type, _sha1_digest, event_size = struct.unpack_from("<II20sI", data, 0)
+    offset = 32
+    if len(data) < offset + event_size:
+        raise EventLogError("header event data truncated")
+    header_data = data[offset : offset + event_size]
+    offset += event_size
+
+    if pcr_index != 0 or event_type != EV_NO_ACTION:
+        raise EventLogError(
+            f"unexpected header event (pcr={pcr_index}, type=0x{event_type:08x})"
+        )
+    digest_sizes = _parse_spec_id(header_data)
+
+    entries: list[EventLogEntry] = []
+    while offset < len(data):
+        if len(data) < offset + 12:
+            raise EventLogError("event truncated before its digest count")
+        pcr_index, event_type, digest_count = struct.unpack_from("<III", data, offset)
+        offset += 12
+
+        digests: dict[int, bytes] = {}
+        for _ in range(digest_count):
+            if len(data) < offset + 2:
+                raise EventLogError("event truncated before a digest algorithm id")
+            (alg_id,) = struct.unpack_from("<H", data, offset)
+            offset += 2
+            size = digest_sizes.get(alg_id)
+            if size is None:
+                raise EventLogError(
+                    f"event uses algorithm 0x{alg_id:04x}, which the header did not declare"
+                )
+            if len(data) < offset + size:
+                raise EventLogError("event truncated inside a digest")
+            digests[alg_id] = data[offset : offset + size]
+            offset += size
+
+        if len(data) < offset + 4:
+            raise EventLogError("event truncated before its data size")
+        (event_size,) = struct.unpack_from("<I", data, offset)
+        offset += 4
+        if len(data) < offset + event_size:
+            raise EventLogError("event data truncated")
+        event_data = data[offset : offset + event_size]
+        offset += event_size
+
+        entries.append(EventLogEntry(pcr_index, event_type, digests, event_data))
+
+    return entries, digest_sizes
+
+
+def replay_pcrs(
+    entries: list[EventLogEntry], algorithm: int = ALG_SHA256
+) -> dict[int, bytes]:
+    """Replay the log and return the PCR values it implies for one algorithm."""
+    hasher = _HASHES.get(algorithm)
+    if hasher is None:
+        raise EventLogError(f"unsupported digest algorithm 0x{algorithm:04x}")
+    digest_size = hasher().digest_size
+
+    pcrs: dict[int, bytes] = {}
+    for entry in entries:
+        if not entry.extends:
+            continue
+        digest = entry.digests.get(algorithm)
+        if digest is None:
+            raise EventLogError(
+                f"event for PCR {entry.pcr_index} carries no "
+                f"{_ALG_NAMES.get(algorithm, algorithm)} digest"
+            )
+        current = pcrs.get(entry.pcr_index, _starting_value(entry.pcr_index, digest_size))
+        pcrs[entry.pcr_index] = hasher(current + digest).digest()
+    return pcrs
+
+
+def verify_event_log(
+    log: bytes, reported_pcrs: dict[int, bytes], algorithm: int = ALG_SHA256
+) -> ReplayResult:
+    """
+    Replay ``log`` and compare the result against the PCR values reported by the TPM.
+
+    ``reported_pcrs`` maps PCR index to raw digest bytes. A PCR that the log never
+    extends is listed in ``absent_from_log`` rather than silently passing, because a
+    reported value with no corresponding measurement is exactly the case a verifier
+    must not accept.
+    """
+    entries, _sizes = parse_event_log(log)
+    computed = replay_pcrs(entries, algorithm)
+
+    matched: list[int] = []
+    mismatched: list[int] = []
+    absent: list[int] = []
+    for index, value in sorted(reported_pcrs.items()):
+        if index not in computed:
+            absent.append(index)
+        elif computed[index] == value:
+            matched.append(index)
+        else:
+            mismatched.append(index)
+
+    return ReplayResult(
+        algorithm=_ALG_NAMES.get(algorithm, f"0x{algorithm:04x}"),
+        computed=computed,
+        matched=matched,
+        mismatched=mismatched,
+        absent_from_log=absent,
+    )

--- a/tests/unit/test_tcg_event_log.py
+++ b/tests/unit/test_tcg_event_log.py
@@ -1,0 +1,148 @@
+"""Unit tests for TCG event log parsing and PCR replay."""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+
+import pytest
+
+from cmcp_verify.tcg_event_log import (
+    ALG_SHA1,
+    ALG_SHA256,
+    EV_NO_ACTION,
+    EventLogError,
+    parse_event_log,
+    replay_pcrs,
+    verify_event_log,
+)
+
+EV_SEPARATOR = 0x00000004
+EV_EFI_BOOT_SERVICES_APPLICATION = 0x80000003
+
+
+def _header_event() -> bytes:
+    """A legacy header event carrying a Spec ID Event03 declaring SHA-1 and SHA-256."""
+    spec = b"Spec ID Event03\x00"
+    spec += struct.pack("<I", 0)  # platformClass
+    spec += bytes([0, 2, 0, 8])  # minor, major, errata, uintnSize
+    spec += struct.pack("<I", 2)  # two algorithms
+    spec += struct.pack("<HH", ALG_SHA1, 20)
+    spec += struct.pack("<HH", ALG_SHA256, 32)
+    spec += bytes([0])  # vendorInfoSize
+    return struct.pack("<II20sI", 0, EV_NO_ACTION, b"\x00" * 20, len(spec)) + spec
+
+
+def _event(pcr: int, event_type: int, payload: bytes) -> bytes:
+    sha1 = hashlib.sha1(payload).digest()
+    sha256 = hashlib.sha256(payload).digest()
+    out = struct.pack("<III", pcr, event_type, 2)
+    out += struct.pack("<H", ALG_SHA1) + sha1
+    out += struct.pack("<H", ALG_SHA256) + sha256
+    out += struct.pack("<I", len(payload)) + payload
+    return out
+
+
+def _expected_pcr(payloads: list[bytes], start: bytes = b"\x00" * 32) -> bytes:
+    """Independently compute the extend chain, so the test does not reuse the code."""
+    value = start
+    for payload in payloads:
+        value = hashlib.sha256(value + hashlib.sha256(payload).digest()).digest()
+    return value
+
+
+@pytest.fixture
+def log() -> bytes:
+    return (
+        _header_event()
+        + _event(0, EV_EFI_BOOT_SERVICES_APPLICATION, b"firmware-blob")
+        + _event(0, EV_SEPARATOR, b"\x00\x00\x00\x00")
+        + _event(4, EV_EFI_BOOT_SERVICES_APPLICATION, b"bootloader")
+    )
+
+
+def test_parse_returns_every_entry_and_the_declared_algorithms(log: bytes) -> None:
+    entries, sizes = parse_event_log(log)
+
+    assert len(entries) == 3
+    assert sizes == {ALG_SHA1: 20, ALG_SHA256: 32}
+    assert [e.pcr_index for e in entries] == [0, 0, 4]
+
+
+def test_replay_matches_an_independently_computed_extend_chain(log: bytes) -> None:
+    entries, _ = parse_event_log(log)
+
+    pcrs = replay_pcrs(entries, ALG_SHA256)
+
+    assert pcrs[0] == _expected_pcr([b"firmware-blob", b"\x00\x00\x00\x00"])
+    assert pcrs[4] == _expected_pcr([b"bootloader"])
+
+
+def test_no_action_events_do_not_extend() -> None:
+    payloads = [b"real-measurement"]
+    log = (
+        _header_event()
+        + _event(0, EV_NO_ACTION, b"informational")
+        + _event(0, EV_EFI_BOOT_SERVICES_APPLICATION, payloads[0])
+    )
+    entries, _ = parse_event_log(log)
+
+    assert replay_pcrs(entries, ALG_SHA256)[0] == _expected_pcr(payloads)
+
+
+def test_drtm_pcrs_start_at_ff_not_zero() -> None:
+    log = _header_event() + _event(17, EV_EFI_BOOT_SERVICES_APPLICATION, b"drtm")
+    entries, _ = parse_event_log(log)
+
+    expected = _expected_pcr([b"drtm"], start=b"\xff" * 32)
+    assert replay_pcrs(entries, ALG_SHA256)[17] == expected
+
+
+def test_verify_reports_matched_and_mismatched_pcrs(log: bytes) -> None:
+    entries, _ = parse_event_log(log)
+    computed = replay_pcrs(entries, ALG_SHA256)
+
+    result = verify_event_log(log, {0: computed[0], 4: b"\x99" * 32})
+
+    assert result.matched == [0]
+    assert result.mismatched == [4]
+    assert result.verified is False
+
+
+def test_verify_flags_a_reported_pcr_the_log_never_extends(log: bytes) -> None:
+    """A PCR value with no corresponding measurement must not silently pass."""
+    entries, _ = parse_event_log(log)
+
+    result = verify_event_log(log, {0: replay_pcrs(entries, ALG_SHA256)[0], 7: b"\x00" * 32})
+
+    assert result.matched == [0]
+    assert result.absent_from_log == [7]
+    assert result.verified is False
+
+
+def test_verify_passes_when_every_reported_pcr_replays(log: bytes) -> None:
+    entries, _ = parse_event_log(log)
+    computed = replay_pcrs(entries, ALG_SHA256)
+
+    result = verify_event_log(log, computed)
+
+    assert result.verified is True
+    assert result.mismatched == []
+
+
+def test_truncated_log_raises_instead_of_replaying_a_partial_chain(log: bytes) -> None:
+    with pytest.raises(EventLogError):
+        parse_event_log(log[:-7])
+
+
+def test_undeclared_algorithm_is_rejected() -> None:
+    body = struct.pack("<III", 0, EV_SEPARATOR, 1)
+    body += struct.pack("<H", 0x000C) + b"\x00" * 48  # SHA-384, never declared
+    body += struct.pack("<I", 0)
+    with pytest.raises(EventLogError, match="did not declare"):
+        parse_event_log(_header_event() + body)
+
+
+def test_missing_header_is_rejected() -> None:
+    with pytest.raises(EventLogError):
+        parse_event_log(b"\x00" * 64)


### PR DESCRIPTION
First half of #433: the verifier can now replay a TCG event log and check it against reported PCR values.

A PCR digest on its own is opaque. A verifier can tell that platform state differs from a known-good value but not what changed, cannot express policy over individual boot components, and cannot debug a mismatch. Replaying the log is what makes the digest auditable.

`src/cmcp_verify/tcg_event_log.py` adds:

- `parse_event_log` for the crypto-agile format: the legacy header event carrying Spec ID Event03, then TCG_PCR_EVENT2 entries with one digest per declared algorithm.
- `replay_pcrs` to compute the PCR values a log implies.
- `verify_event_log` to compare those against what the TPM reported.

Three correctness points worth reviewing:

- **EV_NO_ACTION entries do not extend.** They are informational. Treating them as measurements produces the wrong chain.
- **DRTM PCRs 17 to 22 start at 0xFF, not zero.** Only a measured launch resets them, so replaying from zero is wrong for exactly the PCRs a DRTM design would rely on.
- **A reported PCR the log never extends is a failure, not a pass.** It is listed in `absent_from_log` and `verified` is False. A reported value with no corresponding measurement is precisely what a verifier must refuse.

Truncation raises rather than returning a partial log, since a silently truncated log replays to wrong values. An event using an algorithm the header did not declare is rejected.

## Tests

10 tests, all passing. The expected PCR values are computed independently in the test rather than by calling `replay_pcrs`, so the test does not validate the implementation against itself.

## Scope

This is the verification half only. Collecting the log at runtime (`/sys/kernel/security/tpm0/binary_bios_measurements` on Linux, Measured Boot APIs on Windows) and shipping it with the evidence changes `AttestationReport` and the TRACE claim, so it lands separately. #433 stays open until then, and nothing calls this module in the gateway path yet.

Refs #433
