### PR TITLE
feat(verify): verify the TPM quote signature, validated on real vTPM hardware

### DIFF
--- a/docs/testing/hardware-validation.md
+++ b/docs/testing/hardware-validation.md
@@ -14,7 +14,7 @@ been verified end to end by `cmcp_verify`, and the run is recorded below.
 |---|---|---|---|---|
 | AMD SEV-SNP (Azure CVM, vTPM-rooted) | Yes | Yes, to the real AMD ARK-Milan root | Yes | **Yes**, 2026-07-27, both from a stored capture and **live inside a running CVM** |
 | Intel TDX (GCP C3, non-paravisor) | Yes | Yes, to the pinned Intel SGX Root CA | Yes | **Yes**, 2026-07-27, capture of 2026-07-21 |
-| TPM 2.0 (Azure vTPM, Trusted Launch) | Yes | Not in Phase 1 (`ek_cert_chain` stays unverified) | Not in Phase 1 | **Partly**, 2026-07-27. Parse and freshness binding yes; signature and chain are out of Phase 1 scope |
+| TPM 2.0 (Azure vTPM, Trusted Launch) | Yes | Not yet (`ek_cert_chain` stays unverified, see #431) | Yes | **Yes**, 2026-07-31. AK-signed quote verified end to end, tampered copies rejected; certificate chain still open |
 | NVIDIA GPU CC (H100/H200) | Not implemented | | | No |
 
 "Verified against real hardware evidence" means the committed verifier accepted a
@@ -143,12 +143,49 @@ the outer `TPM2B_ATTEST` two-byte size prefix, but `tpm2_quote -m` writes a bare
 `TPM2B_ATTEST size field invalid`. Both framings are now accepted, told apart by
 the magic constant.
 
-Still out of scope for Phase 1 and unchanged by this run: the AK signature and
-the EK/AK certificate chain, which stay in `unverified_fields`. Note also that
+The AK signature is now verified (see the 2026-07-31 run below). The EK/AK
+certificate chain remains in `unverified_fields`. Note also that
 Azure's pre-provisioned AK certificate (vTPM NV index `0x01C101D0`, issuer
 `CN=Global Virtual TPM CA - 03`) certifies a different key than an in-guest
 `tpm2_createak` AK, and carries no AIA extension, so its issuing intermediate is
 not fetchable from it.
+
+## TPM 2.0 quote signature, Azure Trusted Launch vTPM, 2026-07-31
+
+Evidence: an AK-signed quote from a `Standard_D2s_v5` Ubuntu 24.04 VM with Trusted
+Launch, vTPM and secure boot enabled, eastus. The guest reports TPM 2.0 with
+`TPM2_PT_MANUFACTURER` = `MSFT`. The attestation key was created with
+`tpm2_createek` followed by `tpm2_createak` (RSA, RSASSA, SHA-256), and the quote
+taken over PCRs 0-7 in the SHA-256 bank under a fresh 32-byte nonce:
+
+```
+tpm2_createek -c ek.ctx -G rsa -u ek.pub
+tpm2_createak -C ek.ctx -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub -n ak.name
+tpm2_readpublic -c ak.ctx -f pem -o ak.pem
+tpm2_quote -c ak.ctx -l sha256:0,1,2,3,4,5,6,7 -q $NONCE -m quote.msg -s quote.sig -g sha256
+```
+
+What the run checks: the `TPMS_ATTEST` magic constant, `extraData` equalling the
+nonce, and the RSASSA-SHA256 signature over the attest blob verifying under the AK
+public key. It also confirms rejection of a one-bit tampered attest blob, a
+tampered signature, and a correct signature checked against a different key.
+
+Unlike the SEV-SNP captures, this vector **is committed**, in
+`tests/unit/test_tpm_quote_signature.py`. It carries no per-CPU hardware
+identifier: the AK public key belongs to a virtual TPM in a VM that no longer
+exists, and the PCR values describe a stock Ubuntu image. Committing it means the
+signature path is exercised on every PR rather than only when a fixture directory
+is set.
+
+```
+pytest tests/unit/test_tpm_quote_signature.py
+```
+
+Not closed by this run: the EK certificate chain (#431). The EK certificate was
+not present at NV index `0x01C00002` on this VM, and as recorded above Azure's
+pre-provisioned AK certificate certifies a different key and carries no AIA
+extension. Binding an in-guest AK to the platform EK needs
+`TPM2_ActivateCredential`, which is the next step for #431.
 
 ## Not yet validated
 

--- a/src/cmcp_verify/tpm.py
+++ b/src/cmcp_verify/tpm.py
@@ -211,3 +211,139 @@ def _parse_tpm2b_attest(
         return False, {"error": f"struct parse error: {exc}"}
     except Exception as exc:  # noqa: BLE001
         return False, {"error": f"unexpected parse error: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# Quote signature verification (issue #429)
+#
+# Parsing an attest blob and comparing its qualifying data proves nothing on its
+# own: both are attacker-controllable. The signature is what binds the blob to a
+# key held in a TPM. Validated against a real Azure Trusted Launch vTPM quote,
+# see docs/testing/hardware-validation.md.
+# ---------------------------------------------------------------------------
+
+# TPM2_ALG_ID values for the signing schemes a quote can use.
+_ALG_RSASSA = 0x0014
+_ALG_RSAPSS = 0x0016
+_ALG_ECDSA = 0x0018
+
+_ALG_SHA1 = 0x0004
+_ALG_SHA256 = 0x000B
+_ALG_SHA384 = 0x000C
+_ALG_SHA512 = 0x000D
+
+_SIG_ALG_NAMES = {
+    _ALG_RSASSA: "rsassa",
+    _ALG_RSAPSS: "rsapss",
+    _ALG_ECDSA: "ecdsa",
+}
+
+
+@dataclass
+class ParsedSignature:
+    """A parsed TPMT_SIGNATURE."""
+
+    sig_alg: int
+    hash_alg: int
+    signature: bytes
+
+
+def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
+    """
+    Parse a TPMT_SIGNATURE as written by ``tpm2_quote -s``.
+
+    Layout: sigAlg (2), hashAlg (2), then the algorithm-specific signature. For RSA
+    that is a TPM2B_PUBLIC_KEY_RSA (size-prefixed). For ECDSA it is two size-prefixed
+    integers, R then S.
+    """
+    if len(blob) < 6:
+        raise ValueError("TPMT_SIGNATURE too short")
+    sig_alg, hash_alg = struct.unpack_from(">HH", blob, 0)
+    offset = 4
+
+    if sig_alg in (_ALG_RSASSA, _ALG_RSAPSS):
+        (size,) = struct.unpack_from(">H", blob, offset)
+        offset += 2
+        if len(blob) < offset + size:
+            raise ValueError("TPMT_SIGNATURE truncated inside the RSA signature")
+        return ParsedSignature(sig_alg, hash_alg, blob[offset : offset + size])
+
+    if sig_alg == _ALG_ECDSA:
+        parts = []
+        for _ in range(2):
+            (size,) = struct.unpack_from(">H", blob, offset)
+            offset += 2
+            if len(blob) < offset + size:
+                raise ValueError("TPMT_SIGNATURE truncated inside the ECDSA signature")
+            parts.append(blob[offset : offset + size])
+            offset += size
+        from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+        r = int.from_bytes(parts[0], "big")
+        s = int.from_bytes(parts[1], "big")
+        return ParsedSignature(sig_alg, hash_alg, encode_dss_signature(r, s))
+
+    raise ValueError(f"unsupported signature algorithm 0x{sig_alg:04x}")
+
+
+def verify_quote_signature(
+    attest: bytes, signature_blob: bytes, ak_public_pem: bytes
+) -> tuple[bool, dict[str, str]]:
+    """
+    Verify a TPMT_SIGNATURE over a TPMS_ATTEST blob using the attestation key.
+
+    ``attest`` must be the exact bytes the TPM signed, which is the bare TPMS_ATTEST
+    written by ``tpm2_quote -m``. Returns (verified, details); never raises.
+    """
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+    hashes_by_alg = {
+        _ALG_SHA1: hashes.SHA1,
+        _ALG_SHA256: hashes.SHA256,
+        _ALG_SHA384: hashes.SHA384,
+        _ALG_SHA512: hashes.SHA512,
+    }
+
+    try:
+        parsed = parse_tpmt_signature(signature_blob)
+    except ValueError as exc:
+        return False, {"signature_error": str(exc)}
+
+    hash_cls = hashes_by_alg.get(parsed.hash_alg)
+    if hash_cls is None:
+        return False, {"signature_error": f"unsupported digest 0x{parsed.hash_alg:04x}"}
+
+    try:
+        key = serialization.load_pem_public_key(ak_public_pem)
+    except Exception as exc:  # noqa: BLE001
+        return False, {"signature_error": f"attestation key not loadable: {exc}"}
+
+    try:
+        if parsed.sig_alg == _ALG_RSASSA:
+            if not isinstance(key, rsa.RSAPublicKey):
+                return False, {"signature_error": "RSASSA signature with a non-RSA key"}
+            key.verify(parsed.signature, attest, padding.PKCS1v15(), hash_cls())
+        elif parsed.sig_alg == _ALG_RSAPSS:
+            if not isinstance(key, rsa.RSAPublicKey):
+                return False, {"signature_error": "RSAPSS signature with a non-RSA key"}
+            key.verify(
+                parsed.signature,
+                attest,
+                padding.PSS(mgf=padding.MGF1(hash_cls()), salt_length=hash_cls.digest_size),
+                hash_cls(),
+            )
+        else:
+            if not isinstance(key, ec.EllipticCurvePublicKey):
+                return False, {"signature_error": "ECDSA signature with a non-EC key"}
+            key.verify(parsed.signature, attest, ec.ECDSA(hash_cls()))
+    except InvalidSignature:
+        return False, {"signature_error": "signature does not verify against the attestation key"}
+    except Exception as exc:  # noqa: BLE001
+        return False, {"signature_error": f"verification error: {exc}"}
+
+    return True, {
+        "signature_algorithm": _SIG_ALG_NAMES.get(parsed.sig_alg, f"0x{parsed.sig_alg:04x}"),
+        "signature_digest": f"0x{parsed.hash_alg:04x}",
+    }

--- a/tests/unit/test_tpm_quote_signature.py
+++ b/tests/unit/test_tpm_quote_signature.py
@@ -1,0 +1,124 @@
+"""Quote signature verification, exercised against a real Azure vTPM capture.
+
+The vector below was produced on 2026-07-31 on a Standard_D2s_v5 Azure VM with
+Trusted Launch, vTPM and secure boot enabled, Ubuntu 24.04, TPM manufacturer MSFT.
+The AK was created with tpm2_createek followed by tpm2_createak (RSA, RSASSA,
+SHA-256) and the quote taken over PCRs 0-7 under a fresh 32-byte nonce.
+
+Unlike the SEV-SNP captures, this vector is committed. It carries no per-CPU
+hardware identifier: the AK public key belongs to a virtual TPM in a VM that no
+longer exists, and the PCR values describe a stock Ubuntu image. Committing it
+means signature verification is exercised on every PR rather than only when
+someone sets a fixture directory.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from cmcp_verify.tpm import parse_tpmt_signature, verify_quote_signature
+
+# Bare TPMS_ATTEST as written by `tpm2_quote -m`.
+QUOTE_ATTEST = base64.b64decode(
+    "/1RDR4AYACIAC1Gr2BpHLuEP6q3wUzFvxZPNyfm9bw98RBelxxduCCr7ACBJgPpvWQ1l+6Fc3u8LC7Au"
+    "jPFVBEcFsa8HAb+gsuMjlgAAAAAAAeu7AAAAAwAAAAABICADEgASAAQAAAABAAsD/wAAACDUvEYCCXOU"
+    "AOzy8r898/XnrH99z1VrFNtVJDUg6kRSag=="
+)
+
+# TPMT_SIGNATURE as written by `tpm2_quote -s`.
+QUOTE_SIGNATURE = base64.b64decode(
+    "ABQACwEASCi0Ht6m6zPVnt4HXAahI4V4DV9nHbjWCJT0kYZVtUUS7BLmv7pt/dY2tNjWTJXAZKXJCX5i"
+    "43eo53eVzKjHN3AzFdvkLEK/ahjEQ2/D+Frb+sLe0FlfhvzgfgUyoQCDs9krmCnMy18fDjxOSO+Nm2uy"
+    "Wyg38ZTUpR1fUmjb68n9WHbPR3QZV9nNI4G0IW3AgRhcHZ7gmb9WJdLLSRdzfFJ7wDWEsAFcrtGiycc0"
+    "iRXbCOBh0xTeDTlIWn9ljEYTvDlr8duW3c2fT08ZcV4vxJA6Wa8cr1QQjpd6s1/UO0XaYXneCHxoGI1u"
+    "fbEoR4QA3qTPYNCSKNgyHH9GdV1stg=="
+)
+
+AK_PUBLIC_PEM = base64.b64decode(
+    "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFN"
+    "SUlCQ2dLQ0FRRUF5K3pCVWdBQTcvZW5CMEdyWmQrdgo4OFgvd3F0U2VKZ2dCczBZU0lkcW5HLzF4SjNy"
+    "MEpTc1hyZnJkSkpnU1BwL2t4bzY5eWVtMlhjUlBiVGIzbHQwCjJsakVyaTZlUjhjbEt5RmNFUFFMbUZC"
+    "Qmg3RU5Lai9KV3FnWnJINHhLdW93Y1BlR0ltajJ2S1hlV21LclVmb1gKVU1wdmI3eTUyeTJpNU4vTERQ"
+    "UUcrYnI5NFhyZlNQNFNKTmVJKzlWUUM1Q1ZzRDM1QmZEZncwOHNYNGd6dG5FSwp4SUpyZGFVRUgxRjFs"
+    "MkxPUjJoT0FQcjI5MmxrYUlvdTVoNHF6Y3hwbm5NTTN1djF6Q2Y1ZU5rZ2QwZ1FLdUllCjZ2T2JMcStT"
+    "ZURPWndmYzBTSzRIUjBRVEtNcnhEbSs5eEdnU3ZYeUlFVnVTOExwZzBsZGRYU1Uzd0xpUU5Td1EKOHdJ"
+    "REFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+)
+
+NONCE = bytes.fromhex("4980fa6f590d65fba15cdeef0b0bb02e8cf155044705b1af0701bfa0b2e32396")
+
+
+def test_parses_a_real_tpmt_signature() -> None:
+    parsed = parse_tpmt_signature(QUOTE_SIGNATURE)
+
+    assert parsed.sig_alg == 0x0014  # TPM_ALG_RSASSA
+    assert parsed.hash_alg == 0x000B  # TPM_ALG_SHA256
+    assert len(parsed.signature) == 256
+
+
+def test_real_hardware_quote_signature_verifies() -> None:
+    verified, details = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, AK_PUBLIC_PEM)
+
+    assert verified is True
+    assert details["signature_algorithm"] == "rsassa"
+
+
+def test_the_quote_carries_the_nonce_it_was_taken_under() -> None:
+    """extraData sits after the qualifiedSigner name; the signature is what makes it
+    meaningful, since both fields are otherwise attacker-controllable."""
+    assert NONCE in QUOTE_ATTEST
+
+
+@pytest.mark.parametrize("flip", [0, 40, -1])
+def test_a_tampered_attest_is_rejected(flip: int) -> None:
+    tampered = bytearray(QUOTE_ATTEST)
+    tampered[flip] ^= 0x01
+
+    verified, details = verify_quote_signature(bytes(tampered), QUOTE_SIGNATURE, AK_PUBLIC_PEM)
+
+    assert verified is False
+    assert "does not verify" in details["signature_error"]
+
+
+def test_a_tampered_signature_is_rejected() -> None:
+    tampered = bytearray(QUOTE_SIGNATURE)
+    tampered[-1] ^= 0x01
+
+    verified, _ = verify_quote_signature(QUOTE_ATTEST, bytes(tampered), AK_PUBLIC_PEM)
+
+    assert verified is False
+
+
+def test_a_different_key_does_not_verify() -> None:
+    """A quote is only evidence if it verifies under the key the relying party expects."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+    other_pem = other.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    verified, _ = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, other_pem)
+
+    assert verified is False
+
+
+def test_an_unloadable_key_fails_closed() -> None:
+    verified, details = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, b"not a pem")
+
+    assert verified is False
+    assert "not loadable" in details["signature_error"]
+
+
+def test_unsupported_signature_algorithm_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported signature algorithm"):
+        parse_tpmt_signature(b"\x00\x99\x00\x0b\x00\x04abcd")
+
+
+def test_truncated_signature_is_rejected() -> None:
+    with pytest.raises(ValueError, match="truncated"):
+        parse_tpmt_signature(QUOTE_SIGNATURE[:20])


### PR DESCRIPTION
Closes #429. Verified against a real Azure Trusted Launch vTPM, per the rule in `docs/testing/hardware-validation.md`.

## The gap

`verify_tpm_measurement` parsed the attest blob and compared `qualifyingData` to the expected nonce. Both of those fields are attacker-controllable, so on their own they prove nothing. The signature is the only thing binding the blob to a key held in a TPM, and it was neither retained by the collector nor checked by the verifier.

## What this adds

`parse_tpmt_signature` handles RSASSA, RSAPSS, and ECDSA, including the ECDSA R/S pair that has to be re-encoded as DSS for verification. `verify_quote_signature` verifies a TPMT_SIGNATURE over a TPMS_ATTEST under the attestation key, and fails closed on every error path rather than raising.

## Hardware validation

Captured on a `Standard_D2s_v5` Ubuntu 24.04 VM, Trusted Launch with vTPM and secure boot, eastus. Guest reports TPM 2.0, `TPM2_PT_MANUFACTURER` = `MSFT`. AK created with `tpm2_createek` then `tpm2_createak` (RSA, RSASSA, SHA-256), quote over PCRs 0-7 under a fresh 32-byte nonce.

Confirmed on that capture: magic `0xff544347`, type `0x8018` ATTEST_QUOTE, `extraData` equals the nonce, and the signature verifies. A one-bit flip in the attest, a flipped signature byte, and a correct signature checked against a different key are all rejected.

**The vector is committed**, unlike the SEV-SNP captures. It carries no per-CPU identifier: the AK public key belongs to a virtual TPM in a VM that no longer exists and the PCRs describe a stock Ubuntu image. Committing it means the signature path runs on every PR instead of only when someone sets a fixture directory. 11 tests.

`docs/testing/hardware-validation.md` is updated: the TPM row moves from "Partly" to "Yes" for report signature, with the run recorded.

## Still open

The EK certificate chain (#431). The EK certificate was not at NV `0x01C00002` on this VM, and as the doc already recorded, Azure's pre-provisioned AK certificate certifies a different key and has no AIA extension. Binding an in-guest AK to the platform EK needs `TPM2_ActivateCredential`, which is the next step.

The runtime collector still does not retain the signature; that is #430 and lands next, validated the same way.
