### PR TITLE
feat(tee): measure the gateway into a TPM NV extend index (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The gateway is now measured into a TPM NV extend index at startup (#432).** PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and the bootloader, and there was no `PCR_Extend` anywhere in the codebase, so replacing the policy bundle or the gateway itself produced an identical measurement and the TPM enforced nothing about the thing the TPM path exists to protect. `cmcp_runtime.tee.measurement` digests the installed distributions' recorded per-file hashes (pip's `RECORD`), the policy bundle bytes, and the resolved configuration with secrets excluded, then extends that digest into NV `0x01500432` before the gateway serves traffic. `RuntimeContext` carries the result.
+
+  An NV index with `TPM_NT_EXTEND` rather than an application PCR, per the decision on #432: PCR 23 and PCR 16 are both resettable from locality 0, so an adversary with local code execution could reset and re-extend a chosen value, which is exactly the adversary this tier addresses. Extend writes are one-way (`new = H(old || data)`), so forgery needs a preimage, which is what carries the security argument rather than the write policy the original proposal called for.
+
+  Scope is deliberately honest about two things. Measuring dependencies means an editable install, which has no `RECORD`, cannot be measured: that is fatal in production and a warning under `CMCP_DEV_MODE`, rather than a confident digest over an unknown subset of code. And because extends accumulate across reboots, the index is a hash chain over every start rather than a predictable absolute value, so the collector reports the value both before and after the extend and continuity is what a relying party checks.
+
+### Changed
+
+- **RFC section 5 P2 (`docs/spec/tpm-security-model.md`) rewritten** to record the NV-extend decision instead of leading with the application PCR it rejected, along with the residual-risk analysis: `TPM2_NV_UndefineSpace` with owner auth can erase the measurement, which guest root holds on Azure, so the property is tamper-evident rather than tamper-proof. Section 4.3 now separates what landed from what has not: the index value travels as an ordinary NV read, which the quote signature does not cover, so it is a local integrity control and not yet remote-verifiable evidence. `TPM2_NV_Certify` is the primitive that closes it; committing an NV read into the quote's qualifying data is not sound, because the collector would be asserting the value it read.
+
 ### Changed
 
 - **BREAKING: TRACE Claims now carry the v0.2 profile** `tag:agentrust-io.com,2026:trace-v0.2`, and `agentrust-trace` is pinned to `>=0.5`. The v0.1 URI named `agentrust.io`, a domain this project never controlled, which RFC 4151 does not permit for a tag URI (agentrust-io/trace-spec#107). A verifier on the v0.2 suite rejects a v0.1 claim, so producers and verifiers move together. Nothing else about the claim format changed.

--- a/docs/spec/tpm-security-model.md
+++ b/docs/spec/tpm-security-model.md
@@ -43,9 +43,11 @@ Consequence: any code executing in the gateway process can synthesise attestatio
 
 No AK is provisioned. `ek_cert_chain` is unconditionally listed as unverified with the note `requires_ca_lookup`. Even with a verified signature, nothing distinguishes a discrete TPM from a software emulator or an attacker-generated key.
 
-### 4.3 The gateway is not measured (#432)
+### 4.3 The gateway is not measured (#432, measurement landed, binding open)
 
-PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and bootloader. There is no `PCR_Extend` anywhere in the codebase. Replacing the policy bundle or the gateway binary produces an identical measurement, so the stated purpose of the TPM path, protecting policy from tampering, is not enforced by the TPM.
+PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and bootloader. Replacing the policy bundle or the gateway binary produced an identical measurement, so the stated purpose of the TPM path, protecting policy from tampering, was not enforced by the TPM.
+
+The gateway is now measured into an NV extend index at startup, before it serves traffic, per P2 below. What is still missing is the signed binding: the index value travels as an ordinary NV read, which the quote signature does not cover, so a verifier cannot yet distinguish a genuine value from one a compromised gateway reported. `TPM2_NV_Certify` closes that, and until it does the measurement is a local integrity control rather than remote-verifiable evidence.
 
 ### 4.4 PCR digests are uninterpretable (#433)
 
@@ -73,13 +75,19 @@ Ordered by trust gained per unit of effort.
 
 **P1. Provision an AK and validate its chain (#431).** Restricted signing AK certified against the EK, EK certificate shipped with the evidence, chain verified to a TPM vendor root. Open dependency: vendor CA root distribution.
 
-**P2. Measure the gateway (#432).** Extend an application PCR at startup with a digest over binary, policy bundle, and effective configuration, and include it in the quote selection.
+**P2. Measure the gateway (#432).** Extend an **NV index defined with `TPM_NT_EXTEND`** at startup with a digest over installed code, the policy bundle, and the effective configuration, before the gateway serves traffic.
 
-Important caveat that changes the design. Per the TCG PC Client Platform TPM Profile, PCR 23 is Application Support and PCR 16 is Debug, and **both are resettable from locality 0**. An adversary with local code execution can reset PCR 23 and re-extend a value of their choosing, so an application PCR alone is advisory, not tamper-resistant, against precisely the adversary this tier is meant to address. Options:
+**Decided: NV extend index, not an application PCR.** Per the TCG PC Client Platform TPM Profile, PCR 23 is Application Support and PCR 16 is Debug, and **both are resettable from locality 0**. An adversary with local code execution can reset PCR 23 and re-extend a value of their choosing, so an application PCR is advisory, not tamper-resistant, against precisely the adversary this tier exists to address. An NV extend index is not resettable from locality 0. The alternatives considered and not chosen were sealing the signing key to a policy spanning the application PCR and non-resettable SRTM PCRs (kept as P4, which is enforcement rather than measurement) and DRTM (unavailable on the platforms in scope).
 
-- An NV extend index (`TPM_NT_EXTEND`) with a write policy, which is not resettable from locality 0. Preferred.
-- Sealing the signing key to a policy spanning the application PCR and non-resettable SRTM PCRs, so a reset breaks unseal.
-- DRTM where the platform supports it.
+What the extend semantics buy, and what they do not:
+
+- **Forgery is infeasible without a write policy.** `TPM_NT_EXTEND` writes are one-way, `new = H(old || data)`, so an adversary who can call `TPM2_NV_Extend` can append but cannot set the index to a chosen value without a preimage. The write policy the original proposal called for is therefore not what carries the security argument.
+- **Destruction is possible, but not silent.** `TPM2_NV_UndefineSpace` then a fresh define resets the index, and owner authorization permits it. Guest root holds owner auth on an Azure VM. A redefined index reads back with `TPMA_NV_WRITTEN` clear until written again, so the erasure is visible. The property claimed is therefore **tamper-evident, not tamper-proof**. Tamper-proof needs the platform hierarchy, which a guest VM cannot reach; that is the same client-firmware dependency in section 6.
+- **The value is not predictable.** Extends accumulate and NV is persistent, so after N gateway starts the index is a hash chain over all N digests rather than `H(0 || digest)`. A verifier cannot recompute it from the current gateway digest. The collector therefore reports the index value both before and after the extend, so continuity (`after == H(before || digest)`) is checkable, which is the hash-chain idiom the audit log already uses.
+
+What is measured is the installed distributions' recorded per-file hashes (pip's `RECORD` metadata), plus the policy bundle bytes and the resolved configuration with secrets excluded. RECORD covers dependencies, so a swapped transitive package is caught; measuring only cMCP's own source would report an identical digest for it. An editable install has no RECORD, so the measurement is refused rather than computed over an unknown subset: fatal in production, a warning under `CMCP_DEV_MODE`.
+
+**Remaining for P2:** an NV read is not covered by the quote signature, so the value needs its own signed freshness argument. `TPM2_NV_Certify` is the primitive: the TPM signs a `TPM_ST_ATTEST_NV` structure over the index contents with the AK, under caller-supplied qualifying data. Reading the index and committing the result into the quote's qualifying data is **not** sound, because the collector would be asserting the value it read and a compromised gateway is the adversary. That half also needs a `TPM_ST_ATTEST_NV` parser, which agent-manifest does not currently model.
 
 **P3. Ship the TCG event log (#433).** Collect and replay it so evidence is interpretable and policy can name specific components.
 

--- a/src/cmcp_runtime/startup.py
+++ b/src/cmcp_runtime/startup.py
@@ -32,6 +32,13 @@ from cmcp_runtime.errors import (
 from cmcp_runtime.policy.bundle import PolicyStore, load_policy_bundle
 from cmcp_runtime.tee.base import AttestationReport, TEEProvider
 from cmcp_runtime.tee.detect import detect_provider
+from cmcp_runtime.tee.measurement import (
+    ExtendResult,
+    GatewayMeasurement,
+    MeasurementUnavailable,
+    extend_gateway_measurement,
+    gateway_measurement,
+)
 from cmcp_runtime.tee.nras import AppraisalResult, try_appraise
 from cmcp_runtime.tee.spiffe import SpiffeClientResult, fetch_svid
 
@@ -63,6 +70,11 @@ class RuntimeContext:
     spiffe: SpiffeClientResult | None = None
     nras_appraisal: AppraisalResult | None = None
     agent_manifest: AgentManifestBinding | None = None
+    # #432: the gateway's own measurement, and the NV extend index state around it.
+    # Both None when the platform has no TPM, or in dev mode where an editable
+    # install makes the code digest uncomputable.
+    gateway_measurement: GatewayMeasurement | None = None
+    measurement_extend: ExtendResult | None = None
 
 
 def _jwk_thumbprint_sha256(x_b64url: str) -> bytes:
@@ -84,6 +96,83 @@ def _fatal(code: str, message: str, **fields: Any) -> None:
         **fields,
     }
     logger.critical("%s", entry)
+
+
+def _measure_gateway(
+    config: Config, tee_provider: TEEProvider
+) -> tuple[GatewayMeasurement | None, ExtendResult | None]:
+    """Measure the gateway and extend it into the TPM NV index (#432).
+
+    Returns ``(None, None)`` when the platform has no TPM to extend into, which is
+    not a failure: the SEV-SNP and TDX providers commit their own binding through
+    the report's own fields.
+
+    A TPM platform that cannot be measured is fatal in production and a warning in
+    dev mode, matching how ``CMCP_POLICY_HASH`` is handled. The dev-mode escape
+    matters in practice because an editable install has no ``RECORD`` metadata, so
+    the code digest is genuinely uncomputable there rather than merely inconvenient.
+    """
+    if tee_provider.provider_name() != "tpm":
+        logger.debug(
+            "Gateway measurement skipped: provider %s does not use an NV extend index",
+            tee_provider.provider_name(),
+        )
+        return None, None
+
+    def _degrade(exc: MeasurementUnavailable) -> tuple[None, None]:
+        if config.dev_mode:
+            logger.warning(
+                "Gateway measurement unavailable (%s): %s. Continuing because "
+                "CMCP_DEV_MODE is set; the TPM will not attest what code is running.",
+                exc,
+                exc.detail or "",
+            )
+            return None, None
+        _fatal(
+            "MEASUREMENT_UNAVAILABLE",
+            f"the gateway could not be measured into the TPM: {exc}",
+            detail=exc.detail or "",
+            action="startup_aborted",
+        )
+        sys.exit(1)
+
+    try:
+        measurement = gateway_measurement(config)
+    except MeasurementUnavailable as exc:
+        return _degrade(exc)
+
+    try:
+        from tpm2_pytss.ESAPI import ESAPI
+    except ImportError as exc:
+        return _degrade(
+            MeasurementUnavailable(
+                "tpm2-pytss is required to extend the measurement NV index",
+                detail=str(exc),
+            )
+        )
+
+    try:
+        with ESAPI() as ectx:
+            extend_result = extend_gateway_measurement(ectx, measurement)
+    except MeasurementUnavailable as exc:
+        return _degrade(exc)
+    except Exception as exc:  # noqa: BLE001 - any TPM fault means unmeasured
+        return _degrade(
+            MeasurementUnavailable(
+                "the TPM could not be opened to extend the measurement",
+                detail=f"{type(exc).__name__}: {exc}",
+            )
+        )
+
+    logger.info(
+        "Gateway measured: %s (code=%s policy=%s config=%s) into NV %#x",
+        measurement.digest_hex,
+        measurement.components["code"][:12],
+        measurement.components["policy"][:12],
+        measurement.components["config"][:12],
+        extend_result.index,
+    )
+    return measurement, extend_result
 
 
 def run_startup(config_path: str) -> RuntimeContext:
@@ -117,6 +206,13 @@ def run_startup(config_path: str) -> RuntimeContext:
             action="startup_aborted",
         )
         sys.exit(1)
+
+    # Step 2b (#432): measure the gateway into the NV extend index BEFORE the
+    # attestation report is produced, so the evidence reflects the code, policy, and
+    # config that are actually about to serve traffic. PCRs 0-7 cover firmware and
+    # the bootloader only, so without this the TPM enforced nothing about the
+    # gateway itself and a swapped policy bundle measured identically.
+    measurement, extend_result = _measure_gateway(config, tee_provider)
 
     # Step 3: signing key
     signing_key = SigningKey()
@@ -334,4 +430,6 @@ def run_startup(config_path: str) -> RuntimeContext:
         spiffe=spiffe_result,
         nras_appraisal=nras_appraisal,
         agent_manifest=agent_manifest,
+        gateway_measurement=measurement,
+        measurement_extend=extend_result,
     )

--- a/src/cmcp_runtime/tee/measurement.py
+++ b/src/cmcp_runtime/tee/measurement.py
@@ -1,0 +1,407 @@
+"""Measure the gateway into a TPM NV extend index (issue #432, RFC #439 P2).
+
+PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and the
+bootloader. They do not cover the cMCP gateway, its policy bundle, or its
+effective configuration, so replacing any of those produced an identical
+measurement and the TPM enforced nothing about the thing the TPM path exists to
+protect.
+
+## Why an NV extend index and not an application PCR
+
+Per the TCG PC Client Platform TPM Profile, PCR 23 is Application Support and PCR
+16 is Debug, and **both are resettable from locality 0**. An adversary with local
+code execution can reset PCR 23 and re-extend a value of their choosing, which is
+precisely the adversary this tier exists to address, so an application PCR is
+advisory rather than tamper-resistant. An NV index defined with ``TPM_NT_EXTEND``
+is not resettable from locality 0.
+
+## What this actually guarantees, and what it does not
+
+``TPM_NT_EXTEND`` writes are one-way: ``new = H(old || data)``. An adversary who
+can call ``TPM2_NV_Extend`` can therefore append values but **cannot set the index
+to a chosen value** without finding a preimage. That is what makes the measurement
+meaningful without depending on a write policy.
+
+The residual risk is destruction, not forgery. ``TPM2_NV_UndefineSpace`` followed
+by a fresh define resets the index, and owner authorization permits it. Guest root
+holds owner auth on an Azure VM, so a sufficiently privileged adversary can erase
+the measurement. What they cannot do is erase it *silently*: a redefined index
+reads back with ``TPMA_NV_WRITTEN`` clear until it is written again, and its
+recorded provisioning is gone. So the property claimed here is **tamper-evident,
+not tamper-proof**. Making it tamper-proof needs the platform hierarchy, which a
+guest VM cannot reach, and that is the same client-firmware dependency that gates
+the AI PC tier.
+
+## Predictability is deliberately left to the verifier
+
+Because extends accumulate and NV is persistent across reboots, the index value
+after N gateway starts is a hash chain over all N digests, not ``H(0 ||
+gateway_digest)``. A verifier therefore cannot recompute the expected value from
+the current gateway digest alone. :func:`extend_gateway_measurement` returns the
+value both before and after the extend so a relying party can check continuity
+(``after == H(before || digest)``), which is the same hash-chain idiom cMCP already
+uses for the audit log. Turning that into signed evidence is the second half of
+#432: an NV read is not covered by the quote signature, so it needs
+``TPM2_NV_Certify`` to be signed and fresh.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from importlib.metadata import Distribution, distributions
+from pathlib import Path
+from typing import Any
+
+from cmcp_runtime.errors import CMCPError
+
+logger = logging.getLogger(__name__)
+
+# An extend index holds exactly one digest of its nameAlg, which is SHA-256 here.
+_EXTEND_INDEX_SIZE = 32
+
+# Owner-defined NV index holding the gateway measurement. Outside the TCG-reserved
+# 0x01C00000-0x01C3FFFF range so it cannot collide with platform certificates.
+DEFAULT_MEASUREMENT_NV_INDEX = 0x01500432
+
+# Domain separator, versioned because the digest is compared across builds.
+_DIGEST_PREFIX = b"cmcp-gateway-measurement-v1"
+
+# Config keys never measured: they carry secrets, or they vary per process without
+# changing what code or policy is running.
+_CONFIG_SECRET_KEYS = frozenset({"bearer_token"})
+
+
+class MeasurementUnavailable(CMCPError):
+    """The gateway could not be measured, so there is nothing to extend."""
+
+    code = "MEASUREMENT_UNAVAILABLE"
+    http_status = 500
+
+
+@dataclass(frozen=True)
+class GatewayMeasurement:
+    """The digest extended into the NV index, plus the inputs that produced it.
+
+    ``components`` exists so a mismatch is debuggable. Without it a verifier only
+    learns that the gateway changed, never which of code, policy, or config did,
+    which is the same complaint #433 makes about bare PCR digests.
+    """
+
+    digest: bytes
+    components: dict[str, str]
+
+    @property
+    def digest_hex(self) -> str:
+        return "sha256:" + self.digest.hex()
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def code_digest() -> str:
+    """Digest every installed distribution by its recorded per-file hashes.
+
+    Uses the ``RECORD`` metadata pip already writes, which lists a hash per
+    installed file. That covers dependencies, not just cMCP's own packages: a
+    swapped transitive package is the more likely supply-chain path and measuring
+    only cMCP's own source would report an identical digest for it.
+
+    Raises :class:`MeasurementUnavailable` when a distribution has no ``RECORD``
+    (an editable or ``pth``-based install). That failure is deliberate rather than
+    skipped: silently measuring a subset would report a confident digest over an
+    unknown amount of code.
+    """
+    entries: list[str] = []
+    missing: list[str] = []
+
+    for dist in sorted(distributions(), key=_dist_sort_key):
+        name = dist.metadata["Name"] or "unknown"
+        version = dist.version
+        file_hashes = _record_hashes(dist)
+        if file_hashes is None:
+            missing.append(f"{name} {version}")
+            continue
+        entries.append(
+            json.dumps(
+                {"name": name, "version": version, "files": file_hashes},
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+
+    if missing:
+        raise MeasurementUnavailable(
+            "the gateway cannot be measured: some installed distributions have no "
+            "RECORD metadata, so their contents are unknown",
+            detail=(
+                f"{len(missing)} distribution(s) without RECORD: {', '.join(sorted(missing)[:5])}"
+                f"{' ...' if len(missing) > 5 else ''}. This is normal for an editable "
+                "install ('pip install -e'); measure a wheel or sdist install instead."
+            ),
+        )
+    if not entries:
+        raise MeasurementUnavailable(
+            "the gateway cannot be measured: no installed distributions were found"
+        )
+
+    return _sha256_hex("\n".join(entries).encode())
+
+
+def _dist_sort_key(dist: Distribution) -> tuple[str, str]:
+    """Sort by (name, version) so the digest does not depend on scan order."""
+    return ((dist.metadata["Name"] or "").lower(), dist.version or "")
+
+
+def _record_hashes(dist: Distribution) -> dict[str, str] | None:
+    """Return ``{path: hash}`` from a distribution's RECORD, or None if absent.
+
+    RECORD is CSV: ``path,hash,size``, where hash is ``<algo>=<urlsafe-b64-nopad>``.
+    Entries with an empty hash (RECORD itself, and generated scripts) are kept with
+    an explicit marker rather than dropped, so a file gaining or losing a hash is
+    visible in the digest instead of silently ignored.
+    """
+    try:
+        record = dist.read_text("RECORD")
+    except Exception as exc:  # noqa: BLE001 - unreadable metadata reads as absent
+        logger.debug("RECORD unreadable for %s: %s", dist.metadata["Name"], exc)
+        return None
+    if not record:
+        return None
+
+    hashes: dict[str, str] = {}
+    for row in csv.reader(record.splitlines()):
+        if not row:
+            continue
+        path = row[0]
+        digest = row[1] if len(row) > 1 and row[1] else "<none>"
+        hashes[path] = digest
+    return hashes or None
+
+
+def policy_digest(policy_bundle_path: str) -> str:
+    """Digest the policy bundle's file bytes.
+
+    Deliberately independent of ``load_policy_bundle``'s canonical bundle hash:
+    that runs at startup step 4, while the measurement has to be extended before
+    the attestation report is produced at step 2. This reads bytes off disk and
+    needs nothing validated first.
+    """
+    root = Path(policy_bundle_path)
+    if not root.exists():
+        raise MeasurementUnavailable(
+            "the policy bundle path does not exist, so policy cannot be measured",
+            detail=f"path={policy_bundle_path}",
+        )
+
+    files = [root] if root.is_file() else sorted(p for p in root.rglob("*") if p.is_file())
+    if not files:
+        raise MeasurementUnavailable(
+            "the policy bundle directory is empty, so policy cannot be measured",
+            detail=f"path={policy_bundle_path}",
+        )
+
+    parts = [
+        json.dumps(
+            {"path": p.relative_to(root).as_posix() if root.is_dir() else p.name,
+             "sha256": _sha256_hex(p.read_bytes())},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        for p in files
+    ]
+    return _sha256_hex("\n".join(parts).encode())
+
+
+def config_digest(config: Any) -> str:
+    """Digest the effective configuration, excluding secrets.
+
+    The bearer token is excluded: it authenticates callers rather than describing
+    what is running, and extending a secret's digest into an index that is read
+    back in evidence would leak an oracle for it.
+    """
+    return _sha256_hex(json.dumps(_config_payload(config), separators=(",", ":"), sort_keys=True).encode())
+
+
+def _config_payload(value: Any, *, _depth: int = 0) -> Any:
+    """Reduce a config dataclass to canonical JSON, dropping secret keys."""
+    if _depth > 8:
+        return "<max-depth>"
+    if hasattr(value, "__dataclass_fields__"):
+        return {
+            name: _config_payload(getattr(value, name), _depth=_depth + 1)
+            for name in sorted(value.__dataclass_fields__)
+            if name not in _CONFIG_SECRET_KEYS
+        }
+    if isinstance(value, dict):
+        return {
+            str(k): _config_payload(v, _depth=_depth + 1)
+            for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))
+            if str(k) not in _CONFIG_SECRET_KEYS
+        }
+    if isinstance(value, list | tuple):
+        return [_config_payload(v, _depth=_depth + 1) for v in value]
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    # Enums and anything else: their stable string form.
+    return getattr(value, "value", None) if hasattr(value, "value") else str(value)
+
+
+def gateway_measurement(config: Any) -> GatewayMeasurement:
+    """Compute the digest over installed code, the policy bundle, and the config."""
+    components = {
+        "code": code_digest(),
+        "policy": policy_digest(config.policy_bundle_path),
+        "config": config_digest(config),
+    }
+    canonical = json.dumps(components, separators=(",", ":"), sort_keys=True).encode()
+    return GatewayMeasurement(
+        digest=hashlib.sha256(_DIGEST_PREFIX + b"|" + canonical).digest(),
+        components=components,
+    )
+
+
+@dataclass(frozen=True)
+class ExtendResult:
+    """The NV index state around a measurement extend.
+
+    ``before`` and ``after`` are both returned so a relying party can check
+    ``after == H(before || digest)`` rather than needing to predict an absolute
+    value, which is impossible once extends accumulate across reboots.
+    """
+
+    index: int
+    before: bytes
+    after: bytes
+    provisioned: bool  # True when this call had to define the index first
+
+    def chains_from(self, digest: bytes) -> bool:
+        """True when ``after`` is ``before`` extended by ``digest``.
+
+        ``TPM_NT_EXTEND`` computes ``H(old || data)`` with the index's nameAlg,
+        which this module always defines as SHA-256.
+        """
+        return self.after == hashlib.sha256(self.before + digest).digest()
+
+
+def extend_gateway_measurement(
+    ectx: Any, measurement: GatewayMeasurement, *, index: int = DEFAULT_MEASUREMENT_NV_INDEX
+) -> ExtendResult:
+    """Extend ``measurement`` into the NV index, defining it first if absent.
+
+    Returns the value before and after. Raises :class:`MeasurementUnavailable` if
+    the index cannot be defined, extended, or read back, so a gateway never
+    proceeds believing it was measured when it was not.
+    """
+    from tpm2_pytss.constants import ESYS_TR
+
+    provisioned = False
+    handle = _nv_handle(ectx, index)
+    if handle is None:
+        _define_extend_index(ectx, index)
+        provisioned = True
+        handle = _nv_handle(ectx, index)
+        if handle is None:
+            raise MeasurementUnavailable(
+                "the measurement NV index could not be read back after defining it",
+                detail=f"index={index:#x}",
+            )
+
+    before = _read_extend_index(ectx, handle)
+    try:
+        ectx.nv_extend(handle, measurement.digest, auth_handle=ESYS_TR.OWNER)
+    except Exception as exc:  # noqa: BLE001
+        raise MeasurementUnavailable(
+            "TPM2_NV_Extend failed, so the gateway is not measured",
+            detail=f"index={index:#x}: {type(exc).__name__}: {exc}",
+        ) from exc
+
+    after = _read_extend_index(ectx, handle)
+    result = ExtendResult(index=index, before=before, after=after, provisioned=provisioned)
+
+    if not result.chains_from(measurement.digest):
+        raise MeasurementUnavailable(
+            "the NV index value does not chain from its previous value, so the "
+            "measurement that was written is not the one computed",
+            detail=(
+                f"index={index:#x} before={before.hex()} after={after.hex()} "
+                f"digest={measurement.digest.hex()}"
+            ),
+        )
+    logger.info(
+        "Gateway measured into NV %#x (%s): %s -> %s",
+        index,
+        "provisioned" if provisioned else "existing index",
+        before.hex()[:16],
+        after.hex()[:16],
+    )
+    return result
+
+
+def _nv_handle(ectx: Any, index: int) -> Any | None:
+    """Return an ESYS handle for a defined NV index, or None when undefined."""
+    try:
+        return ectx.tr_from_tpmpublic(index)
+    except Exception as exc:  # noqa: BLE001 - an undefined index is expected
+        logger.debug("NV index %#x is not defined: %s", index, exc)
+        return None
+
+
+def _read_extend_index(ectx: Any, handle: Any) -> bytes:
+    """Read an extend index's current digest, treating never-written as all zeroes.
+
+    A freshly defined extend index reads back as ``TPM_RC_NV_UNINITIALIZED`` until
+    its first write, which is the same starting state as a reset PCR, so it is
+    reported as zeroes rather than as an error.
+    """
+    try:
+        public, _ = ectx.nv_read_public(handle)
+        size = int(public.nvPublic.dataSize)
+    except Exception as exc:  # noqa: BLE001
+        raise MeasurementUnavailable(
+            "the measurement NV index public area could not be read",
+            detail=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    try:
+        return bytes(ectx.nv_read(handle, size, 0))
+    except Exception as exc:  # noqa: BLE001 - uninitialized reads as zeroes
+        logger.debug("NV index reads as uninitialized: %s", exc)
+        return bytes(size)
+
+
+def _define_extend_index(ectx: Any, index: int) -> None:
+    """Define ``index`` as a ``TPM_NT_EXTEND`` index under the owner hierarchy.
+
+    ``TPM_NT_EXTEND`` is the whole point: writes hash into the existing value
+    instead of replacing it, so the index cannot be set to a chosen value and it is
+    not resettable from locality 0 the way PCR 16 and PCR 23 are.
+    """
+    from tpm2_pytss.constants import ESYS_TR, TPM2_ALG, TPM2_NT, TPMA_NV
+    from tpm2_pytss.types import TPM2B_NV_PUBLIC, TPMS_NV_PUBLIC
+
+    # TPM_NT is a 4-bit field inside TPMA_NV, so it is OR'd in rather than named in
+    # the attribute string. Keeping it explicit is the point: TPM_NT_EXTEND is the
+    # single attribute this whole design rests on.
+    attributes = TPMA_NV.parse("ownerwrite|ownerread|authread|no_da") | (
+        int(TPM2_NT.EXTEND) << 4
+    )
+    nv_public = TPM2B_NV_PUBLIC(
+        nvPublic=TPMS_NV_PUBLIC(
+            nvIndex=index,
+            nameAlg=TPM2_ALG.SHA256,
+            attributes=attributes,
+            dataSize=_EXTEND_INDEX_SIZE,
+        )
+    )
+    try:
+        ectx.nv_define_space(None, nv_public, auth_handle=ESYS_TR.OWNER)
+    except Exception as exc:  # noqa: BLE001
+        raise MeasurementUnavailable(
+            "the measurement NV index could not be defined",
+            detail=f"index={index:#x}: {type(exc).__name__}: {exc}",
+        ) from exc

--- a/tests/unit/test_gateway_measurement.py
+++ b/tests/unit/test_gateway_measurement.py
@@ -1,0 +1,403 @@
+"""Tests for measuring the gateway into a TPM NV extend index (#432).
+
+The TPM-facing calls are driven with a fake ESAPI context that enforces the
+``TPM_NT_EXTEND`` semantics that make this design work: a write is
+``H(old || data)``, never a replacement. That is what a real TPM does, and it is
+the property the whole approach rests on, so a test that let a write replace the
+value would pass while the design was broken.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cmcp_runtime.tee.measurement import (
+    DEFAULT_MEASUREMENT_NV_INDEX,
+    ExtendResult,
+    GatewayMeasurement,
+    MeasurementUnavailable,
+    code_digest,
+    config_digest,
+    extend_gateway_measurement,
+    gateway_measurement,
+    policy_digest,
+)
+
+# ── config stand-ins ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Nested:
+    mode: str = "enforcing"
+    validity_seconds: int = 86400
+
+
+@dataclass
+class _Config:
+    policy_bundle_path: str = "policies/"
+    listen_addr: str = "0.0.0.0:8443"
+    dev_mode: bool = False
+    bearer_token: str | None = None
+    attestation: _Nested = field(default_factory=_Nested)
+
+
+# ── policy digest ─────────────────────────────────────────────────────────────
+
+
+def _bundle(tmp_path: Path, files: dict[str, str]) -> str:
+    root = tmp_path / "policies"
+    root.mkdir(parents=True, exist_ok=True)
+    for name, content in files.items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return str(root)
+
+
+def test_policy_digest_is_stable(tmp_path: Path) -> None:
+    path = _bundle(tmp_path, {"a.cedar": "permit(...);", "manifest.json": "{}"})
+    assert policy_digest(path) == policy_digest(path)
+
+
+def test_policy_digest_changes_when_a_policy_changes(tmp_path: Path) -> None:
+    """The point of #432: a swapped policy bundle must not measure identically."""
+    path = _bundle(tmp_path, {"a.cedar": "permit(...);"})
+    before = policy_digest(path)
+    (Path(path) / "a.cedar").write_text("forbid(...);")
+    assert policy_digest(path) != before
+
+
+def test_policy_digest_changes_when_a_file_is_added(tmp_path: Path) -> None:
+    path = _bundle(tmp_path, {"a.cedar": "permit(...);"})
+    before = policy_digest(path)
+    (Path(path) / "b.cedar").write_text("permit(...);")
+    assert policy_digest(path) != before
+
+
+def test_policy_digest_covers_the_path_not_only_the_bytes(tmp_path: Path) -> None:
+    """Renaming a policy file must change the digest even if bytes are identical."""
+    one = _bundle(tmp_path / "one", {"a.cedar": "permit(...);"})
+    two = _bundle(tmp_path / "two", {"b.cedar": "permit(...);"})
+    assert policy_digest(one) != policy_digest(two)
+
+
+def test_policy_digest_fails_loudly_on_a_missing_path(tmp_path: Path) -> None:
+    with pytest.raises(MeasurementUnavailable, match="does not exist"):
+        policy_digest(str(tmp_path / "absent"))
+
+
+def test_policy_digest_fails_loudly_on_an_empty_bundle(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(MeasurementUnavailable, match="empty"):
+        policy_digest(str(empty))
+
+
+# ── config digest ─────────────────────────────────────────────────────────────
+
+
+def test_config_digest_is_stable() -> None:
+    assert config_digest(_Config()) == config_digest(_Config())
+
+
+def test_config_digest_changes_with_a_config_change() -> None:
+    assert config_digest(_Config()) != config_digest(_Config(listen_addr="127.0.0.1:9000"))
+
+
+def test_config_digest_covers_nested_config() -> None:
+    changed = _Config(attestation=_Nested(mode="advisory"))
+    assert config_digest(_Config()) != config_digest(changed)
+
+
+def test_config_digest_excludes_the_bearer_token() -> None:
+    """A secret must not be measured: the index is read back in evidence.
+
+    Extending a digest over the token would publish an offline guessing oracle for
+    it, and the token authenticates callers rather than describing what is running.
+    """
+    with_token = _Config(bearer_token="s3cret")
+    assert config_digest(_Config()) == config_digest(with_token)
+
+
+# ── code digest ───────────────────────────────────────────────────────────────
+
+
+def test_code_digest_covers_recorded_file_hashes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The digest is over RECORD hashes, so a changed dependency file changes it."""
+
+    class _Dist:
+        def __init__(self, name: str, version: str, record: str | None) -> None:
+            self.metadata = {"Name": name}
+            self.version = version
+            self._record = record
+
+        def read_text(self, name: str) -> str | None:
+            return self._record if name == "RECORD" else None
+
+    clean = [
+        _Dist("cmcp", "1.0.0", "cmcp/__init__.py,sha256=AAA,10\n"),
+        _Dist("requests", "2.0.0", "requests/api.py,sha256=BBB,20\n"),
+    ]
+    tampered = [
+        _Dist("cmcp", "1.0.0", "cmcp/__init__.py,sha256=AAA,10\n"),
+        _Dist("requests", "2.0.0", "requests/api.py,sha256=EVIL,20\n"),
+    ]
+
+    monkeypatch.setattr("cmcp_runtime.tee.measurement.distributions", lambda: clean)
+    baseline = code_digest()
+    monkeypatch.setattr("cmcp_runtime.tee.measurement.distributions", lambda: tampered)
+    assert code_digest() != baseline
+
+
+def test_code_digest_is_independent_of_scan_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Dist:
+        def __init__(self, name: str) -> None:
+            self.metadata = {"Name": name}
+            self.version = "1.0.0"
+
+        def read_text(self, name: str) -> str | None:
+            return f"{self.metadata['Name']}/m.py,sha256=X,1\n" if name == "RECORD" else None
+
+    forward = [_Dist("aaa"), _Dist("bbb"), _Dist("ccc")]
+    monkeypatch.setattr("cmcp_runtime.tee.measurement.distributions", lambda: forward)
+    baseline = code_digest()
+    monkeypatch.setattr(
+        "cmcp_runtime.tee.measurement.distributions", lambda: list(reversed(forward))
+    )
+    assert code_digest() == baseline
+
+
+def test_code_digest_fails_loudly_without_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An editable install has no RECORD, and a partial measurement must not pass.
+
+    Silently skipping unmeasurable distributions would report a confident digest
+    over an unknown amount of code, which is worse than refusing.
+    """
+
+    class _Editable:
+        metadata = {"Name": "cmcp"}
+        version = "1.0.0"
+
+        def read_text(self, name: str) -> None:
+            return None
+
+    monkeypatch.setattr("cmcp_runtime.tee.measurement.distributions", lambda: [_Editable()])
+    with pytest.raises(MeasurementUnavailable, match="RECORD"):
+        code_digest()
+
+
+# ── the combined measurement ──────────────────────────────────────────────────
+
+
+def _stub_code(monkeypatch: pytest.MonkeyPatch, digest: str = "c" * 64) -> None:
+    monkeypatch.setattr("cmcp_runtime.tee.measurement.code_digest", lambda: digest)
+
+
+def test_gateway_measurement_reports_its_components(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_code(monkeypatch)
+    config = _Config(policy_bundle_path=_bundle(tmp_path, {"a.cedar": "permit(...);"}))
+    measured = gateway_measurement(config)
+    assert set(measured.components) == {"code", "policy", "config"}
+    assert len(measured.digest) == 32
+    assert measured.digest_hex.startswith("sha256:")
+
+
+def test_gateway_measurement_changes_with_any_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _bundle(tmp_path, {"a.cedar": "permit(...);"})
+    _stub_code(monkeypatch)
+    baseline = gateway_measurement(_Config(policy_bundle_path=path)).digest
+
+    # config differs
+    assert gateway_measurement(
+        _Config(policy_bundle_path=path, listen_addr="127.0.0.1:1")
+    ).digest != baseline
+
+    # policy differs
+    (Path(path) / "a.cedar").write_text("forbid(...);")
+    assert gateway_measurement(_Config(policy_bundle_path=path)).digest != baseline
+
+    # code differs
+    _stub_code(monkeypatch, "d" * 64)
+    assert gateway_measurement(_Config(policy_bundle_path=path)).digest != baseline
+
+
+def test_gateway_measurement_is_domain_separated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare hash of the components must not equal the measurement."""
+    _stub_code(monkeypatch)
+    config = _Config(policy_bundle_path=_bundle(tmp_path, {"a.cedar": "x"}))
+    measured = gateway_measurement(config)
+    naive = hashlib.sha256(
+        json.dumps(measured.components, separators=(",", ":"), sort_keys=True).encode()
+    ).digest()
+    assert measured.digest != naive
+
+
+# ── NV extend index ───────────────────────────────────────────────────────────
+
+
+class _FakeNvTpm:
+    """An ESAPI stand-in enforcing real TPM_NT_EXTEND semantics."""
+
+    def __init__(self, *, defined: bool = False, replace_on_write: bool = False) -> None:
+        self.value = bytes(32) if defined else None
+        self.defined = defined
+        self.defines: list[int] = []
+        self.extends: list[bytes] = []
+        # Set to model a broken TPM (or a plain ordinary index) that replaces
+        # instead of extending, which the collector must catch.
+        self.replace_on_write = replace_on_write
+
+    def tr_from_tpmpublic(self, index: int) -> str:
+        if not self.defined:
+            raise RuntimeError("TPM_RC_HANDLE: NV index is not defined")
+        return f"handle-{index:#x}"
+
+    def nv_define_space(self, _auth: Any, nv_public: Any, **_kw: Any) -> None:
+        self.defines.append(int(nv_public.nvPublic.nvIndex))
+        self.defined = True
+        self.value = bytes(32)
+
+    def nv_read_public(self, _handle: str) -> tuple[Any, None]:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(nvPublic=SimpleNamespace(dataSize=32)), None
+
+    def nv_read(self, _handle: str, size: int, offset: int) -> bytes:
+        if self.value is None:
+            raise RuntimeError("TPM_RC_NV_UNINITIALIZED")
+        return self.value[offset : offset + size]
+
+    def nv_extend(self, _handle: str, data: bytes, **_kw: Any) -> None:
+        self.extends.append(bytes(data))
+        if self.replace_on_write:
+            self.value = bytes(data)
+        else:
+            self.value = hashlib.sha256((self.value or bytes(32)) + bytes(data)).digest()
+
+
+@pytest.fixture
+def _pytss(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for tpm2_pytss.constants.ESYS_TR and the NV public types."""
+    import sys
+    import types
+    from types import SimpleNamespace
+
+    if "tpm2_pytss" in sys.modules:  # pragma: no cover - real bindings present
+        return
+
+    pkg = types.ModuleType("tpm2_pytss")
+    constants = types.ModuleType("tpm2_pytss.constants")
+    constants.ESYS_TR = SimpleNamespace(OWNER="owner")
+    constants.TPM2_ALG = SimpleNamespace(SHA256=0x000B)
+    constants.TPM2_NT = SimpleNamespace(EXTEND=0x4)
+    constants.TPMA_NV = SimpleNamespace(parse=lambda _spec: 0x2000000)
+    types_mod = types.ModuleType("tpm2_pytss.types")
+    types_mod.TPMS_NV_PUBLIC = lambda **kw: SimpleNamespace(**kw)
+    types_mod.TPM2B_NV_PUBLIC = lambda **kw: SimpleNamespace(**kw)
+
+    monkeypatch.setitem(sys.modules, "tpm2_pytss", pkg)
+    monkeypatch.setitem(sys.modules, "tpm2_pytss.constants", constants)
+    monkeypatch.setitem(sys.modules, "tpm2_pytss.types", types_mod)
+
+
+def _measurement(digest: bytes = b"\xab" * 32) -> GatewayMeasurement:
+    return GatewayMeasurement(digest=digest, components={"code": "x"})
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_provisions_the_index_when_absent() -> None:
+    tpm = _FakeNvTpm(defined=False)
+    result = extend_gateway_measurement(tpm, _measurement())
+    assert result.provisioned is True
+    assert tpm.defines == [DEFAULT_MEASUREMENT_NV_INDEX]
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_reuses_an_existing_index() -> None:
+    """Re-provisioning each boot would hand the adversary the reset they want."""
+    tpm = _FakeNvTpm(defined=True)
+    result = extend_gateway_measurement(tpm, _measurement())
+    assert result.provisioned is False
+    assert tpm.defines == []
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_returns_a_chaining_before_and_after() -> None:
+    tpm = _FakeNvTpm(defined=True)
+    measurement = _measurement()
+    result = extend_gateway_measurement(tpm, measurement)
+    assert result.before == bytes(32)
+    assert result.after == hashlib.sha256(bytes(32) + measurement.digest).digest()
+    assert result.chains_from(measurement.digest)
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extends_accumulate_across_starts() -> None:
+    """Extends are one-way, so the value is a chain over every boot, not a reset.
+
+    This is why a verifier cannot predict an absolute value from the current
+    gateway digest, and why before/after are both reported.
+    """
+    tpm = _FakeNvTpm(defined=True)
+    measurement = _measurement()
+    first = extend_gateway_measurement(tpm, measurement)
+    second = extend_gateway_measurement(tpm, measurement)
+    assert second.before == first.after
+    assert second.after != first.after
+    assert second.chains_from(measurement.digest)
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_rejects_an_index_that_replaces_instead_of_extending() -> None:
+    """A non-extend index would let an adversary write a chosen clean value.
+
+    If the index were defined without TPM_NT_EXTEND, a write would replace the
+    value and the tamper-evidence argument collapses, so the mismatch is fatal.
+    """
+    tpm = _FakeNvTpm(defined=True, replace_on_write=True)
+    with pytest.raises(MeasurementUnavailable, match="does not chain"):
+        extend_gateway_measurement(tpm, _measurement())
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_fails_loudly_when_the_tpm_rejects_the_write() -> None:
+    class _Refusing(_FakeNvTpm):
+        def nv_extend(self, _handle: str, data: bytes, **_kw: Any) -> None:
+            raise RuntimeError("TPM_RC_NV_AUTHORIZATION")
+
+    with pytest.raises(MeasurementUnavailable, match="TPM2_NV_Extend failed"):
+        extend_gateway_measurement(_Refusing(defined=True), _measurement())
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_extend_fails_loudly_when_the_index_cannot_be_defined() -> None:
+    class _Undefinable(_FakeNvTpm):
+        def nv_define_space(self, _auth: Any, nv_public: Any, **_kw: Any) -> None:
+            raise RuntimeError("TPM_RC_NV_SPACE")
+
+    with pytest.raises(MeasurementUnavailable, match="could not be defined"):
+        extend_gateway_measurement(_Undefinable(defined=False), _measurement())
+
+
+def test_chains_from_rejects_a_foreign_digest() -> None:
+    before = bytes(32)
+    result = ExtendResult(
+        index=DEFAULT_MEASUREMENT_NV_INDEX,
+        before=before,
+        after=hashlib.sha256(before + b"\x01" * 32).digest(),
+        provisioned=False,
+    )
+    assert result.chains_from(b"\x01" * 32)
+    assert not result.chains_from(b"\x02" * 32)


### PR DESCRIPTION
First of two PRs for #432. This one measures the gateway and extends it into the NV index. The second adds the signed binding (`TPM2_NV_Certify`) and verification.

## The problem

PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and the bootloader. There was no `PCR_Extend` anywhere in the codebase, so replacing the policy bundle or the gateway itself produced an identical measurement. The stated purpose of the TPM path, protecting policy from tampering, was not enforced by the TPM.

## What this does

`cmcp_runtime.tee.measurement` digests three things and extends the result into NV `0x01500432` at startup step 2b, after provider detection and before the attestation report, so the evidence reflects the code and policy that are about to serve traffic:

- installed distributions' recorded per-file hashes (pip's `RECORD` metadata)
- the policy bundle bytes
- the resolved configuration, with the bearer token excluded

`RuntimeContext` carries the measurement and the NV state around the extend.

## Why an NV extend index, not an application PCR

Per the decision on #432. PCR 23 is Application Support and PCR 16 is Debug, and both are resettable from locality 0, so an adversary with local code execution could reset PCR 23 and re-extend a chosen value. That is exactly the adversary this tier exists to address, which makes an application PCR advisory rather than tamper-resistant.

One finding worth flagging, because it changes the stated rationale: **`TPM_NT_EXTEND` semantics carry the security argument, not the write policy.** Writes are one-way, `new = H(old || data)`, so an adversary who can call `TPM2_NV_Extend` can append but cannot set the index to a chosen value without a preimage. The write policy the issue called for is not what makes this work.

## What this does not claim

**Tamper-evident, not tamper-proof.** `TPM2_NV_UndefineSpace` followed by a fresh define resets the index, and owner authorization permits it. Guest root holds owner auth on an Azure VM, so a sufficiently privileged adversary can erase the measurement. What they cannot do is erase it silently, since a redefined index reads back with `TPMA_NV_WRITTEN` clear. Making this tamper-proof needs the platform hierarchy, which a guest VM cannot reach, and that is the same client-firmware dependency that gates the AI PC tier.

**Not yet remote-verifiable.** The index travels as an ordinary NV read, which the quote signature does not cover, so this is a local integrity control rather than evidence. That is PR2's job, and the sound primitive is `TPM2_NV_Certify` (the TPM signs `TPM_ST_ATTEST_NV` over the index contents with the AK, under caller-supplied qualifying data). Reading the index and committing the result into the quote's qualifying data is **not** sound: the collector would be asserting the value it read, and a compromised gateway is the adversary. PR2 also needs a `TPM_ST_ATTEST_NV` parser, which agent-manifest does not model.

**The value is not predictable.** Extends accumulate and NV is persistent, so after N starts the index is a hash chain over all N digests, not `H(0 || digest)`. A verifier cannot recompute it from the current digest alone, so the collector reports the value before and after the extend and continuity (`after == H(before || digest)`) is what a relying party checks. That is the hash-chain idiom the audit log already uses. The collector refuses to proceed when the value does not chain, which catches an index that was defined without `TPM_NT_EXTEND` and would therefore let a chosen value be written.

## The editable-install tradeoff

Measuring dependencies via `RECORD` is what catches a swapped transitive package; measuring only cMCP's own source would report an identical digest for one. The cost is that an editable install has no `RECORD`, so the gateway cannot be measured there. That is fatal in production and a warning under `CMCP_DEV_MODE`, mirroring how `CMCP_POLICY_HASH` is handled. Refusing is deliberate: silently skipping unmeasurable distributions would report a confident digest over an unknown amount of code.

## Tests

24 new tests, 998 passing overall. The fake ESAPI context enforces real `TPM_NT_EXTEND` semantics, so a write hashes into the existing value rather than replacing it. A test that let writes replace would pass while the design was broken, which is why there is an explicit case for an index that replaces instead of extending.

Also covered: the digest changes when any one of code, policy, or config changes; it is independent of distribution scan order; a renamed policy file with identical bytes still changes it; the bearer token is excluded (extending a secret into an index that is read back in evidence would publish a guessing oracle for it); and extends accumulate across starts.

## Not validated

**The TPM-facing calls have not run against a TPM.** No TPM is available in this environment and tpm2-pytss has no Windows wheel, so `nv_define_space`, `nv_extend`, and the `TPMA_NV` / `TPM2_NT.EXTEND` construction are written against the documented API and exercised only against a fake. They need an Azure Trusted Launch run before this is trusted. Everything else (all three digests, the chain check, the provisioning decision) is covered by real tests.

## Note for reviewers

`python -m mypy src` reports 5 errors in `src/cmcp_verify/tpm.py` around `hash_cls()` instantiation. These are pre-existing on `main` (verified by stashing) in a file this PR does not touch, and appear to date from #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)