### PR TITLE
docs(tee): record the NV extend hardware run, and correct the Azure PKI claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Azure vTPM certificate hierarchy is fleet variance, not a migration (hardware, 2026-08-01).** `docs/testing/hardware-validation.md` recorded on 2026-07-31 that "Azure has changed its vTPM PKI", after finding the AK certificate at NV `0x01C101D0` issued by `Azure Cloud Virtual TPM CA - 11` with a walkable AIA chain, superseding an earlier no-AIA observation. A VM provisioned 2026-08-01 (`Standard_D2s_v7`, eastus2) presented the older form again: 994 bytes, issued by `Global Virtual TPM CA - 03`, **no AIA extension at all**, and `tpm2_getcap handles-nv-index` confirmed no intermediates stored in NV as a fallback. Both hierarchies are live concurrently, so the planning assumption must be that a host may present either and **AIA cannot be relied on**. The practical consequence, now stated in the doc and in `cmcp_verify/tpm_roots.py`: pinning the 2023 root does not make Azure verify everywhere, and chained verification is impossible on a host presenting the no-AIA hierarchy. This is worth re-reading against #431, which was closed on the basis that chains ship with the evidence.
+
 ### Added
+
+- **Hardware validation for the gateway measurement NV extend index (#432, #451).** The TPM calls in `cmcp_runtime.tee.measurement` were written against the documented tpm2-pytss API without ever executing against a TPM. All of them work on a real Azure Trusted Launch vTPM: `nv_define_space` with `TPMA_NV.parse(...) | (TPM2_NT.EXTEND << 4)` created a genuine extend index (`TPM_NT = 4` read back from the public area), `nv_extend` accumulated as `H(old || data)` across calls, an existing index was reused rather than redefined, and **a plain `nv_write` to the index was refused by the TPM**, which is the check the tamper-evidence argument actually rests on. Recorded in `docs/testing/hardware-validation.md`.
 
 - **The gateway is now measured into a TPM NV extend index at startup (#432).** PCRs 0 through 7 cover firmware, option ROMs, boot configuration, and the bootloader, and there was no `PCR_Extend` anywhere in the codebase, so replacing the policy bundle or the gateway itself produced an identical measurement and the TPM enforced nothing about the thing the TPM path exists to protect. `cmcp_runtime.tee.measurement` digests the installed distributions' recorded per-file hashes (pip's `RECORD`), the policy bundle bytes, and the resolved configuration with secrets excluded, then extends that digest into NV `0x01500432` before the gateway serves traffic. `RuntimeContext` carries the result.
 

--- a/docs/testing/hardware-validation.md
+++ b/docs/testing/hardware-validation.md
@@ -146,12 +146,38 @@ the magic constant.
 The AK signature is now verified (see the 2026-07-31 run below). The EK/AK
 certificate chain remains in `unverified_fields`. **Corrected 2026-07-31.** An earlier run recorded that Azure's pre-provisioned AK
 certificate carries no AIA extension and that its issuing intermediate is
-therefore not fetchable. That is no longer true: Azure has changed its vTPM PKI.
-On a VM provisioned 2026-07-31 in eastus, the certificate at vTPM NV index
-`0x01C101D0` is issued by `CN=Azure Cloud Virtual TPM CA - 11`, not
-`CN=Global Virtual TPM CA - 03`, and it does carry an AIA extension with four CA
-Issuers URIs. The intermediate was fetched from the public CDN and verified to
-have signed the AK certificate. See the certificate-chain section below.
+therefore not fetchable. On a VM provisioned 2026-07-31 in eastus, the
+certificate at vTPM NV index `0x01C101D0` is issued by
+`CN=Azure Cloud Virtual TPM CA - 11`, not `CN=Global Virtual TPM CA - 03`, and it
+does carry an AIA extension with four CA Issuers URIs. The intermediate was
+fetched from the public CDN and verified to have signed the AK certificate. See
+the certificate-chain section below.
+
+**Corrected again 2026-08-01: this is fleet variance, not a migration.** The
+2026-07-31 note above concluded that "Azure has changed its vTPM PKI", which
+implies the old presentation is gone and AIA can be relied on going forward. That
+is wrong. A VM provisioned 2026-08-01 (`Standard_D2s_v7`, eastus2) presented the
+*old* form again:
+
+| | 2026-07-31, `D2s_v5` eastus | 2026-08-01, `D2s_v7` eastus2 |
+|---|---|---|
+| Certificate size | 1596 bytes | **994 bytes** |
+| Issuer | `Azure Cloud Virtual TPM CA - 11` | **`Global Virtual TPM CA - 03`** |
+| AIA extension | present, 4 CA Issuers URIs | **absent entirely** |
+| Chain to a pinnable root | yes | **no** |
+
+Both hierarchies are live concurrently, so the correct planning assumption is that
+**an Azure Trusted Launch host may present either, and AIA cannot be relied on.**
+On the 2026-08-01 host `tpm2_getcap handles-nv-index` returned only `0x01C101D0`
+(plus a test index), confirming the intermediates are not stored in NV as a
+fallback. Chained verification against the root pinned in
+`cmcp_verify/tpm_roots.py` is therefore impossible on such a host, and it fails
+closed with "AK chain root is not among the supplied trusted TPM roots", which is
+correct: key provenance genuinely cannot be established there.
+
+Consequence for #431 and for any deployment: pinning the 2023 root does not make
+Azure verify everywhere. A deployment must obtain and pin the root for the
+hierarchy its own hosts present, and a fleet spanning both needs both.
 
 It remains true that this certificate certifies a different key than an in-guest
 `tpm2_createak` AK. The resolution is not to certify our own AK: it is to use the
@@ -235,11 +261,44 @@ event-log replay cannot be exercised on an Azure vTPM at all. The replay code in
 against a real log needs a platform that publishes one, which in practice means
 physical client hardware. `#433` tracks that.
 
+## Gateway measurement NV extend index, Azure Trusted Launch vTPM, 2026-08-01
+
+`Standard_D2s_v7`, Ubuntu 24.04, Trusted Launch with vTPM and secure boot, eastus2.
+This validates `cmcp_runtime.tee.measurement` (#432, #451), whose TPM calls had
+been written against the documented tpm2-pytss API without ever executing against
+a TPM. All of them work:
+
+- `nv_define_space(None, nv_public, auth_handle=ESYS_TR.OWNER)` created the index,
+  and `TPMA_NV.parse("ownerwrite|ownerread|authread|no_da") | (TPM2_NT.EXTEND << 4)`
+  produced the intended attributes. Reading the public area back gave
+  `TPM_NT = 4`, confirming a genuine `TPM_NT_EXTEND` index rather than an
+  ordinary one. `tpm2_getcap handles-nv-index` listed `0x01500432` at size 32.
+- `nv_extend(handle, digest, auth_handle=ESYS_TR.OWNER)` extended it. First call
+  reported `provisioned=True`, second `provisioned=False`, so an existing index is
+  reused rather than redefined, which matters because redefining each boot would
+  hand an adversary the reset the design exists to prevent.
+- The extend semantics the security argument rests on hold on hardware: after the
+  second extend, `before` equalled the first `after`, the value moved, and both
+  extends satisfied `after == H(before || digest)`.
+- **A plain `nv_write` to the index was refused by the TPM.** This is the
+  load-bearing check: it is what makes an adversary unable to write a chosen clean
+  value, and it is confirmed independently by the `TPM_NT` field above rather than
+  only by an exception.
+
+Not covered by this run: the index value still travels as an ordinary NV read,
+which no signature covers, so it is a local integrity control and not yet
+remote-verifiable evidence. `TPM2_NV_Certify` is the remaining half of #432.
+
 ## Not yet validated
 
-- **TPM signature and certificate chain**: out of Phase 1 scope here. The
-  sibling [ca2a](https://github.com/agentrust-io/ca2a) verifier does check the AK
-  signature and has now done so against this same real quote.
+- **TPM certificate chain on every Azure host**: the AK signature is verified, and
+  the sibling [ca2a](https://github.com/agentrust-io/ca2a) verifier has done so
+  against real quotes. Chaining that key to a pinned root is **host-dependent**:
+  see the fleet-variance correction above, where a host presenting the
+  `Global Virtual TPM CA - 03` hierarchy with no AIA extension cannot produce a
+  chain at all.
+- **`TPM2_NV_Certify` for the gateway measurement**: the remaining half of #432,
+  without which the NV index value is not signed evidence.
 - **NVIDIA GPU CC**: not implemented, planned for v0.2 via NRAS.
 - **cMCP serving traffic from inside the TEE**: attestation collection and
   verification now run in situ on a CVM (above). A production gateway serving

--- a/src/cmcp_runtime/tee/measurement.py
+++ b/src/cmcp_runtime/tee/measurement.py
@@ -32,6 +32,16 @@ not tamper-proof**. Making it tamper-proof needs the platform hierarchy, which a
 guest VM cannot reach, and that is the same client-firmware dependency that gates
 the AI PC tier.
 
+## Validated on hardware
+
+Exercised on a real Azure Trusted Launch vTPM (``Standard_D2s_v7``, eastus2,
+2026-08-01): the index was defined with ``TPM_NT_EXTEND`` (confirmed by reading
+``TPM_NT = 4`` back out of the public area), extends accumulated as
+``H(old || data)`` across successive calls, an existing index was reused rather
+than redefined, and **a plain ``TPM2_NV_Write`` to it was refused by the TPM**,
+which is the check the tamper-evidence argument actually rests on. See
+docs/testing/hardware-validation.md.
+
 ## Predictability is deliberately left to the verifier
 
 Because extends accumulate and NV is persistent across reboots, the index value

--- a/src/cmcp_verify/tpm_roots.py
+++ b/src/cmcp_verify/tpm_roots.py
@@ -21,8 +21,16 @@ from __future__ import annotations
 #       CN=Azure Cloud Virtual TPM CA 2025
 #         CN=Azure Virtual TPM Root Certificate Authority 2023   <- this cert
 #
-# The intermediates are fetchable over the certificate AIA extension; only the
-# self-signed root is pinned here.
+# On that host the intermediates are fetchable over the certificate AIA extension,
+# so only the self-signed root is pinned here.
+#
+# NOT SUFFICIENT FLEET-WIDE, measured 2026-08-01 on a Standard_D2s_v7 in eastus2.
+# The same NV index there held a 994-byte certificate issued by
+# CN=Global Virtual TPM CA - 03 with NO AIA extension, so no intermediates can be
+# fetched, none are stored elsewhere in NV, and no chain reaches this root.
+# Verification correctly fails closed on such a host. Azure runs both hierarchies
+# concurrently, so a deployment must pin the root its own hosts actually present;
+# see docs/testing/hardware-validation.md.
 AZURE_VTPM_ROOT_2023_PEM = b"""\
 -----BEGIN CERTIFICATE-----
 MIIFsDCCA5igAwIBAgIQUfQx2iySCIpOKeDZKd5KpzANBgkqhkiG9w0BAQwFADBp


### PR DESCRIPTION
Ran the TPM path on a real Azure Trusted Launch vTPM (`Standard_D2s_v7`, eastus2, 2026-08-01), specifically to validate the calls #451 shipped without ever executing against a TPM. Docs and comments only.

## 1. The NV extend index from #451 works on hardware

Every TPM call in `cmcp_runtime.tee.measurement` had been written against the documented tpm2-pytss API and exercised only against a fake. All of them are now confirmed:

| Check | Result |
|---|---|
| `nv_define_space(None, nv_public, auth_handle=ESYS_TR.OWNER)` | index created |
| `TPMA_NV.parse(...) \| (TPM2_NT.EXTEND << 4)` | **`TPM_NT = 4` read back from the public area** |
| `tpm2_getcap handles-nv-index` | `0x01500432`, size 32 |
| `nv_extend(handle, digest, auth_handle=ESYS_TR.OWNER)` | extended |
| First call provisions, second reuses | `provisioned=True` then `False` |
| Accumulation | `before2 == after1`, value moved |
| `after == H(before \|\| digest)` | held on both extends |
| **Plain `nv_write` to the index** | **refused by the TPM** |

That last row is the load-bearing one: it is what makes an adversary unable to write a chosen clean value, and it is corroborated independently by the `TPM_NT` field rather than resting on an exception type. The `nv_extend` keyword-argument form this module uses is also confirmed correct.

Still open for #432: the index value travels as an ordinary NV read that no signature covers, so it remains a local integrity control rather than remote-verifiable evidence. `TPM2_NV_Certify` is the remaining half.

## 2. The 2026-07-31 Azure PKI conclusion is wrong

`docs/testing/hardware-validation.md` currently says Azure "has changed its vTPM PKI", based on finding the AK certificate issued by `Azure Cloud Virtual TPM CA - 11` with a walkable AIA chain, superseding an earlier no-AIA observation.

The 2026-08-01 host presented the **older form again**:

| | 2026-07-31, `D2s_v5` eastus | 2026-08-01, `D2s_v7` eastus2 |
|---|---|---|
| Certificate size | 1596 bytes | **994 bytes** |
| Issuer | `Azure Cloud Virtual TPM CA - 11` | **`Global Virtual TPM CA - 03`** |
| AIA extension | present, 4 CA Issuers URIs | **absent entirely** |
| Chain to a pinnable root | yes | **no** |

`tpm2_getcap handles-nv-index` returned only `0x01C101D0` plus the test index, so the intermediates are not stored in NV as a fallback either.

**This is fleet variance, not a migration, and the distinction changes the design assumption.** A migration reading implies AIA can be relied on going forward. What is actually true is that an Azure Trusted Launch host may present either hierarchy, so AIA cannot be relied on, and on the no-AIA host chained verification is impossible: it fails closed with "AK chain root is not among the supplied trusted TPM roots", which is correct, because key provenance genuinely cannot be established there.

Pinning the 2023 root does not make Azure verify everywhere. A deployment must pin the root for the hierarchy its own hosts present, and a fleet spanning both needs both. Noted in the doc and in `cmcp_verify/tpm_roots.py`.

## Worth a second look: #431

#431 was closed on the basis that the runtime ships AK certificate chains with its evidence. It does ship what it can assemble, and the code is correct. But on this fleet there is nothing to assemble, so "ships its chain" does not imply "provenance is verifiable". I have not reopened it, since the code change that closed it stands; flagging it as a judgement call for you.

## Note for reviewers

`python -m mypy src` reports 5 pre-existing errors in `src/cmcp_verify/tpm.py` (`hash_cls()` instantiation, dating from #444), in a file this PR does not touch. CI passes, so CI's mypy invocation differs from a bare `mypy src`; worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)