### PR TITLE
fix(tee): make TPM2_NV_Certify actually work, found on hardware (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`TPM2_NV_Certify` could never have worked as shipped in #459 (hardware, 2026-08-01).** Two defects, both found by running it against a real Azure Trusted Launch vTPM and neither catchable by the unit tests as written:
+
+  1. `ESAPI.nv_certify` takes `in_scheme` (a `TPMT_SIG_SCHEME`) and `size` as **required positional** arguments. The shipped call omitted both, so it raised `TypeError` before the TPM was ever reached. The fake in the unit tests accepted any signature, so the tests passed against code that could not run.
+  2. A freshly defined `TPM_NT_EXTEND` index is **uninitialised**, and `TPM2_NV_Certify` on it fails with `TPM_RC_NV_UNINITIALIZED`. On a first gateway start there was therefore no pre-value to certify. Fixed by seeding the index once at provision time, which keeps the verifier's `post == H(pre || digest)` check free of a first-boot special case.
+
+  The fake now enforces both constraints, so each defect has a regression test that fails without its fix (verified by mutation).
+
+  What the run then established: the platform AK at `0x81000003` **can** sign an NV certify, which was an open question for a restricted signing key; `parse_nv_certify`'s field offsets are correct against a real blob, which was the highest-risk item since they came from the TCG spec and had never met real bytes; the extend relation holds across two consecutive starts with run 2's `pre` equal to run 1's `post`; and `verify_gateway_measurement` passes all seven steps while rejecting a wrong digest and a replayed nonce on genuine evidence. The chain was anchored on the leaf because that host presented the no-AIA hierarchy, so key provenance remains unproven on Azure (#453).
+
 ### Added
 
 - **The gateway measurement is now signed evidence (#432, second half).** The NV index value previously travelled as an ordinary NV read that no signature covers, so it was a local integrity control: a compromised gateway could report any value. `certify_and_extend_gateway_measurement` now certifies the index, extends it, and certifies again, giving two TPM-signed values. `cmcp_verify.nv_certify.verify_gateway_measurement` appraises the pair, checking `post == H(pre || expected_gateway_digest)` with nothing collector-asserted and no verifier-side state.

--- a/docs/testing/hardware-validation.md
+++ b/docs/testing/hardware-validation.md
@@ -289,6 +289,47 @@ Not covered by this run: the index value still travels as an ordinary NV read,
 which no signature covers, so it is a local integrity control and not yet
 remote-verifiable evidence. `TPM2_NV_Certify` is the remaining half of #432.
 
+## TPM2_NV_Certify for the gateway measurement, Azure Trusted Launch vTPM, 2026-08-01
+
+`Standard_D2s_v7`, eastus2. Validates the signed half of #432 (#459, corrected by
+#461). This run **found two defects in code that had already merged**, which is the
+argument for running it.
+
+**Defect 1: the call was wrong and could never have worked.** `ESAPI.nv_certify`
+takes `in_scheme` (a `TPMT_SIG_SCHEME`) and `size` as *required positional*
+arguments. The shipped call omitted both, so it raised `TypeError` before reaching
+the TPM. The unit tests passed because the fake accepted any signature.
+
+**Defect 2: a freshly provisioned index cannot be certified at all.** A newly
+defined `TPM_NT_EXTEND` index is uninitialised, and `TPM2_NV_Certify` on it fails
+with `TPM_RC_NV_UNINITIALIZED`. So on a first gateway start there was no pre-value
+to certify. Fixed by seeding the index once at provision time, which keeps the
+verifier's `post == H(pre || digest)` check free of a first-boot special case.
+
+With both fixed, the following hold on hardware:
+
+- `nv_certify(sign_handle, nv_index, qualifying_data, TPMT_SIG_SCHEME(NULL), 32, 0,
+  auth_handle=ESYS_TR.OWNER)` returns a 173-byte attest and a 262-byte
+  `TPMT_SIGNATURE`. A NULL scheme resolves to the key's own, RSASSA/SHA-256 here.
+- **The platform AK at `0x81000003` can sign an NV certify.** This was an open
+  question, since it is a restricted signing key; the answer is yes.
+- **`parse_nv_certify`'s field offsets are correct against a real blob.** This was
+  the highest-risk item, as the offsets came from the TCG structures spec and had
+  never met real bytes. `indexName`, `offset` and `nvContents` all parse, and
+  `nvContents` equals the value returned by `TPM2_NV_Read`.
+- The extend relation holds on hardware across two consecutive starts: run 1
+  provisioned the index and run 2 reused it, with run 2's `pre` equal to run 1's
+  `post`, which is the accumulation the two-certify design exists to handle.
+- `verify_gateway_measurement` passes all seven appraisal steps, and rejects both a
+  wrong expected digest (`gateway_digest_mismatch`) and a replayed nonce
+  (`pre_binding_mismatch`) on genuine evidence.
+
+One limit on this run: the VM drew the `Global Virtual TPM CA - 03` hierarchy, whose
+AK certificate has no AIA, so the chain is the leaf alone. The verification above
+was therefore anchored on the leaf itself, which exercises the verifier's plumbing
+but proves **no key provenance**. Chained verification against a vendor root still
+needs a host of the other hierarchy, or the root from #453.
+
 ## Not yet validated
 
 - **TPM certificate chain on every Azure host**: the AK signature is verified, and
@@ -297,8 +338,9 @@ remote-verifiable evidence. `TPM2_NV_Certify` is the remaining half of #432.
   see the fleet-variance correction above, where a host presenting the
   `Global Virtual TPM CA - 03` hierarchy with no AIA extension cannot produce a
   chain at all.
-- **`TPM2_NV_Certify` for the gateway measurement**: the remaining half of #432,
-  without which the NV index value is not signed evidence.
+- **The NV certify pair against a real vendor-rooted chain**: the 2026-08-01 run
+  anchored on the leaf because that host presented the no-AIA hierarchy, so key
+  provenance for the certifying key is still unproven on Azure (#453).
 - **NVIDIA GPU CC**: not implemented, planned for v0.2 via NRAS.
 - **cMCP serving traffic from inside the TEE**: attestation collection and
   verification now run in situ on a CVM (above). A production gateway serving

--- a/src/cmcp_runtime/tee/measurement.py
+++ b/src/cmcp_runtime/tee/measurement.py
@@ -39,8 +39,13 @@ Exercised on a real Azure Trusted Launch vTPM (``Standard_D2s_v7``, eastus2,
 ``TPM_NT = 4`` back out of the public area), extends accumulated as
 ``H(old || data)`` across successive calls, an existing index was reused rather
 than redefined, and **a plain ``TPM2_NV_Write`` to it was refused by the TPM**,
-which is the check the tamper-evidence argument actually rests on. See
-docs/testing/hardware-validation.md.
+which is the check the tamper-evidence argument actually rests on.
+
+The certify path was validated in the same session, after that run found two
+defects in it: the ``nv_certify`` call omitted the required ``in_scheme`` and
+``size`` arguments, and a freshly provisioned index cannot be certified at all. Both
+are fixed; the platform AK does sign an NV certify, and the parser's field offsets
+are correct against a real blob. See docs/testing/hardware-validation.md.
 
 ## Predictability is deliberately left to the verifier
 
@@ -87,6 +92,15 @@ logger = logging.getLogger(__name__)
 
 # An extend index holds exactly one digest of its nameAlg, which is SHA-256 here.
 _EXTEND_INDEX_SIZE = 32
+
+# A freshly defined extend index is *uninitialised*, and TPM2_NV_Certify on an
+# uninitialised index fails with TPM_RC_NV_UNINITIALIZED. So on the very first start
+# there would be no pre-value to certify at all. Seeding the index once at provision
+# time makes the pre-certify always possible, which keeps the verifier's
+# post == H(pre || digest) check free of a first-boot special case. The seed value is
+# irrelevant to security: the pre-certify signs whatever the index holds, and the
+# verifier only checks the relation between the two certified values.
+_INDEX_SEED = hashlib.sha256(b"cmcp-nv-index-initialised-v1").digest()
 
 # Owner-defined NV index holding the gateway measurement. Outside the TCG-reserved
 # 0x01C00000-0x01C3FFFF range so it cannot collide with platform certificates.
@@ -412,6 +426,10 @@ def certify_and_extend_gateway_measurement(
                 detail=f"index={index:#x}",
             )
 
+    if provisioned:
+        # See _INDEX_SEED: an uninitialised index cannot be certified.
+        _extend(ectx, handle, _INDEX_SEED, index)
+
     pre_attest, pre_sig = _certify_nv(
         ectx, handle, sign_handle, certify_qualifying_data(nonce, PHASE_PRE), phase="pre"
     )
@@ -451,15 +469,24 @@ def certify_and_extend_gateway_measurement(
 def _certify_nv(
     ectx: Any, nv_handle: Any, sign_handle: Any, qualifying_data: bytes, *, phase: str
 ) -> tuple[bytes, bytes]:
-    """Run TPM2_NV_Certify and return the marshalled (attest, signature)."""
-    from tpm2_pytss.constants import ESYS_TR
-    from tpm2_pytss.types import TPM2B_DATA
+    """Run TPM2_NV_Certify and return the marshalled (attest, signature).
+
+    ``in_scheme`` and ``size`` are required positional arguments, not optional:
+    omitting them raises a ``TypeError`` before the TPM is ever reached, which is how
+    the first hardware run failed. A NULL scheme means "use the signing key's own
+    scheme", which for the Azure platform AK is RSASSA/SHA-256.
+    """
+    from tpm2_pytss.constants import ESYS_TR, TPM2_ALG
+    from tpm2_pytss.types import TPM2B_DATA, TPMT_SIG_SCHEME
 
     try:
         attest, signature = ectx.nv_certify(
             sign_handle,
             nv_handle,
             TPM2B_DATA(qualifying_data),
+            TPMT_SIG_SCHEME(scheme=TPM2_ALG.NULL),
+            _EXTEND_INDEX_SIZE,
+            0,
             auth_handle=ESYS_TR.OWNER,
         )
     except Exception as exc:  # noqa: BLE001

--- a/tests/unit/test_gateway_measurement.py
+++ b/tests/unit/test_gateway_measurement.py
@@ -300,12 +300,14 @@ def _pytss(monkeypatch: pytest.MonkeyPatch) -> None:
     pkg = types.ModuleType("tpm2_pytss")
     constants = types.ModuleType("tpm2_pytss.constants")
     constants.ESYS_TR = SimpleNamespace(OWNER="owner")
-    constants.TPM2_ALG = SimpleNamespace(SHA256=0x000B)
+    constants.TPM2_ALG = SimpleNamespace(SHA256=0x000B, NULL=0x0010)
     constants.TPM2_NT = SimpleNamespace(EXTEND=0x4)
     constants.TPMA_NV = SimpleNamespace(parse=lambda _spec: 0x2000000)
     types_mod = types.ModuleType("tpm2_pytss.types")
     types_mod.TPMS_NV_PUBLIC = lambda **kw: SimpleNamespace(**kw)
     types_mod.TPM2B_NV_PUBLIC = lambda **kw: SimpleNamespace(**kw)
+    types_mod.TPM2B_DATA = lambda data=b"": data
+    types_mod.TPMT_SIG_SCHEME = lambda **kw: SimpleNamespace(**kw)
 
     monkeypatch.setitem(sys.modules, "tpm2_pytss", pkg)
     monkeypatch.setitem(sys.modules, "tpm2_pytss.constants", constants)
@@ -401,3 +403,97 @@ def test_chains_from_rejects_a_foreign_digest() -> None:
     )
     assert result.chains_from(b"\x01" * 32)
     assert not result.chains_from(b"\x02" * 32)
+
+
+# ── regressions from the 2026-08-01 hardware run (#460) ───────────────────────
+
+
+class _CertifyingTpm(_FakeNvTpm):
+    """Fake TPM that enforces the two constraints real hardware enforced.
+
+    Both were missed by the original fake, which is why #459 shipped broken:
+    nv_certify's in_scheme and size are required positional arguments, and an
+    uninitialised NV index cannot be certified at all.
+    """
+
+    def __init__(self, **kw: Any) -> None:
+        super().__init__(**kw)
+        self.written = False
+        self.certifies: list[bytes] = []
+
+    def nv_extend(self, handle: str, data: bytes, **kw: Any) -> None:
+        super().nv_extend(handle, data, **kw)
+        self.written = True
+
+    def nv_certify(
+        self,
+        sign_handle: Any,
+        nv_index: Any,
+        qualifying_data: Any,
+        in_scheme: Any = None,
+        size: Any = None,
+        offset: int = 0,
+        **kw: Any,
+    ) -> tuple[Any, Any]:
+        if in_scheme is None or size is None:
+            raise TypeError("nv_certify requires in_scheme and size")
+        if not self.written:
+            raise RuntimeError("TPM_RC_NV_UNINITIALIZED")
+        from types import SimpleNamespace
+
+        blob = b"attest:" + bytes(self.value or b"")
+        self.certifies.append(blob)
+        return (
+            SimpleNamespace(attestationData=blob),
+            SimpleNamespace(marshal=lambda: b"sig:" + blob),
+        )
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_certify_passes_in_scheme_and_size() -> None:
+    """Regression: omitting them raises TypeError before the TPM is reached.
+
+    That is how the first hardware run failed, and the original fake accepted the
+    call, so the unit tests passed while the shipped code could not work.
+    """
+    from cmcp_runtime.tee.measurement import certify_and_extend_gateway_measurement
+
+    tpm = _CertifyingTpm(defined=True)
+    tpm.nv_extend("h", b"\x00" * 32)  # initialise so certify is permitted
+    result = certify_and_extend_gateway_measurement(
+        tpm, _measurement(), sign_handle="ak", nonce=b"\xa5" * 32
+    )
+    assert len(tpm.certifies) == 2
+    assert result.pre_attest and result.post_attest
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_a_freshly_provisioned_index_is_seeded_before_certifying() -> None:
+    """Regression: TPM2_NV_Certify on an uninitialised index fails on hardware.
+
+    On a first start the index is defined and has never been written, so without a
+    seeding extend the pre-certify is impossible.
+    """
+    from cmcp_runtime.tee.measurement import certify_and_extend_gateway_measurement
+
+    tpm = _CertifyingTpm(defined=False)
+    result = certify_and_extend_gateway_measurement(
+        tpm, _measurement(), sign_handle="ak", nonce=b"\xa5" * 32
+    )
+    assert result.extend.provisioned is True
+    # The seed plus the measurement: two extends, and both certifies succeeded.
+    assert len(tpm.extends) == 2
+    assert len(tpm.certifies) == 2
+
+
+@pytest.mark.usefixtures("_pytss")
+def test_certified_extend_still_chains_after_seeding() -> None:
+    """The relation the verifier checks must hold on a first start too."""
+    from cmcp_runtime.tee.measurement import certify_and_extend_gateway_measurement
+
+    tpm = _CertifyingTpm(defined=False)
+    m = _measurement()
+    result = certify_and_extend_gateway_measurement(
+        tpm, m, sign_handle="ak", nonce=b"\xa5" * 32
+    )
+    assert result.extend.chains_from(m.digest)


### PR DESCRIPTION
Closes #460. Ran the certify path on a real Azure Trusted Launch vTPM (`Standard_D2s_v7`, eastus2, 2026-08-01) and it **found two defects in code that had already merged in #459**. This fixes both.

That is the argument for the run, so worth stating plainly: #459 shipped a certify path that could never have executed, and CI was green.

## Defect 1: the call was wrong

`ESAPI.nv_certify` takes `in_scheme` (a `TPMT_SIG_SCHEME`) and `size` as **required positional** arguments:

```
nv_certify(self, sign_handle, nv_index, qualifying_data, in_scheme, size, offset=0, auth_handle=None, ...)
```

The shipped call omitted both, so it raised `TypeError` before the TPM was ever reached. A NULL scheme resolves to the signing key's own, which is RSASSA/SHA-256 for the Azure platform AK.

**Why the tests missed it:** the fake `nv_certify` in the unit tests accepted any signature. The tests were green against code that could not run. That is the same failure mode as trusting an edit confirmation, one level up.

## Defect 2: a fresh index cannot be certified

A newly defined `TPM_NT_EXTEND` index is **uninitialised**, and `TPM2_NV_Certify` on it fails with `TPM_RC_NV_UNINITIALIZED`. So on a first gateway start there was no pre-value to certify at all, and the whole pair was impossible.

Fixed by seeding the index once at provision time. That keeps the verifier's `post == H(pre || digest)` check free of a first-boot special case, which was the alternative and would have meant a second code path plus a weaker claim on first boot. The seed value is irrelevant to security: the pre-certify signs whatever the index holds and the verifier only checks the relation between the two certified values.

## Regression coverage

The fake now enforces both constraints: it raises `TypeError` without `in_scheme`/`size`, and `TPM_RC_NV_UNINITIALIZED` when the index has never been written. Three new tests, and I mutation-checked them rather than assuming — removing the seed fails two of them, so they are real.

## What the run established once fixed

| Question | Answer |
|---|---|
| Can the platform AK sign an NV certify? | **Yes.** Open question for a restricted signing key. |
| Are `parse_nv_certify`'s offsets right on a real blob? | **Yes.** `indexName`, `offset`, `nvContents` all parse; `nvContents` equals `TPM2_NV_Read`. |
| Does the extend relation hold on hardware? | **Yes**, across two consecutive starts: run 1 provisioned, run 2 reused, run 2's `pre` == run 1's `post`. |
| Does `verify_gateway_measurement` pass end to end? | **Yes**, all seven steps, and it rejects a wrong digest and a replayed nonce on genuine evidence. |

The offsets were the highest-risk item, since they came from the TCG structures spec and had never met real bytes. A silent misparse would have read the wrong bytes as `nvContents` and the relation would then fail in a way that looks exactly like tampering.

## The one limit

The VM drew the `Global Virtual TPM CA - 03` hierarchy, whose AK certificate carries no AIA, so the chain is the leaf alone and verification was anchored on the leaf itself. That exercises the verifier's plumbing but proves **no key provenance**. Recorded as such in `hardware-validation.md` rather than counted as a chain validation. Still open as #453.

## Note for reviewers

My local environment currently cannot collect 12 test modules, because the editable `agent_os` install from the local agent-governance-toolkit checkout changed underneath it (`GovernancePolicy` gone, `agent_os.policies.backends` missing). Those failures are present on clean `main` too and are unrelated to this change; CI installs pinned versions. The 91 TPM-related tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)