### PR TITLE
refactor(tee): consume the shared TPM parsers from agent-manifest 0.8

### DIFF
--- a/docs/testing/hardware-validation.md
+++ b/docs/testing/hardware-validation.md
@@ -203,16 +203,27 @@ nonce, and the RSASSA-SHA256 signature over the attest blob verifying under the 
 public key. It also confirms rejection of a one-bit tampered attest blob, a
 tampered signature, and a correct signature checked against a different key.
 
-Unlike the SEV-SNP captures, this vector **is committed**, in
-`tests/unit/test_tpm_quote_signature.py`. It carries no per-CPU hardware
-identifier: the AK public key belongs to a virtual TPM in a VM that no longer
-exists, and the PCR values describe a stock Ubuntu image. Committing it means the
-signature path is exercised on every PR rather than only when a fixture directory
-is set.
+Unlike the SEV-SNP captures, this vector **is committed**. It carries no per-CPU
+hardware identifier: the AK public key belongs to a virtual TPM in a VM that no
+longer exists, and the PCR values describe a stock Ubuntu image. Committing it
+means the signature path is exercised on every PR rather than only when a fixture
+directory is set.
+
+**The vector now lives in agent-manifest**, alongside the code it validates: the
+`TPMT_SIGNATURE` parse and both `TPMS_ATTEST` framings consolidated there in
+agent-manifest 0.8.0, and cMCP imports them rather than carrying its own copies.
+Keeping the evidence with the implementation is the point: a capture that
+validates code in another repository drifts away from it. It runs on every
+agent-manifest PR.
 
 ```
-pytest tests/unit/test_tpm_quote_signature.py
+# in agent-manifest
+pytest python/tests/test_tpm_hardware_vector.py
 ```
+
+The provenance above is the record of how the capture was taken and stays here;
+`tests/unit/test_tpm_quote_signature.py` still covers cMCP's own layer, which is
+result shaping and fail-closed handling of blobs agent-manifest rejects.
 
 Not closed by this run: the EK certificate chain (#431). The EK certificate was
 not present at NV index `0x01C00002` on this VM, and as recorded above Azure's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # is called on a peer-supplied manifest below, and before 0.6.1 a manifest
     # declaring ML-DSA-65 or hybrid crashed the verifier with an uncaught
     # RuntimeError on any install without the optional [pq] extra.
-    "agent-manifest>=0.6.1",
+    "agent-manifest>=0.8",
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",

--- a/src/cmcp_verify/nv_certify.py
+++ b/src/cmcp_verify/nv_certify.py
@@ -50,7 +50,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from cmcp_verify.tpm import parse_tpmt_signature
+from agent_manifest import parse_tpmt_signature
 
 # TPMS_ATTEST header constants.
 _TPM_GENERATED_VALUE = 0xFF544347

--- a/src/cmcp_verify/tpm.py
+++ b/src/cmcp_verify/tpm.py
@@ -1,12 +1,36 @@
-"""TPM 2.0 attestation verification - implements issue #62."""
+"""TPM 2.0 attestation verification - implements issue #62.
+
+The wire formats live in agent-manifest and are imported, not reimplemented:
+``parse_tpm_quote`` handles both attest framings and ``parse_tpmt_signature``
+unwraps the signature that ``tpm2_quote -s`` writes. cMCP keeps only what is
+genuinely its own, which is the ``TPMVerificationResult`` shaping and the
+verified/unverified field accounting. ``ParsedSignature`` and
+``parse_tpmt_signature`` are re-exported so existing importers of
+``cmcp_verify.tpm`` keep working.
+"""
 
 from __future__ import annotations
 
 import hmac
-import struct
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
+
+from agent_manifest import (
+    ParsedSignature,
+    TpmVerificationError,
+    parse_tpm_quote,
+    parse_tpmt_signature,
+)
+
+__all__ = [
+    "ParsedSignature",
+    "TPMVerificationResult",
+    "parse_tpmt_signature",
+    "verify_quote_signature",
+    "verify_tpm_measurement",
+    "verify_tpm_quote_chained",
+]
 
 
 @dataclass
@@ -16,10 +40,6 @@ class TPMVerificationResult:
     unverified_fields: list[str] = field(default_factory=list)
     failure_reason: str | None = None
     details: dict[str, str] = field(default_factory=dict)
-
-
-# TPMS_ATTEST magic constant (FF 54 43 47 - "TPM generated")
-_TPM_GENERATED_VALUE = 0xFF544347
 
 
 def verify_tpm_measurement(
@@ -136,82 +156,33 @@ def _parse_tpm2b_attest(
     expected_qualifying_data: bytes | None,
 ) -> tuple[bool, dict[str, Any]]:
     """
-    Parse a TPM2B_ATTEST blob and verify qualifying_data if an expected value is given.
+    Parse an attest blob and verify qualifying_data if an expected value is given.
 
-    TPM2B_ATTEST layout:
-      [0:2]  size (uint16 big-endian) - size of the following TPMS_ATTEST
-      [2:]   TPMS_ATTEST
-
-    A bare TPMS_ATTEST with no TPM2B size prefix is also accepted, because that
-    is what `tpm2_quote -m` writes and what a real capture therefore looks like.
-    The two are told apart by the magic: a bare blob starts with 0xFF544347
-    where a wrapped one starts with a length. Rejecting the bare framing would
-    mean the verifier could not read quotes produced by the standard tooling.
-
-    TPMS_ATTEST layout (big-endian):
-      [0:4]  magic (uint32, must be 0xFF544347)
-      [4:6]  type (uint16)
-      [6:]   qualifiedSigner (TPM2B: uint16 size + <size> bytes)
-      [...]  extraData / qualifyingData (TPM2B: uint16 size + <size> bytes)
-      [...]  clockInfo (8 bytes)
-      [...]  firmwareVersion (8 bytes)
-      [...]  attested (union, type-dependent)
+    Both framings are handled by ``agent_manifest.parse_tpm_quote``: the bare
+    ``TPMS_ATTEST`` that ``tpm2_quote -m`` writes, and the size-prefixed
+    ``TPM2B_ATTEST`` other producers write. What stays here is the ``(ok, details)``
+    shaping that :class:`TPMVerificationResult` needs; the layout itself is shared
+    so a fix found on hardware lands once rather than three times.
     """
     try:
-        if len(data) < 2:
-            return False, {"error": "TPM2B_ATTEST too short"}
-
-        if len(data) >= 4 and struct.unpack_from(">I", data, 0)[0] == _TPM_GENERATED_VALUE:
-            # Bare TPMS_ATTEST (tpm2_quote -m output): no outer TPM2B size field.
-            attest = data
-        else:
-            # Skip the outer TPM2B size field
-            tpms_size = struct.unpack_from(">H", data, 0)[0]
-            if tpms_size == 0 or len(data) < 2 + tpms_size:
-                return False, {"error": "TPM2B_ATTEST size field invalid"}
-            attest = data[2 : 2 + tpms_size]
-
-        if len(attest) < 6:
-            return False, {"error": "TPMS_ATTEST too short for magic+type"}
-
-        magic = struct.unpack_from(">I", attest, 0)[0]
-        if magic != _TPM_GENERATED_VALUE:
-            return False, {"error": f"TPMS_ATTEST magic mismatch: got 0x{magic:08x}"}
-
-        # Skip magic (4) + type (2) = 6 bytes, then read qualifiedSigner (TPM2B)
-        offset = 6
-        if len(attest) < offset + 2:
-            return False, {"error": "TPMS_ATTEST truncated before qualifiedSigner"}
-
-        qs_size = struct.unpack_from(">H", attest, offset)[0]
-        offset += 2 + qs_size  # skip qualifiedSigner
-
-        if len(attest) < offset + 2:
-            return False, {"error": "TPMS_ATTEST truncated before extraData"}
-
-        # Read extraData (qualifyingData)
-        ed_size = struct.unpack_from(">H", attest, offset)[0]
-        offset += 2
-        if len(attest) < offset + ed_size:
-            return False, {"error": "TPMS_ATTEST truncated inside extraData"}
-
-        qualifying_data = attest[offset : offset + ed_size]
-
-        result: dict[str, Any] = {"qualifying_data_verified": False}
-
-        if expected_qualifying_data is not None:
-            # hmac.compare_digest for constant-time comparison of the committed nonce
-            if hmac.compare_digest(qualifying_data, expected_qualifying_data):
-                result["qualifying_data_verified"] = True
-            else:
-                result["qualifying_data_error"] = "qualifying_data does not match expected key thumbprint"
-
-        return True, result
-
-    except struct.error as exc:
-        return False, {"error": f"struct parse error: {exc}"}
+        quote = parse_tpm_quote(data)
+    except TpmVerificationError as exc:
+        return False, {"error": str(exc)}
     except Exception as exc:  # noqa: BLE001
         return False, {"error": f"unexpected parse error: {exc}"}
+
+    result: dict[str, Any] = {"qualifying_data_verified": False}
+
+    if expected_qualifying_data is not None:
+        # hmac.compare_digest for constant-time comparison of the committed nonce
+        if hmac.compare_digest(quote.qualifying_data, expected_qualifying_data):
+            result["qualifying_data_verified"] = True
+        else:
+            result["qualifying_data_error"] = (
+                "qualifying_data does not match expected key thumbprint"
+            )
+
+    return True, result
 
 
 # ---------------------------------------------------------------------------
@@ -238,53 +209,6 @@ _SIG_ALG_NAMES = {
     _ALG_RSAPSS: "rsapss",
     _ALG_ECDSA: "ecdsa",
 }
-
-
-@dataclass
-class ParsedSignature:
-    """A parsed TPMT_SIGNATURE."""
-
-    sig_alg: int
-    hash_alg: int
-    signature: bytes
-
-
-def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
-    """
-    Parse a TPMT_SIGNATURE as written by ``tpm2_quote -s``.
-
-    Layout: sigAlg (2), hashAlg (2), then the algorithm-specific signature. For RSA
-    that is a TPM2B_PUBLIC_KEY_RSA (size-prefixed). For ECDSA it is two size-prefixed
-    integers, R then S.
-    """
-    if len(blob) < 6:
-        raise ValueError("TPMT_SIGNATURE too short")
-    sig_alg, hash_alg = struct.unpack_from(">HH", blob, 0)
-    offset = 4
-
-    if sig_alg in (_ALG_RSASSA, _ALG_RSAPSS):
-        (size,) = struct.unpack_from(">H", blob, offset)
-        offset += 2
-        if len(blob) < offset + size:
-            raise ValueError("TPMT_SIGNATURE truncated inside the RSA signature")
-        return ParsedSignature(sig_alg, hash_alg, blob[offset : offset + size])
-
-    if sig_alg == _ALG_ECDSA:
-        parts = []
-        for _ in range(2):
-            (size,) = struct.unpack_from(">H", blob, offset)
-            offset += 2
-            if len(blob) < offset + size:
-                raise ValueError("TPMT_SIGNATURE truncated inside the ECDSA signature")
-            parts.append(blob[offset : offset + size])
-            offset += size
-        from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
-
-        r = int.from_bytes(parts[0], "big")
-        s = int.from_bytes(parts[1], "big")
-        return ParsedSignature(sig_alg, hash_alg, encode_dss_signature(r, s))
-
-    raise ValueError(f"unsupported signature algorithm 0x{sig_alg:04x}")
 
 
 def verify_quote_signature(
@@ -318,7 +242,7 @@ def verify_quote_signature(
 
     try:
         parsed = parse_tpmt_signature(signature_blob)
-    except ValueError as exc:
+    except TpmVerificationError as exc:
         return False, {"signature_error": str(exc)}
 
     hash_cls = hashes_by_alg.get(parsed.hash_alg)
@@ -393,7 +317,7 @@ def verify_tpm_quote_chained(
     """
     try:
         parsed = parse_tpmt_signature(signature_blob)
-    except ValueError as exc:
+    except TpmVerificationError as exc:
         return False, {"signature_error": str(exc)}
 
     try:

--- a/tests/unit/test_tpm_quote_signature.py
+++ b/tests/unit/test_tpm_quote_signature.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 import struct
 
 import pytest
-
-from cmcp_verify.tpm import parse_tpmt_signature, verify_quote_signature
-
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from cmcp_verify.tpm import parse_tpmt_signature, verify_quote_signature
 
 _ALG_RSASSA = 0x0014
 _ALG_SHA256 = 0x000B

--- a/tests/unit/test_tpm_quote_signature.py
+++ b/tests/unit/test_tpm_quote_signature.py
@@ -1,124 +1,126 @@
-"""Quote signature verification, exercised against a real Azure vTPM capture.
+"""Quote signature verification, covering what cMCP still owns after the union.
 
-The vector below was produced on 2026-07-31 on a Standard_D2s_v5 Azure VM with
-Trusted Launch, vTPM and secure boot enabled, Ubuntu 24.04, TPM manufacturer MSFT.
-The AK was created with tpm2_createek followed by tpm2_createak (RSA, RSASSA,
-SHA-256) and the quote taken over PCRs 0-7 under a fresh 32-byte nonce.
+The `TPMT_SIGNATURE` unwrap and both `TPMS_ATTEST` framings moved to
+agent-manifest (>=0.8), and the real Azure vTPM capture moved with them so the
+code and the evidence validating it stay in one place. agent-manifest runs that
+vector on every one of its PRs; `docs/testing/hardware-validation.md` here keeps
+the capture provenance and now points at where the vector lives.
 
-Unlike the SEV-SNP captures, this vector is committed. It carries no per-CPU
-hardware identifier: the AK public key belongs to a virtual TPM in a VM that no
-longer exists, and the PCR values describe a stock Ubuntu image. Committing it
-means signature verification is exercised on every PR rather than only when
-someone sets a fixture directory.
+What is left to test here is cMCP's own layer: that `verify_quote_signature`
+shapes a `(verified, details)` pair correctly, that it fails closed on inputs
+agent-manifest rejects, and that the re-export keeps existing importers working.
+The key below is generated per-run rather than captured, because none of these
+assertions are about the wire format any more.
 """
 
 from __future__ import annotations
 
-import base64
+import struct
 
 import pytest
 
 from cmcp_verify.tpm import parse_tpmt_signature, verify_quote_signature
 
-# Bare TPMS_ATTEST as written by `tpm2_quote -m`.
-QUOTE_ATTEST = base64.b64decode(
-    "/1RDR4AYACIAC1Gr2BpHLuEP6q3wUzFvxZPNyfm9bw98RBelxxduCCr7ACBJgPpvWQ1l+6Fc3u8LC7Au"
-    "jPFVBEcFsa8HAb+gsuMjlgAAAAAAAeu7AAAAAwAAAAABICADEgASAAQAAAABAAsD/wAAACDUvEYCCXOU"
-    "AOzy8r898/XnrH99z1VrFNtVJDUg6kRSag=="
-)
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
-# TPMT_SIGNATURE as written by `tpm2_quote -s`.
-QUOTE_SIGNATURE = base64.b64decode(
-    "ABQACwEASCi0Ht6m6zPVnt4HXAahI4V4DV9nHbjWCJT0kYZVtUUS7BLmv7pt/dY2tNjWTJXAZKXJCX5i"
-    "43eo53eVzKjHN3AzFdvkLEK/ahjEQ2/D+Frb+sLe0FlfhvzgfgUyoQCDs9krmCnMy18fDjxOSO+Nm2uy"
-    "Wyg38ZTUpR1fUmjb68n9WHbPR3QZV9nNI4G0IW3AgRhcHZ7gmb9WJdLLSRdzfFJ7wDWEsAFcrtGiycc0"
-    "iRXbCOBh0xTeDTlIWn9ljEYTvDlr8duW3c2fT08ZcV4vxJA6Wa8cr1QQjpd6s1/UO0XaYXneCHxoGI1u"
-    "fbEoR4QA3qTPYNCSKNgyHH9GdV1stg=="
-)
-
-AK_PUBLIC_PEM = base64.b64decode(
-    "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFN"
-    "SUlCQ2dLQ0FRRUF5K3pCVWdBQTcvZW5CMEdyWmQrdgo4OFgvd3F0U2VKZ2dCczBZU0lkcW5HLzF4SjNy"
-    "MEpTc1hyZnJkSkpnU1BwL2t4bzY5eWVtMlhjUlBiVGIzbHQwCjJsakVyaTZlUjhjbEt5RmNFUFFMbUZC"
-    "Qmg3RU5Lai9KV3FnWnJINHhLdW93Y1BlR0ltajJ2S1hlV21LclVmb1gKVU1wdmI3eTUyeTJpNU4vTERQ"
-    "UUcrYnI5NFhyZlNQNFNKTmVJKzlWUUM1Q1ZzRDM1QmZEZncwOHNYNGd6dG5FSwp4SUpyZGFVRUgxRjFs"
-    "MkxPUjJoT0FQcjI5MmxrYUlvdTVoNHF6Y3hwbm5NTTN1djF6Q2Y1ZU5rZ2QwZ1FLdUllCjZ2T2JMcStT"
-    "ZURPWndmYzBTSzRIUjBRVEtNcnhEbSs5eEdnU3ZYeUlFVnVTOExwZzBsZGRYU1Uzd0xpUU5Td1EKOHdJ"
-    "REFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
-)
-
-NONCE = bytes.fromhex("4980fa6f590d65fba15cdeef0b0bb02e8cf155044705b1af0701bfa0b2e32396")
+_ALG_RSASSA = 0x0014
+_ALG_SHA256 = 0x000B
+_TPM_GENERATED_VALUE = 0xFF544347
 
 
-def test_parses_a_real_tpmt_signature() -> None:
-    parsed = parse_tpmt_signature(QUOTE_SIGNATURE)
+def _attest(nonce: bytes = b"\x01" * 32) -> bytes:
+    """A minimal well-formed bare TPMS_ATTEST carrying `nonce` as extraData."""
+    return (
+        struct.pack(">I", _TPM_GENERATED_VALUE)
+        + struct.pack(">H", 0x8018)  # TPM_ST_ATTEST_QUOTE
+        + struct.pack(">H", 4) + b"name"  # qualifiedSigner
+        + struct.pack(">H", len(nonce)) + nonce  # extraData
+        + b"\x00" * 17  # clockInfo
+        + b"\x00" * 8  # firmwareVersion
+        + struct.pack(">I", 0)  # TPML_PCR_SELECTION count
+        + struct.pack(">H", 32) + b"\x02" * 32  # pcrDigest
+    )
 
-    assert parsed.sig_alg == 0x0014  # TPM_ALG_RSASSA
-    assert parsed.hash_alg == 0x000B  # TPM_ALG_SHA256
-    assert len(parsed.signature) == 256
+
+def _signed(attest: bytes) -> tuple[bytes, bytes]:
+    """Return (TPMT_SIGNATURE blob, AK public PEM) over `attest`."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    raw = key.sign(attest, padding.PKCS1v15(), hashes.SHA256())
+    blob = struct.pack(">HH", _ALG_RSASSA, _ALG_SHA256) + struct.pack(">H", len(raw)) + raw
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return blob, pem
 
 
-def test_real_hardware_quote_signature_verifies() -> None:
-    verified, details = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, AK_PUBLIC_PEM)
+def test_the_re_export_still_resolves() -> None:
+    """Importers of cmcp_verify.tpm must keep working after the implementation
+    moved to agent-manifest."""
+    import agent_manifest
+
+    assert parse_tpmt_signature is agent_manifest.parse_tpmt_signature
+
+
+def test_a_valid_signature_verifies_and_reports_its_algorithm() -> None:
+    attest = _attest()
+    blob, pem = _signed(attest)
+
+    verified, details = verify_quote_signature(attest, blob, pem)
 
     assert verified is True
     assert details["signature_algorithm"] == "rsassa"
 
 
-def test_the_quote_carries_the_nonce_it_was_taken_under() -> None:
-    """extraData sits after the qualifiedSigner name; the signature is what makes it
-    meaningful, since both fields are otherwise attacker-controllable."""
-    assert NONCE in QUOTE_ATTEST
+def test_a_tampered_attest_is_rejected() -> None:
+    attest = _attest()
+    blob, pem = _signed(attest)
+    tampered = bytearray(attest)
+    tampered[-1] ^= 0x01
 
-
-@pytest.mark.parametrize("flip", [0, 40, -1])
-def test_a_tampered_attest_is_rejected(flip: int) -> None:
-    tampered = bytearray(QUOTE_ATTEST)
-    tampered[flip] ^= 0x01
-
-    verified, details = verify_quote_signature(bytes(tampered), QUOTE_SIGNATURE, AK_PUBLIC_PEM)
+    verified, details = verify_quote_signature(bytes(tampered), blob, pem)
 
     assert verified is False
     assert "does not verify" in details["signature_error"]
 
 
-def test_a_tampered_signature_is_rejected() -> None:
-    tampered = bytearray(QUOTE_SIGNATURE)
-    tampered[-1] ^= 0x01
-
-    verified, _ = verify_quote_signature(QUOTE_ATTEST, bytes(tampered), AK_PUBLIC_PEM)
-
-    assert verified is False
-
-
 def test_a_different_key_does_not_verify() -> None:
-    """A quote is only evidence if it verifies under the key the relying party expects."""
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import rsa
-
+    attest = _attest()
+    blob, _ = _signed(attest)
     other = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
     other_pem = other.public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     )
 
-    verified, _ = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, other_pem)
+    verified, _details = verify_quote_signature(attest, blob, other_pem)
 
     assert verified is False
 
 
 def test_an_unloadable_key_fails_closed() -> None:
-    verified, details = verify_quote_signature(QUOTE_ATTEST, QUOTE_SIGNATURE, b"not a pem")
+    attest = _attest()
+    blob, _ = _signed(attest)
+
+    verified, details = verify_quote_signature(attest, blob, b"not a pem")
 
     assert verified is False
     assert "not loadable" in details["signature_error"]
 
 
-def test_unsupported_signature_algorithm_is_rejected() -> None:
-    with pytest.raises(ValueError, match="unsupported signature algorithm"):
-        parse_tpmt_signature(b"\x00\x99\x00\x0b\x00\x04abcd")
+@pytest.mark.parametrize(
+    "blob",
+    [
+        b"\x00\x99\x00\x0b\x00\x04abcd",  # unsupported sigAlg
+        struct.pack(">HH", _ALG_RSASSA, _ALG_SHA256) + struct.pack(">H", 400) + b"short",
+    ],
+    ids=["unsupported_algorithm", "truncated"],
+)
+def test_a_malformed_signature_blob_fails_closed(blob: bytes) -> None:
+    """agent-manifest raises TpmVerificationError; cMCP must turn that into a
+    reported failure rather than letting it escape to the caller."""
+    verified, details = verify_quote_signature(_attest(), blob, b"")
 
-
-def test_truncated_signature_is_rejected() -> None:
-    with pytest.raises(ValueError, match="truncated"):
-        parse_tpmt_signature(QUOTE_SIGNATURE[:20])
+    assert verified is False
+    assert "signature_error" in details

--- a/tests/unit/test_tpm_verify.py
+++ b/tests/unit/test_tpm_verify.py
@@ -36,15 +36,29 @@ def _make_tpm2b_attest(
     magic: int = 0xFF544347,
     qualified_signer: bytes = b"",
 ) -> bytes:
-    """Build a minimal TPM2B_ATTEST with the given qualifying_data."""
+    """Build a minimal but structurally complete TPM2B_ATTEST.
+
+    The tail must be a real TPMS_ATTEST tail. An earlier version of this helper
+    wrote 16 zero bytes for clockInfo + firmwareVersion and no PCR selection at
+    all, which parsed only because cMCP's own parser stopped reading after
+    extraData. agent-manifest's shared parser reads the whole structure and
+    rejects that, correctly: TPMS_CLOCK_INFO is 17 bytes (clock 8, resetCount 4,
+    restartCount 4, safe 1), firmwareVersion is 8, and TPMS_QUOTE_INFO is a
+    TPML_PCR_SELECTION followed by a TPM2B_DIGEST.
+    """
     # TPMS_ATTEST body
     magic_bytes = struct.pack(">I", magic)
     type_bytes = struct.pack(">H", 0x8018)  # TPM_ST_ATTEST_QUOTE
     qs = struct.pack(">H", len(qualified_signer)) + qualified_signer
     ed = struct.pack(">H", len(qualifying_data)) + qualifying_data
-    # clockInfo (8 bytes) + firmwareVersion (8 bytes) + minimal attested
-    tail = b"\x00" * 16 + struct.pack(">H", 0) + b"\x00" * 4  # minimal pcrSelect
-    attest_body = magic_bytes + type_bytes + qs + ed + tail
+    clock_info = b"\x00" * 17
+    firmware_version = b"\x00" * 8
+    pcr_selection = struct.pack(">I", 0)  # TPML_PCR_SELECTION with no entries
+    pcr_digest = struct.pack(">H", 32) + b"\x02" * 32  # TPM2B_DIGEST
+    attest_body = (
+        magic_bytes + type_bytes + qs + ed
+        + clock_info + firmware_version + pcr_selection + pcr_digest
+    )
 
     # Outer TPM2B size
     return struct.pack(">H", len(attest_body)) + attest_body


### PR DESCRIPTION
Phase B1 of the TEE consolidation. cMCP stops carrying its own copies of the TPM wire formats and imports them from agent-manifest 0.8.0, so a fix found on hardware lands once instead of three times. Net **-49 lines**.

## Deleted here, imported from agent-manifest

- `ParsedSignature` / `parse_tpmt_signature` — was byte-identical to ca2a's copy, differing only in the exception raised. This repo's own comment already named it "the piece agent-manifest does not model"; it models it now.
- The `TPMS_ATTEST` framing and field parse inside `_parse_tpm2b_attest`.

What stays is genuinely cMCP's: the `TPMVerificationResult` shaping and the verified/unverified field accounting. `parse_tpmt_signature` is re-exported from `cmcp_verify.tpm`, so existing importers keep working.

Also gained for free: this file previously accepted only the bare `TPMS_ATTEST` in some paths. The shared parser handles both framings.

## A defect this surfaced in our own fixtures

Adopting the stricter shared parser broke four tests, and the fixture was wrong rather than the code. `_make_tpm2b_attest` built a `TPMS_ATTEST` whose tail was 16 zero bytes with no PCR selection and no digest. It parsed only because the old parser stopped reading after `extraData`. `TPMS_CLOCK_INFO` is 17 bytes, not 8, and `TPMS_QUOTE_INFO` was absent entirely — the fixture never described a structurally real quote.

Fixed properly rather than worked around. This is the same lesson as the DCAP type-6 header: synthetic self-consistency is not validation, and it is the argument for having one implementation that real captures exercise.

## Hardware vector

The Azure vTPM capture moved to agent-manifest with the code it validates, and runs on every PR there. `docs/testing/hardware-validation.md` keeps the capture provenance and now points at the new location, with a note on why evidence should live next to the implementation it validates.

`tests/unit/test_tpm_quote_signature.py` is rewritten to cover cMCP's remaining layer: result shaping, fail-closed handling of blobs agent-manifest rejects, and that the re-export still resolves.

## Migration note applied

`parse_tpmt_signature` now raises `TpmVerificationError` rather than `ValueError`. Both call sites widened. `nv_certify.py` catches broad `Exception` and was unaffected, but its import moved to `agent_manifest` so the dependency is explicit.

## Testing

`925 passed, 8 skipped` with **agent-manifest 0.8.0 resolved from PyPI**, not an editable local checkout. Running against an editable install is what let the agentrust-trace publishing gap hide, so this was verified against the published wheel deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)