### PR TITLE
fix(otel): wire R8 telemetry export into the running gateway

### DIFF
--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -84,7 +84,12 @@ def start(config: str, enforcement: str | None) -> None:
     import uvicorn
 
     from cmcp_runtime.config import parse_listen_addr
+    from cmcp_runtime.observability.otel import configure_tracer_provider
     from cmcp_runtime.startup import run_startup
+
+    # AARM R8: install the tracer provider before any session exists, so the
+    # first session's entries are exported too. No-op unless CMCP_OTEL_ENABLED.
+    configure_tracer_provider()
 
     ctx = run_startup(config)
 

--- a/src/cmcp_runtime/observability/otel.py
+++ b/src/cmcp_runtime/observability/otel.py
@@ -48,6 +48,7 @@ _otel_trace: Any = None
 _SpanKind: Any = None
 _Status: Any = None
 _StatusCode: Any = None
+_PLACEHOLDER_PROVIDERS: tuple[type, ...] = ()
 
 try:  # pragma: no cover - import-time branch depends on the environment
     from opentelemetry import trace as _imported_trace
@@ -56,10 +57,36 @@ try:  # pragma: no cover - import-time branch depends on the environment
     _otel_trace = _imported_trace
     _SpanKind, _Status, _StatusCode = SpanKind, Status, StatusCode
     OTEL_AVAILABLE = True
+
+    # get_tracer_provider() returns one of these until something installs a real
+    # SDK provider; spans from them are NonRecordingSpans that go nowhere. They
+    # are how `enabled` tells "OTel is importable" from "spans are exported".
+    #
+    # Resolved by getattr rather than a top-level import on purpose. These two
+    # names are a convenience, not a requirement, and folding them into the
+    # import above would mean a release that renames either one turns export off
+    # entirely -- reintroducing the silent no-op this module exists to avoid. An
+    # empty tuple degrades `enabled` to optimistic, which is the milder failure.
+    _PLACEHOLDER_PROVIDERS = tuple(
+        candidate
+        for candidate in (
+            getattr(_imported_trace, "NoOpTracerProvider", None),
+            getattr(_imported_trace, "ProxyTracerProvider", None),
+        )
+        if isinstance(candidate, type)
+    )
 except ImportError:  # pragma: no cover
     OTEL_AVAILABLE = False
 
-__all__ = ["OTEL_AVAILABLE", "OtelAuditExporter", "otel_sink_from_env"]
+__all__ = [
+    "OTEL_AVAILABLE",
+    "OtelAuditExporter",
+    "configure_tracer_provider",
+    "otel_sink_from_env",
+]
+
+#: Values of CMCP_OTEL_ENABLED that turn export on, case-insensitively.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 #: Audit entry fields that are safe to export. Everything omitted is either a
 #: payload-adjacent value or internal chain bookkeeping that a telemetry
@@ -107,7 +134,17 @@ class OtelAuditExporter:
 
     @property
     def enabled(self) -> bool:
-        return self._tracer is not None
+        """
+        True when a span emitted now would actually be recorded and exported.
+
+        Deliberately stricter than "opentelemetry imported". Without an SDK
+        provider installed the tracer is a proxy that yields NonRecordingSpans,
+        so export is silently a no-op; reporting True there told an operator
+        telemetry was working when nothing was leaving the process (#456).
+        """
+        if self._tracer is None:
+            return False
+        return not isinstance(_otel_trace.get_tracer_provider(), _PLACEHOLDER_PROVIDERS)
 
     def __call__(self, entry: AuditEntry) -> None:
         self.export(entry)
@@ -127,6 +164,12 @@ class OtelAuditExporter:
     def _export(self, tracer: Any, entry: AuditEntry) -> None:
         name = f"cmcp.{entry.entry_type}"
         with tracer.start_as_current_span(name, kind=_SpanKind.INTERNAL) as span:
+            # Skip the attribute work when the span is a NonRecordingSpan (no
+            # provider installed) or the sampler dropped it. This runs once per
+            # audit entry on the call path, so the ~19 discarded set_attribute
+            # calls are worth avoiding.
+            if not span.is_recording():
+                return
             for field_name in _EXPORTED_FIELDS:
                 value = getattr(entry, field_name, None)
                 if value is not None:
@@ -134,6 +177,90 @@ class OtelAuditExporter:
             decision = entry.policy_decision
             if decision in _ERROR_DECISIONS:
                 span.set_status(_Status(_StatusCode.ERROR, f"policy_decision={decision}"))
+
+
+def _export_requested() -> bool:
+    """True when ``CMCP_OTEL_ENABLED`` asks for export."""
+    return os.environ.get("CMCP_OTEL_ENABLED", "").strip().lower() in _TRUTHY
+
+
+def configure_tracer_provider() -> bool:
+    """
+    Install an SDK tracer provider so exported spans have somewhere to go.
+
+    Call once during process startup, before any session is created. Attaching
+    the sink is not sufficient on its own: ``trace.get_tracer()`` returns a
+    proxy that drops every span until a real provider is installed, which is
+    why ``CMCP_OTEL_ENABLED=1`` alone produced no telemetry at all (#456).
+
+    Returns True when spans will be exported after this call. No-ops when
+    export was not requested, when the optional dependency is missing, or when
+    something else already installed a provider - an embedder that configures
+    its own pipeline keeps it, and this function never replaces it.
+
+    The endpoint and the rest of the pipeline come from the standard
+    ``OTEL_EXPORTER_OTLP_*`` environment variables, so cMCP introduces no
+    second way to point telemetry at a collector.
+
+    Shutdown behaviour, measured against a live collector and a dead one: the
+    SDK flushes the batch queue at exit, so spans still buffered when the
+    gateway is signalled do arrive rather than being dropped. When the collector
+    is unreachable that flush retries with backoff before giving up, which added
+    roughly 6s to gateway shutdown in testing (~8.8s against a dead collector
+    versus ~2.2s against a healthy one). It terminates on its own and is well
+    inside a default Kubernetes grace period; operators who need it tighter can
+    set ``OTEL_BSP_EXPORT_TIMEOUT``.
+    """
+    if not _export_requested():
+        return False
+    if not OTEL_AVAILABLE:
+        logger.warning(
+            "CMCP_OTEL_ENABLED is set but opentelemetry is not installed; "
+            "telemetry export is disabled. Install with: pip install cmcp-runtime[otel]"
+        )
+        return False
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:  # pragma: no cover - depends on the environment
+        logger.warning(
+            "CMCP_OTEL_ENABLED is set but the OpenTelemetry SDK and OTLP exporter are "
+            "not installed; telemetry export is disabled. "
+            "Install with: pip install cmcp-runtime[otel]"
+        )
+        return False
+
+    if not isinstance(_otel_trace.get_tracer_provider(), _PLACEHOLDER_PROVIDERS):
+        logger.info("A tracer provider is already installed; leaving it in place")
+        return True
+
+    try:
+        resource = Resource.create(
+            {"service.name": os.environ.get("OTEL_SERVICE_NAME", "cmcp-gateway")}
+        )
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        _otel_trace.set_tracer_provider(provider)
+    except Exception:  # pragma: no cover - defensive
+        # The SDK validates OTEL_EXPORTER_OTLP_* at construction and raises on
+        # values it cannot parse: OTEL_EXPORTER_OTLP_TIMEOUT=abc and
+        # OTEL_EXPORTER_OTLP_COMPRESSION=bogus both raise ValueError. This runs
+        # from `cmcp start`, so letting that propagate would mean a typo in a
+        # telemetry variable takes the gateway down at boot. Telemetry is never
+        # allowed to do that; log it and run without export instead.
+        logger.warning(
+            "OTel tracer provider could not be configured; telemetry export is "
+            "disabled and the gateway will run without it. Check the "
+            "OTEL_EXPORTER_OTLP_* environment variables.",
+            exc_info=True,
+        )
+        return False
+
+    logger.info("OTel tracer provider installed; audit entries will be exported as spans")
+    return True
 
 
 def otel_sink_from_env() -> Callable[[Any], None] | None:
@@ -144,8 +271,11 @@ def otel_sink_from_env() -> Callable[[Any], None] | None:
     unset or falsey, so telemetry is opt-in rather than something a deployment
     discovers it is doing. Recognised truthy values are ``1``, ``true``,
     ``yes``, and ``on``, case-insensitively.
+
+    Attaching the returned sink exports nothing unless a tracer provider is
+    installed; see :func:`configure_tracer_provider`.
     """
-    if os.environ.get("CMCP_OTEL_ENABLED", "").strip().lower() not in {"1", "true", "yes", "on"}:
+    if not _export_requested():
         return None
     if not OTEL_AVAILABLE:
         logger.warning(

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -7,13 +7,14 @@ import hashlib
 import json
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
 from cmcp_runtime.agent_manifest import AgentManifestBinding
-from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.audit.chain import AuditChain, AuditEntry
 from cmcp_runtime.audit.trace_claim import (
     AgentIdentityInfo,
     AttestationReportInfo,
@@ -28,6 +29,7 @@ from cmcp_runtime.audit.trace_claim import (
 from cmcp_runtime.config import KillSwitchConfig
 from cmcp_runtime.errors import KillSwitchTripped
 from cmcp_runtime.kill_switch import KillSwitchEvaluator
+from cmcp_runtime.observability.otel import otel_sink_from_env
 from cmcp_runtime.policy.decisions import claim_value
 from cmcp_runtime.session.call_log import CallLog, SessionCallLog
 from cmcp_runtime.session.state import SessionState
@@ -58,6 +60,14 @@ class SessionManager:
         if not isinstance(ks_cfg, KillSwitchConfig):
             ks_cfg = KillSwitchConfig()  # disabled by default if not configured
         self._kill_switch = KillSwitchEvaluator(ks_cfg)
+        # AARM R8: telemetry export. Built once here rather than per session so
+        # every chain shares one exporter, and empty unless CMCP_OTEL_ENABLED
+        # asks for it. Sinks run after an entry is durable and cannot break the
+        # chain, so a collector outage stays a telemetry problem.
+        sink = otel_sink_from_env()
+        self._audit_sinks: list[Callable[[AuditEntry], None]] = (
+            [sink] if sink is not None else []
+        )
 
     def create_session(self) -> tuple[SessionState, AuditChain]:
         """
@@ -87,7 +97,11 @@ class SessionManager:
 
         session_id = str(uuid4())
         state = SessionState(session_id=session_id)
-        chain = AuditChain(session_id=session_id, store=self._ctx.audit_store)
+        chain = AuditChain(
+            session_id=session_id,
+            store=self._ctx.audit_store,
+            sinks=self._audit_sinks,
+        )
 
         # AUDIT-006: derive a per-session nonce that commits the chain root into
         # report_data, then KEEP the resulting report so close_session() builds the

--- a/tests/test_aarm_conformance.py
+++ b/tests/test_aarm_conformance.py
@@ -16,6 +16,7 @@ import pytest
 
 from cmcp_runtime.audit.chain import AuditChain
 from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.observability import otel as otel_module
 from cmcp_runtime.observability.otel import OtelAuditExporter, otel_sink_from_env
 from cmcp_runtime.policy.decisions import (
     AARM_DECISION_ANNOTATION,
@@ -207,3 +208,228 @@ class TestR8TelemetryExport:
             assert "payload" not in field_name or field_name.endswith("_hash")
         assert "detail" not in _EXPORTED_FIELDS
         assert "external_execution_evidence" not in _EXPORTED_FIELDS
+
+
+class TestOtelSpansActuallyExport:
+    """
+    #456: every test above passes against a feature that exports nothing.
+
+    They assert the sink plumbing and the inert path, which is exactly the state
+    the exporter was released in: no provider was ever installed and no sink was
+    ever attached to a production chain, so `CMCP_OTEL_ENABLED=1` produced no
+    telemetry. These tests exercise the recording path instead.
+
+    The global tracer provider is process-wide and refuses to be replaced, so
+    rather than calling set_tracer_provider these swap the module's handle on the
+    OTel API for one backed by an in-memory provider.
+    """
+
+    @pytest.fixture
+    def recorded(self, monkeypatch: pytest.MonkeyPatch):
+        """Yield a callable returning the spans exported so far."""
+        pytest.importorskip("opentelemetry.sdk")
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from cmcp_runtime.observability import otel as otel_module
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        class _Shim:
+            @staticmethod
+            def get_tracer(name: str):
+                return provider.get_tracer(name)
+
+            @staticmethod
+            def get_tracer_provider():
+                return provider
+
+        monkeypatch.setattr(otel_module, "_otel_trace", _Shim)
+        return exporter.get_finished_spans
+
+    def test_one_span_per_audit_entry_with_expected_attributes(self, recorded) -> None:
+        chain = AuditChain("otel-live-1", sinks=[OtelAuditExporter()])
+        chain.append(
+            "tool_call",
+            call_id="c-allow",
+            tool_name="echo",
+            policy_decision="allow",
+            latency_us=1234,
+            request_payload_hash="a" * 64,
+        )
+
+        spans = recorded()
+        assert [s.name for s in spans] == ["cmcp.session_start", "cmcp.tool_call"]
+
+        attrs = spans[1].attributes
+        assert attrs["cmcp.tool_name"] == "echo"
+        assert attrs["cmcp.policy_decision"] == "allow"
+        assert attrs["cmcp.call_id"] == "c-allow"
+        assert attrs["cmcp.latency_us"] == 1234
+        assert attrs["cmcp.request_payload_hash"] == "a" * 64
+        # The chain must be unaffected by having been mirrored.
+        assert chain.verify_chain()
+
+    def test_every_attribute_survives_the_otlp_type_constraint(self, recorded) -> None:
+        """set_attribute drops values it cannot represent; nothing may be dropped."""
+        from cmcp_runtime.observability.otel import _EXPORTED_FIELDS
+
+        chain = AuditChain("otel-live-2", sinks=[OtelAuditExporter()])
+        entry = chain.append(
+            "tool_call",
+            call_id="c1",
+            tool_name="echo",
+            server_identity="mock",
+            policy_decision="allow",
+            policy_rule_matched="allow-all",
+            latency_us=7,
+            request_payload_hash="a" * 64,
+            response_payload_hash="b" * 64,
+            response_inspection_result="pass",
+            workflow_id="w1",
+        )
+
+        attrs = recorded()[-1].attributes
+        for field_name in _EXPORTED_FIELDS:
+            if getattr(entry, field_name, None) is not None:
+                assert f"cmcp.{field_name}" in attrs, f"{field_name} was dropped by the SDK"
+                assert isinstance(attrs[f"cmcp.{field_name}"], (str, int, float, bool))
+
+    @pytest.mark.parametrize("decision", ["deny", "advisory_deny", "fault"])
+    def test_refused_calls_set_span_status_to_error(self, recorded, decision: str) -> None:
+        from opentelemetry.trace import StatusCode
+
+        chain = AuditChain("otel-live-3", sinks=[OtelAuditExporter()])
+        chain.append("tool_call", tool_name="blocked", policy_decision=decision)
+
+        span = recorded()[-1]
+        assert span.status.status_code is StatusCode.ERROR
+        assert span.status.description == f"policy_decision={decision}"
+
+    def test_allowed_calls_do_not_set_error_status(self, recorded) -> None:
+        from opentelemetry.trace import StatusCode
+
+        chain = AuditChain("otel-live-4", sinks=[OtelAuditExporter()])
+        chain.append("tool_call", tool_name="echo", policy_decision="allow")
+        assert recorded()[-1].status.status_code is not StatusCode.ERROR
+
+    def test_session_manager_attaches_the_sink(
+        self, recorded, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The gap in #456: the exporter worked, but nothing ever attached it to the
+        chain a running gateway uses, so a live collector received nothing.
+        """
+        from unittest.mock import MagicMock
+
+        from cmcp_runtime.session.manager import SessionManager
+
+        monkeypatch.setenv("CMCP_OTEL_ENABLED", "1")
+        ctx = MagicMock()
+        ctx.tee_provider.get_attestation_report.return_value = None
+
+        SessionManager(ctx).create_session()
+
+        assert "cmcp.session_start" in [s.name for s in recorded()]
+
+    def test_session_manager_attaches_nothing_when_export_is_off(
+        self, recorded, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from cmcp_runtime.session.manager import SessionManager
+
+        monkeypatch.delenv("CMCP_OTEL_ENABLED", raising=False)
+        ctx = MagicMock()
+        ctx.tee_provider.get_attestation_report.return_value = None
+
+        SessionManager(ctx).create_session()
+
+        assert recorded() == ()
+
+
+class TestExporterEnabledReportsRecording:
+    """`enabled` claimed True while spans were being discarded (#456)."""
+
+    def test_enabled_is_false_without_a_tracer_provider(self) -> None:
+        # Guarded on the module's own flag rather than importorskip: the
+        # opentelemetry namespace package can remain importable after the API
+        # is uninstalled, so importorskip does not mean the API is usable.
+        if not otel_module.OTEL_AVAILABLE:
+            pytest.skip("opentelemetry is not installed")
+        # No provider installed in the test process, so nothing is exported.
+        assert OtelAuditExporter().enabled is False
+
+    def test_configure_tracer_provider_is_a_noop_when_export_is_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from cmcp_runtime.observability.otel import configure_tracer_provider
+
+        monkeypatch.delenv("CMCP_OTEL_ENABLED", raising=False)
+        assert configure_tracer_provider() is False
+
+    def test_enabled_degrades_to_optimistic_if_placeholders_cannot_be_resolved(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The placeholder provider classes are resolved by getattr, so a release
+        that renames them costs this one signal rather than switching export off.
+        Deliberately the milder failure: `enabled` over-reports instead of the
+        module deciding OpenTelemetry is absent.
+        """
+        if not otel_module.OTEL_AVAILABLE:
+            pytest.skip("opentelemetry is not installed")
+
+        monkeypatch.setattr(otel_module, "_PLACEHOLDER_PROVIDERS", ())
+        assert otel_module.OtelAuditExporter().enabled is True
+
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [
+            ("OTEL_EXPORTER_OTLP_TIMEOUT", "abc"),
+            ("OTEL_EXPORTER_OTLP_COMPRESSION", "bogus"),
+            ("OTEL_EXPORTER_OTLP_HEADERS", "this is not valid"),
+            ("OTEL_EXPORTER_OTLP_ENDPOINT", "not-a-url::://x"),
+        ],
+    )
+    def test_a_malformed_otlp_variable_cannot_take_the_gateway_down(
+        self, monkeypatch: pytest.MonkeyPatch, var: str, value: str
+    ) -> None:
+        """
+        configure_tracer_provider() runs from `cmcp start`. The SDK validates
+        OTEL_EXPORTER_OTLP_* at construction and raises on values it cannot
+        parse, so an unguarded call would mean a typo in a telemetry variable
+        stops the gateway booting. Telemetry must never be able to do that.
+        """
+        if not otel_module.OTEL_AVAILABLE:
+            pytest.skip("opentelemetry is not installed")
+
+        monkeypatch.setenv("CMCP_OTEL_ENABLED", "1")
+        monkeypatch.setenv(var, value)
+        # Force the construction path rather than the already-installed early
+        # return, which would make this test vacuous.
+        monkeypatch.setattr(otel_module, "_PLACEHOLDER_PROVIDERS", (object,))
+        monkeypatch.setattr(
+            otel_module._otel_trace, "get_tracer_provider", lambda: object()
+        )
+        # Keep the process-global provider untouched: the values that parse
+        # cleanly would otherwise install one and leak into later tests.
+        monkeypatch.setattr(
+            otel_module._otel_trace, "set_tracer_provider", lambda provider: None
+        )
+
+        # Only some of these raise inside the SDK, and which ones is the SDK's
+        # business. The contract under test is that none of them propagate.
+        try:
+            result = otel_module.configure_tracer_provider()
+        except Exception as exc:  # pragma: no cover - the failure being guarded
+            pytest.fail(
+                f"{var}={value!r} propagated {exc!r}; a malformed telemetry "
+                "variable must not stop the gateway booting"
+            )
+        assert isinstance(result, bool)


### PR DESCRIPTION
Wires up the AARM R8 telemetry export that #442 shipped but never connected. Refs #456 — full investigation and the live-collector evidence are in [the issue comment](https://github.com/agentrust-io/cmcp/issues/456).

Deliberately does not close #456, so the issue can be closed by hand once the run is confirmed independently.

## The problem

Running a gateway with `CMCP_OTEL_ENABLED=1` and `pip install cmcp-runtime[otel]`, pointed at a real OTLP collector, produced **zero spans**. Two independent gaps, either one sufficient:

1. **The sink was never attached.** `otel_sink_from_env()` was exported and called nowhere in `src/`. `SessionManager` built its `AuditChain` without `sinks=`, so the only chain a running gateway uses had no observer.
2. **No tracer provider was ever installed.** `trace.get_tracer()` returns a proxy yielding `NonRecordingSpan`s until an SDK provider exists, so nothing read `OTEL_EXPORTER_OTLP_ENDPOINT`. Fixing gap 1 alone still exports nothing.

The exporter's payload logic needed no change — it was correct, just disconnected.

## What changed

1. `SessionManager.__init__` builds the sink once and passes it to every chain it creates.
2. New `configure_tracer_provider()`, called from `cmcp start` before the first session. Installs a `TracerProvider` with a `BatchSpanProcessor` over the OTLP exporter, using the SDK and exporter the `[otel]` extra already declared but never imported, driven by the standard `OTEL_EXPORTER_OTLP_*` variables. An embedder that installed its own provider keeps it.
3. That construction is guarded. The SDK validates `OTEL_EXPORTER_OTLP_*` eagerly and raises `ValueError` on values it cannot parse (`OTEL_EXPORTER_OTLP_TIMEOUT=abc`, `OTEL_EXPORTER_OTLP_COMPRESSION=bogus`). Since this runs at startup, an unguarded call would turn a typo in a telemetry variable into a gateway that will not boot.
4. `OtelAuditExporter.enabled` now reports whether a span emitted now would actually be recorded, rather than whether the OpenTelemetry API imported. It previously returned `True` in exactly the dead state.
5. Tests covering the recording path rather than the inert one.

## Verification

| Check | Result |
| --- | --- |
| Suite with `[otel]` | 1034 passed, 7 skipped |
| Suite on base install (no OpenTelemetry) | 1020 passed, 21 skipped |
| ruff / mypy | clean |
| Live gateway to live collector | allowed call `Unset`; denied call `Error` / `policy_decision=deny`; digests only |
| Shutdown flush (30s batch delay, signalled mid-buffer) | all buffered spans arrived |
| Unreachable collector | tool calls unaffected (0.01–0.06s); shutdown bounded ~8.8s vs ~2.2s healthy, self-terminating |
| Malformed `OTEL_EXPORTER_OTLP_*` values | returns `False` and the gateway starts without export, rather than raising |
| 16 concurrent sessions × 25 entries, one shared exporter | 416/416 spans, no cross-session attribute bleed, no sequence gaps, every chain verifies |

Eight of the new tests fail against `main`, including a direct reproduction of #456: a session created through `SessionManager` emits no span.

Live verification was done with `otel/opentelemetry-collector-contrib:0.115.1` against the `examples/minimal` bundle and the mock upstream.

## Notes for review

- No change to `AuditEntry`, entry hashing, or the TRACE Claim. Export remains a read-only mirror attached as a sink, and existing chains still verify.
- Export remains opt-in and a no-op without `CMCP_OTEL_ENABLED`; the base install is unaffected.
- The design question of whether cMCP owns the `TracerProvider` or defers to `opentelemetry-instrument` was settled by #442's own dependency list: the `[otel]` extra declares `opentelemetry-sdk` and `opentelemetry-exporter-otlp-proto-http`, and nothing imported either. Happy to revisit if the intent was different.
- Reproducing the live run currently needs `COPY README.md .` added to the `Dockerfile` — an unrelated packaging bug on `main`, filed separately and deliberately not fixed here.