### PR TITLE
refactor(tee): consume the shared SNP report layout from agent-manifest 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # is called on a peer-supplied manifest below, and before 0.6.1 a manifest
     # declaring ML-DSA-65 or hybrid crashed the verifier with an uncaught
     # RuntimeError on any install without the optional [pq] extra.
-    "agent-manifest>=0.8",
+    "agent-manifest>=0.10",
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",

--- a/src/cmcp_runtime/tee/sev_snp.py
+++ b/src/cmcp_runtime/tee/sev_snp.py
@@ -13,12 +13,13 @@ in the report's REPORT_DATA field and the report verifies against the AMD VCEK.
 from __future__ import annotations
 
 import contextlib
-import ctypes
 import hashlib
 import hmac
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN, parse_snp_report
 
 from cmcp_runtime.tee.base import AttestationReport, TEEProvider
 
@@ -31,52 +32,9 @@ _TSM_REPORT_DIR = Path("/sys/kernel/config/tsm/report")
 _TSM_ENTRY = "cmcp"
 
 
-class _SnpAttestationReport(ctypes.LittleEndianStructure):
-    """Mirror of struct snp_attestation_report from the Linux kernel
-    (include/uapi/linux/sev-guest.h).  Field offsets are computed by
-    ctypes so magic numeric offsets are never needed in application code.
-
-    Total size: 0x4A0 (1184) bytes.
-    """
-
-    _pack_ = 1
-    _fields_ = [
-        ("version",             ctypes.c_uint32),
-        ("guest_svn",           ctypes.c_uint32),
-        ("policy",              ctypes.c_uint64),
-        ("family_id",           ctypes.c_uint8 * 16),
-        ("image_id",            ctypes.c_uint8 * 16),
-        ("vmpl",                ctypes.c_uint32),
-        ("sig_algo",            ctypes.c_uint32),
-        ("current_tcb",         ctypes.c_uint64),
-        ("plat_info",           ctypes.c_uint64),
-        ("author_key_en",       ctypes.c_uint32),
-        ("rsvd1",               ctypes.c_uint32),
-        ("report_data",         ctypes.c_uint8 * 64),
-        ("measurement",         ctypes.c_uint8 * 48),
-        ("host_data",           ctypes.c_uint8 * 32),
-        ("id_key_digest",       ctypes.c_uint8 * 48),
-        ("author_key_digest",   ctypes.c_uint8 * 48),
-        ("report_id",           ctypes.c_uint8 * 32),
-        ("report_id_ma",        ctypes.c_uint8 * 32),
-        ("reported_tcb",        ctypes.c_uint64),
-        ("rsvd2",               ctypes.c_uint8 * 24),
-        ("chip_id",             ctypes.c_uint8 * 64),
-        ("committed_svn",       ctypes.c_uint8 * 8),
-        ("committed_version",   ctypes.c_uint8 * 8),
-        ("launch_svn",          ctypes.c_uint8 * 8),
-        ("rsvd3",               ctypes.c_uint8 * 168),
-        ("signature",           ctypes.c_uint8 * 512),
-    ]
-
-
-# Compile-time assertion: struct must be exactly 0x4A0 (1184) bytes.
-assert ctypes.sizeof(_SnpAttestationReport) == 0x4A0, (
-    f"_SnpAttestationReport size mismatch: "
-    f"got {ctypes.sizeof(_SnpAttestationReport):#x}, expected 0x4A0"
-)
-
-_SNP_REPORT_SIZE = ctypes.sizeof(_SnpAttestationReport)
+# The report length comes from agent-manifest's shared ABI table, so the
+# collector cannot disagree with the verifier about how long a report is.
+_SNP_REPORT_SIZE = SNP_REPORT_LEN
 
 
 def _tsm_get_report(report_data: bytes) -> bytes:
@@ -153,11 +111,12 @@ class SEVSNPProvider(TEEProvider):
         report_data = (nonce[:64] + b"\x00" * 64)[:64]
         raw_evidence = _tsm_get_report(report_data)
 
-        # Parse report via ctypes struct for named field access (HW-006)
-        report = _SnpAttestationReport.from_buffer_copy(raw_evidence)
+        # Layout and parse are shared with the verifier via agent-manifest, so
+        # collector and appraiser cannot disagree about where a field sits.
+        report = parse_snp_report(raw_evidence)
 
         # Measurement = SHA-384 of the measurement field within the SNP report
-        measurement_bytes = bytes(report.measurement)
+        measurement_bytes = report.measurement
         measurement = "sha384:" + hashlib.sha384(measurement_bytes).hexdigest()
 
         # HW-002: reject reports whose measurement does not match the expected binary hash.
@@ -178,6 +137,7 @@ class SEVSNPProvider(TEEProvider):
         )
 
 
-# Retained for callers/tests that referenced the module-level constant.
-_SNP_MEASUREMENT_OFFSET: int = _SnpAttestationReport.measurement.offset
-_SNP_MEASUREMENT_END: int = _SNP_MEASUREMENT_OFFSET + _SnpAttestationReport.measurement.size
+# Retained for callers/tests that referenced the module-level constants; the
+# values come from agent-manifest's shared ABI table rather than a local mirror.
+_SNP_MEASUREMENT_OFFSET: int = SNP_OFFSETS["measurement"]
+_SNP_MEASUREMENT_END: int = _SNP_MEASUREMENT_OFFSET + 48

--- a/src/cmcp_verify/azure_cvm.py
+++ b/src/cmcp_verify/azure_cvm.py
@@ -19,26 +19,19 @@ Validated against evidence produced on live Azure SEV-SNP hardware.
 from __future__ import annotations
 
 import base64
-import ctypes
 import hashlib
 import hmac
 import json
 import struct
 from dataclasses import dataclass, field
 
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN, load_snp_cert_chain, parse_snp_report
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
-from cmcp_verify.sev_snp import (
-    _SnpAttestationReport,
-    load_snp_cert_chain,
-    verify_snp_report_signature,
-    verify_vcek_chain,
-)
+from cmcp_verify.sev_snp import verify_snp_report_signature, verify_vcek_chain
 
-# SNP REPORT_DATA offset (AMD ABI); _rd_offset() prefers the ctypes field offset.
-_RD_OFFSET = 0x50
-_SNP_REPORT_SIZE = ctypes.sizeof(_SnpAttestationReport)
+_SNP_REPORT_SIZE = SNP_REPORT_LEN
 
 _TPM_GENERATED_VALUE = 0xFF544347
 # TPMT_SIGNATURE sigAlg values.
@@ -59,11 +52,8 @@ class AzureCVMVerificationResult:
 
 
 def _rd_offset() -> int:
-    # Prefer the ctypes-computed offset; fall back to the ABI constant.
-    try:
-        return int(_SnpAttestationReport.report_data.offset)
-    except Exception:  # noqa: BLE001
-        return _RD_OFFSET
+    # The ABI table is shared, so there is no local mirror to fall back to.
+    return SNP_OFFSETS["report_data"]
 
 
 def _extract_extra_data(quote_msg: bytes) -> bytes:
@@ -160,8 +150,8 @@ def verify_azure_cvm_measurement(
 
     # Step c: measurement field matches the claim.
     try:
-        report = _SnpAttestationReport.from_buffer_copy(snp[:_SNP_REPORT_SIZE])
-        computed = "sha384:" + hashlib.sha384(bytes(report.measurement)).hexdigest()
+        report = parse_snp_report(snp)
+        computed = "sha384:" + hashlib.sha384(report.measurement).hexdigest()
     except Exception:  # noqa: BLE001
         result.verified = False
         result.failure_reason = "raw_evidence_parse_error"

--- a/src/cmcp_verify/sev_snp.py
+++ b/src/cmcp_verify/sev_snp.py
@@ -14,12 +14,18 @@ pinned by the operator (AMD publishes it on the KDS).
 """
 from __future__ import annotations
 
-import ctypes
 import hashlib
 from dataclasses import dataclass, field
 
+from agent_manifest import (
+    SIG_ALGO_ECDSA_P384_SHA384,
+    SNP_REPORT_LEN,
+    load_snp_cert_chain,
+    parse_snp_report,
+    verify_snp_signature,
+)
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding
 
 # The SNP report is signed over its leading bytes; the 512-byte signature field
@@ -33,53 +39,6 @@ _SIG_ALGO_ECDSA_P384_SHA384 = 1
 # bytes (P-384 components are 48 bytes; the upper 24 are zero padding).
 _SNP_SIG_COMPONENT_LEN = 72
 _P384_COMPONENT_LEN = 48
-
-
-class _SnpAttestationReport(ctypes.LittleEndianStructure):
-    """Mirror of struct snp_attestation_report from the Linux kernel
-    (include/uapi/linux/sev-guest.h).  Matches the layout defined in
-    the gateway provider; kept in sync via the sizeof assertion below.
-
-    Total size: 0x4A0 (1184) bytes.
-    """
-
-    _pack_ = 1
-    _fields_ = [
-        ("version",             ctypes.c_uint32),
-        ("guest_svn",           ctypes.c_uint32),
-        ("policy",              ctypes.c_uint64),
-        ("family_id",           ctypes.c_uint8 * 16),
-        ("image_id",            ctypes.c_uint8 * 16),
-        ("vmpl",                ctypes.c_uint32),
-        ("sig_algo",            ctypes.c_uint32),
-        ("current_tcb",         ctypes.c_uint64),
-        ("plat_info",           ctypes.c_uint64),
-        ("author_key_en",       ctypes.c_uint32),
-        ("rsvd1",               ctypes.c_uint32),
-        ("report_data",         ctypes.c_uint8 * 64),
-        ("measurement",         ctypes.c_uint8 * 48),
-        ("host_data",           ctypes.c_uint8 * 32),
-        ("id_key_digest",       ctypes.c_uint8 * 48),
-        ("author_key_digest",   ctypes.c_uint8 * 48),
-        ("report_id",           ctypes.c_uint8 * 32),
-        ("report_id_ma",        ctypes.c_uint8 * 32),
-        ("reported_tcb",        ctypes.c_uint64),
-        ("rsvd2",               ctypes.c_uint8 * 24),
-        ("chip_id",             ctypes.c_uint8 * 64),
-        ("committed_svn",       ctypes.c_uint8 * 8),
-        ("committed_version",   ctypes.c_uint8 * 8),
-        ("launch_svn",          ctypes.c_uint8 * 8),
-        ("rsvd3",               ctypes.c_uint8 * 168),
-        ("signature",           ctypes.c_uint8 * 512),
-    ]
-
-
-assert ctypes.sizeof(_SnpAttestationReport) == 0x4A0, (
-    f"_SnpAttestationReport size mismatch: "
-    f"got {ctypes.sizeof(_SnpAttestationReport):#x}, expected 0x4A0"
-)
-
-_SNP_REPORT_MIN_SIZE = ctypes.sizeof(_SnpAttestationReport)
 
 
 @dataclass
@@ -101,49 +60,28 @@ def verify_snp_report_signature(
     the format pre-checks below keep cmcp's specific failure reasons. Returns
     (True, None) on a valid signature, (False, reason) otherwise. Fails closed.
     """
-    from agent_manifest import parse_snp_report, verify_snp_signature
-
     if len(raw_report) < _SNP_SIG_OFFSET + 2 * _SNP_SIG_COMPONENT_LEN:
         return False, "report too short to contain a signature"
     try:
-        report = _SnpAttestationReport.from_buffer_copy(raw_report[:_SNP_REPORT_MIN_SIZE])
+        report = parse_snp_report(raw_report)
     except Exception:  # noqa: BLE001
         return False, "cannot parse SNP report"
-    if report.sig_algo != _SIG_ALGO_ECDSA_P384_SHA384:
-        return False, f"unsupported sig_algo {report.sig_algo} (expected ECDSA-P384/SHA-384)"
+    if report.signature_algo != SIG_ALGO_ECDSA_P384_SHA384:
+        return False, (
+            f"unsupported sig_algo {report.signature_algo} (expected ECDSA-P384/SHA-384)"
+        )
 
     pub = vcek_cert.public_key()
     if not isinstance(pub, ec.EllipticCurvePublicKey) or pub.curve.name != "secp384r1":
         return False, "VCEK public key is not EC P-384"
 
     try:
-        ok = verify_snp_signature(parse_snp_report(raw_report), vcek_cert.public_bytes(Encoding.DER))
+        ok = verify_snp_signature(report, vcek_cert.public_bytes(Encoding.DER))
     except Exception:  # noqa: BLE001  (fail closed on any parse/verify error)
         return False, "SNP report signature does not verify against the VCEK"
     if not ok:
         return False, "SNP report signature does not verify against the VCEK"
     return True, None
-
-
-def load_snp_cert_chain(
-    pem_bundle: bytes,
-) -> tuple[x509.Certificate, x509.Certificate, x509.Certificate]:
-    """Parse a PEM bundle into (vcek, ask, ark).
-
-    VCEK is the EC leaf; among the RSA certs, the self-signed one is the ARK and
-    the other is the ASK. Raises ValueError if the bundle is not a well-formed
-    SNP chain.
-    """
-    certs = x509.load_pem_x509_certificates(pem_bundle)
-    vcek = next(
-        (c for c in certs if isinstance(c.public_key(), ec.EllipticCurvePublicKey)), None
-    )
-    rsa_certs = [c for c in certs if isinstance(c.public_key(), rsa.RSAPublicKey)]
-    ark = next((c for c in rsa_certs if c.subject == c.issuer), None)
-    ask = next((c for c in rsa_certs if c is not ark), None)
-    if vcek is None or ask is None or ark is None:
-        raise ValueError("bundle must contain a VCEK (EC), an ASK and a self-signed ARK (RSA)")
-    return vcek, ask, ark
 
 
 def verify_vcek_chain(
@@ -218,10 +156,9 @@ def verify_sev_snp_measurement(
         result.details["raw_evidence"] = "not provided; SNP report cannot be checked"
         return result
 
-    if len(raw_evidence) >= _SNP_REPORT_MIN_SIZE:
+    if len(raw_evidence) >= SNP_REPORT_LEN:
         try:
-            # Parse via ctypes struct for named field access (HW-006)
-            report = _SnpAttestationReport.from_buffer_copy(raw_evidence[:_SNP_REPORT_MIN_SIZE])
+            report = parse_snp_report(raw_evidence)
 
             # Accept report version >= 2. The fields we read (report_data 0x50,
             # measurement 0x90, reported_tcb 0x180, chip_id 0x1a0, signature 0x2a0)
@@ -239,7 +176,7 @@ def verify_sev_snp_measurement(
             result.details["snp_report_version"] = str(report.version)
 
             # Verify measurement field using named struct access
-            m_bytes = bytes(report.measurement)
+            m_bytes = report.measurement
             computed = "sha384:" + hashlib.sha384(m_bytes).hexdigest()
             if computed == measurement:
                 result.verified_fields.append("measurement")
@@ -255,7 +192,7 @@ def verify_sev_snp_measurement(
             # silently ignoring a mismatch would accept an SNP report for a
             # different enclave whose measurement happens to match.
             if report_data_hex is not None:
-                extracted_rd = bytes(report.report_data)
+                extracted_rd = report.report_data
                 expected_rd = bytes.fromhex(report_data_hex[:128])
                 # Pad expected to 64 bytes if shorter
                 if len(expected_rd) < 64:

--- a/tests/unit/test_azure_cvm_verify.py
+++ b/tests/unit/test_azure_cvm_verify.py
@@ -9,7 +9,6 @@ closed on tampering. A real-hardware fixture test is env-gated at the bottom.
 from __future__ import annotations
 
 import base64
-import ctypes
 import hashlib
 import json
 import os
@@ -17,6 +16,7 @@ import struct
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
@@ -25,12 +25,12 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509.oid import NameOID
 
 from cmcp_verify.azure_cvm import verify_azure_cvm_measurement
-from cmcp_verify.sev_snp import _SNP_SIG_OFFSET, _SnpAttestationReport
+from cmcp_verify.sev_snp import _SNP_SIG_OFFSET
 
-_MEAS_OFFSET = _SnpAttestationReport.measurement.offset
-_RD_OFFSET = _SnpAttestationReport.report_data.offset
-_SIG_ALGO_OFFSET = _SnpAttestationReport.sig_algo.offset
-_REPORT_SIZE = ctypes.sizeof(_SnpAttestationReport)
+_MEAS_OFFSET = SNP_OFFSETS["measurement"]
+_RD_OFFSET = SNP_OFFSETS["report_data"]
+_SIG_ALGO_OFFSET = SNP_OFFSETS["sig_algo"]
+_REPORT_SIZE = SNP_REPORT_LEN
 
 
 def _name(cn: str) -> x509.Name:

--- a/tests/unit/test_sev_snp_verify.py
+++ b/tests/unit/test_sev_snp_verify.py
@@ -1,16 +1,17 @@
 """Unit tests for AMD SEV-SNP attestation verification (issue #67)."""
 from __future__ import annotations
 
-import ctypes
 import hashlib
 import struct
 
-from cmcp_verify.sev_snp import _SnpAttestationReport, verify_sev_snp_measurement
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN, parse_snp_report
 
-_REPORT_DATA_OFFSET = _SnpAttestationReport.report_data.offset
-_MEASUREMENT_OFFSET = _SnpAttestationReport.measurement.offset
-_HOST_DATA_OFFSET   = _SnpAttestationReport.host_data.offset
-_REPORT_SIZE        = ctypes.sizeof(_SnpAttestationReport)
+from cmcp_verify.sev_snp import verify_sev_snp_measurement
+
+_REPORT_DATA_OFFSET = SNP_OFFSETS["report_data"]
+_MEASUREMENT_OFFSET = SNP_OFFSETS["measurement"]
+_HOST_DATA_OFFSET   = SNP_OFFSETS["host_data"]
+_REPORT_SIZE        = SNP_REPORT_LEN
 
 
 def make_snp_report(
@@ -27,20 +28,26 @@ def make_snp_report(
     return bytes(buf)
 
 
+# These pin the ABI values cMCP builds and appraises reports against. The table
+# now comes from agent-manifest, and the dependency is a floor pin, so these are
+# the guard that an upstream release cannot move an offset out from under cMCP
+# without a red build here.
+
+
 def test_snp_struct_size() -> None:
-    assert ctypes.sizeof(_SnpAttestationReport) == 0x4A0
+    assert SNP_REPORT_LEN == 0x4A0
 
 
 def test_snp_struct_report_data_offset() -> None:
-    assert _SnpAttestationReport.report_data.offset == 0x050
+    assert SNP_OFFSETS["report_data"] == 0x050
 
 
 def test_snp_struct_measurement_offset() -> None:
-    assert _SnpAttestationReport.measurement.offset == 0x090
+    assert SNP_OFFSETS["measurement"] == 0x090
 
 
 def test_snp_struct_host_data_offset() -> None:
-    assert _SnpAttestationReport.host_data.offset == 0x0C0
+    assert SNP_OFFSETS["host_data"] == 0x0C0
 
 
 def test_snp_struct_round_trip() -> None:
@@ -50,7 +57,7 @@ def test_snp_struct_round_trip() -> None:
     buf[_MEASUREMENT_OFFSET : _MEASUREMENT_OFFSET + 48] = pattern
     host_pattern = bytes(range(32, 64))
     buf[_HOST_DATA_OFFSET : _HOST_DATA_OFFSET + 32] = host_pattern
-    report = _SnpAttestationReport.from_buffer_copy(buf)
+    report = parse_snp_report(bytes(buf))
     assert report.version == 2
     assert bytes(report.measurement) == pattern
     assert bytes(report.host_data) == host_pattern

--- a/tests/unit/test_snp_signature_verify.py
+++ b/tests/unit/test_snp_signature_verify.py
@@ -10,11 +10,11 @@ marked skipped below and unblocks when that hardware fixture lands.
 """
 from __future__ import annotations
 
-import ctypes
 import hashlib
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -24,15 +24,14 @@ from cryptography.x509.oid import NameOID
 
 from cmcp_verify.sev_snp import (
     _SNP_SIG_OFFSET,
-    _SnpAttestationReport,
     verify_sev_snp_measurement,
     verify_snp_report_signature,
 )
 
-_SIG_ALGO_OFFSET = _SnpAttestationReport.sig_algo.offset
-_MEAS_OFFSET = _SnpAttestationReport.measurement.offset
-_RD_OFFSET = _SnpAttestationReport.report_data.offset
-_REPORT_SIZE = ctypes.sizeof(_SnpAttestationReport)
+_SIG_ALGO_OFFSET = SNP_OFFSETS["sig_algo"]
+_MEAS_OFFSET = SNP_OFFSETS["measurement"]
+_RD_OFFSET = SNP_OFFSETS["report_data"]
+_REPORT_SIZE = SNP_REPORT_LEN
 
 
 def _name(cn: str) -> x509.Name:

--- a/tests/unit/test_tee_providers.py
+++ b/tests/unit/test_tee_providers.py
@@ -10,10 +10,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from agent_manifest import SNP_OFFSETS, SNP_REPORT_LEN, parse_snp_report
 
 from cmcp_runtime.errors import AttestationProviderNotImplemented
 from cmcp_runtime.tee.opaque import OpaqueProvider
-from cmcp_runtime.tee.sev_snp import SEVSNPProvider, _SnpAttestationReport
+from cmcp_runtime.tee.sev_snp import SEVSNPProvider
 from cmcp_runtime.tee.tdx import TDXProvider, _TdxReportReq
 from cmcp_runtime.tee.tpm import TPMProvider
 
@@ -33,33 +34,35 @@ def test_opaque_provider_name() -> None:
     assert OpaqueProvider().provider_name() == "opaque"
 
 
-# ── SEVSNPProvider struct layout (HW-006) ─────────────────────────────────────
+# ── SNP report layout (HW-006) ────────────────────────────────────────────────
+# The layout is agent-manifest's; these assert the resolved version still agrees
+# with what this provider assumes, which a floor pin does not otherwise guarantee.
 
 def test_snp_struct_size() -> None:
-    """_SnpAttestationReport must be exactly 0x4A0 bytes."""
-    assert ctypes.sizeof(_SnpAttestationReport) == 0x4A0
+    """An SNP report must be exactly 0x4A0 bytes."""
+    assert SNP_REPORT_LEN == 0x4A0
 
 
 def test_snp_struct_measurement_field_round_trip() -> None:
     """Write a known pattern at the struct-derived measurement offset,
     parse with from_buffer_copy, assert the named field reads it back."""
-    buf = bytearray(ctypes.sizeof(_SnpAttestationReport))
+    buf = bytearray(SNP_REPORT_LEN)
     struct.pack_into("<I", buf, 0, 2)
     pattern = bytes(range(48))
-    offset = _SnpAttestationReport.measurement.offset
+    offset = SNP_OFFSETS["measurement"]
     buf[offset : offset + 48] = pattern
-    report = _SnpAttestationReport.from_buffer_copy(buf)
+    report = parse_snp_report(bytes(buf))
     assert bytes(report.measurement) == pattern
 
 
 def test_snp_struct_host_data_field_round_trip() -> None:
     """Write a known pattern at the host_data offset; read back via named field."""
-    buf = bytearray(ctypes.sizeof(_SnpAttestationReport))
+    buf = bytearray(SNP_REPORT_LEN)
     struct.pack_into("<I", buf, 0, 2)
     pattern = bytes(range(32))
-    offset = _SnpAttestationReport.host_data.offset
+    offset = SNP_OFFSETS["host_data"]
     buf[offset : offset + 32] = pattern
-    report = _SnpAttestationReport.from_buffer_copy(buf)
+    report = parse_snp_report(bytes(buf))
     assert bytes(report.host_data) == pattern
 
 
@@ -102,11 +105,11 @@ def test_sev_snp_get_report_raises_when_tsm_unavailable(monkeypatch: pytest.Monk
 def test_sev_snp_get_report_success_via_tsm(monkeypatch: pytest.MonkeyPatch) -> None:
     """get_attestation_report parses the configfs-TSM outblob and binds the nonce."""
     from cmcp_runtime.tee import sev_snp as snp_mod
-    from cmcp_runtime.tee.sev_snp import _SNP_REPORT_SIZE, _SnpAttestationReport
+    from cmcp_runtime.tee.sev_snp import _SNP_REPORT_SIZE
 
     nonce = bytes(range(64))
     raw = bytearray(_SNP_REPORT_SIZE)
-    raw[_SnpAttestationReport.report_data.offset:_SnpAttestationReport.report_data.offset + 64] = nonce
+    raw[SNP_OFFSETS["report_data"]:SNP_OFFSETS["report_data"] + 64] = nonce
     monkeypatch.setattr(snp_mod, "_tsm_get_report", lambda report_data: bytes(raw))
 
     report = SEVSNPProvider().get_attestation_report(nonce)


### PR DESCRIPTION
Phase B2 of the TEE consolidation, following #464 (TPM). Net **-104 lines**.

## Two copies, both gone

cMCP carried **two byte-identical ctypes mirrors** of the SEV-SNP report layout: one in `cmcp_verify/sev_snp.py` and one in `cmcp_runtime/tee/sev_snp.py`. The verifier and the collector each had their own idea of where a field sits, and nothing checked that the two agreed. They do agree today; nothing structural kept them agreeing.

Both are deleted. The layout, the parse, and the ABI offset table now come from agent-manifest, so the thing that collects a report and the thing that appraises it read the same table by construction.

`load_snp_cert_chain` also goes, having moved upstream in 0.9.0.

## What 0.9.0 restored

agent-manifest's `verify_snp_signature()` now checks the report's declared `sig_algo` before verifying under ECDSA-P384/SHA-384. cMCP already did this, which is how the gap upstream was found: consolidating onto the shared implementation as it stood would have silently dropped a check this repo already performed. It is enforced in both places now.

## Tests

The struct was used as an offset oracle across four test files. Those now read `agent_manifest.SNP_OFFSETS`.

The offset assertions (`report_data == 0x50`, `measurement == 0x90`, and so on) are **kept rather than deleted**. They look redundant now that agent-manifest tests its own table against a genuine Azure capture, but the dependency is a floor pin (`>=0.10`), so these are the guard that an upstream release cannot move an offset out from under cMCP without turning this build red.

## Testing

`925 passed, 8 skipped` with **agent-manifest 0.10.0 resolved from PyPI**, not an editable checkout. Identical count to before the change, so two layout mirrors came out with no behavioural movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)