### PR TITLE
chore(deps): ceiling agt-core below 5.0 so pip cannot break Cedar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,14 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.29",
     "click>=8.1",
-    "agent-governance-toolkit-core>=4.0",
+    # Held on the 4.x line deliberately, see #472. PolicyEvaluator imports
+    # agent_os.policies.backends.CedarBackend, which AGT removed in #3444 when
+    # the v4 policy language was replaced by ACS v5. 4.1.0 (tagged 2026-06-09)
+    # is the last release that ships it, and >=4.0 with no ceiling let pip pick
+    # a 5.x that would break policy evaluation entirely. The ceiling is the
+    # constraint that matters; the floor stays open so an agt-core 4.1.1 with
+    # the cryptography cap lift (#471) is taken automatically when it ships.
+    "agent-governance-toolkit-core>=4.1.0,<5.0",
     "cedarpy>=4.0",
 ]
 


### PR DESCRIPTION
First step from #472.

## The hazard

`PolicyEvaluator` imports the v4 Cedar backend directly:

```python
# src/cmcp_runtime/policy/evaluator.py
from agent_os.policies.backends import CedarBackend
```

AGT removed that module in [microsoft/agent-governance-toolkit#3444](https://github.com/microsoft/agent-governance-toolkit/pull/3444), when the v4 policy language was replaced by ACS v5. It does not exist on `main` and will not be in any release after the 4.x line. `agent-governance-toolkit-core` 4.1.0, tagged 2026-06-09, is the last release that ships it.

We work today only because `>=4.0` with no ceiling *happens* to resolve to 4.1.0, and 4.1.0 happens to be preferred because 5.0.0's `agentrust-trace<0.3.0` conflicts with our `agentrust-trace>=0.5`. Both of those are accidents of the current dependency graph, not decisions. Either could change without us touching anything.

Cedar evaluation is the enforcement path, so this is not a degradation risk. A resolver that picks 5.x does not make cMCP slower or noisier, it stops it deciding anything correctly, and the demos, the web console, and every conformance claim go with it.

## Why a range and not an exact pin

#472 suggested `==4.1.0`. `>=4.1.0,<5.0` is better:

- The **ceiling** is the part carrying the safety property. `<5.0` is where `CedarBackend` disappears, and semver says a 4.x minor should not remove public API, so the major boundary is the correct line.
- Leaving the **floor** open means an agt-core **4.1.1** carrying the cryptography cap lift is picked up automatically. That is the fix for the two reachable advisories in #471, requested upstream as [microsoft/agent-governance-toolkit#3614](https://github.com/microsoft/agent-governance-toolkit/issues/3614). An exact pin would need a second PR to take it.

## CI will be red, and not because of this

The security scan fails on this branch exactly as it does on every other cmcp branch right now: `cryptography` 48.0.1 reports CVE-2026-69249 and CVE-2026-69248, both reachable through the untrusted `cert_chain` a claim carries into `verify_ak_ek_chain`. That is #471, it predates this change, and this PR neither helps nor worsens it. Verified separately that with `cryptography` 49.0.0 forced over the cap, agt-core 4.1.0 is fine: 1041 tests pass, `CedarBackend` decisions are unchanged, and the audit exits clean.

This PR is only about making the constraint deliberate rather than accidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)