### PR TITLE
test(catalog): pin the sensitivity vocabulary against a fail-open regression

### DIFF
--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -160,3 +160,35 @@ def test_uppercase_tool_name_is_rejected(catalog_file):
     entry["tool_name"] = "CRM.Query"
     with pytest.raises(ConfigError, match="lowercase"):
         load_catalog(catalog_file([entry]))
+
+
+def test_unknown_sensitivity_level_is_rejected(catalog_file):
+    """An out-of-vocabulary sensitivity level must not load.
+
+    This guards a would-be fail-open path. SENSITIVITY_ORDER.get(level, 0) ranks
+    anything it does not recognise at 0, the same rank as "public", so a catalog
+    that slipped through with "secret" or "restricted" would silently be treated
+    as the least sensitive class the gateway has: policies keyed on
+    sensitivity_level would under-enforce and the session maximum would never
+    rise. Schema validation at load is what stops that, and this test pins it.
+    """
+    entry = dict(ENTRY_1, sensitivity_level="secret")
+    with pytest.raises(ConfigError, match="is not one of"):
+        load_catalog(catalog_file([entry]))
+
+
+def test_miscased_sensitivity_level_is_rejected(catalog_file):
+    """The vocabulary is case-sensitive, so "Confidential" is not "confidential"."""
+    entry = dict(ENTRY_1, sensitivity_level="Confidential")
+    with pytest.raises(ConfigError, match="is not one of"):
+        load_catalog(catalog_file([entry]))
+
+
+def test_every_known_sensitivity_level_loads(catalog_file):
+    """The accepted set is exactly the one the ordering table knows about."""
+    from cmcp_runtime.session.state import SENSITIVITY_ORDER
+
+    for level in SENSITIVITY_ORDER:
+        entry = dict(ENTRY_1, sensitivity_level=level)
+        cat = load_catalog(catalog_file([entry]))
+        assert cat.entries["crm.query"].sensitivity_level == level


### PR DESCRIPTION
No production change. Three regression tests around a security-relevant invariant that nothing currently asserts.

## The invariant

`SENSITIVITY_ORDER.get(level, 0)` ranks anything it does not recognise at `0` — the same rank as `public`. So if an out-of-vocabulary `sensitivity_level` ever reached a `CatalogEntry`:

- every policy keyed on `sensitivity_level` would under-enforce, because the value handed to Cedar at egress is that `0`
- `_max_sensitivity` would never raise the session maximum for that call

A security control failing open, from a typo in a catalog file.

## Why this is worth tests

Schema validation at load already prevents it, and correctly:

```
Catalog entry 'crm.query' schema violation: 'Confidential' is not one of
['public', 'pii', 'confidential', 'hipaa_phi', 'mnpi', 'trade_secret']
```

I went looking for this expecting a bug and found the guard already in place. But nothing in the suite said so, which means the guarantee was one refactor of the loader away from disappearing silently — and the failure mode is invisible at runtime, since an under-enforcing policy looks exactly like a policy that allowed the call.

## The tests

- an unknown level (`secret`) is rejected at load
- a miscased level (`Confidential`) is rejected, pinning case sensitivity
- **every key of `SENSITIVITY_ORDER` loads successfully** — this one couples the schema to the ordering table, so the two cannot drift apart. If someone adds a level to the ordering table without adding it to the schema, this fails.

## Verification

`tests/unit/test_catalog.py` passes, 17 tests.

I could not run the full unit suite locally: 11 modules fail to collect with `cannot import name 'GovernancePolicy' from 'agent_os.mcp_gateway'`, which is a local editable AGT checkout shadowing the released package. It reproduces identically on `main`, so it predates this branch and is an environment issue on my machine rather than anything here. CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)