### PR TITLE
Repair the broken social card image, give the homepage a real title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,8 @@
-﻿# cMCP Spec
+---
+title: The secure, confidential way to run MCP
+---
+
+# cMCP Spec
 
 cMCP Runtime is a hardware-attested MCP (Model Context Protocol) runtime. Every MCP tool call an agent makes passes through a TEE-isolated gateway that evaluates it against a Cedar policy bundle and produces a TRACE Claim: a signed, hardware-attested proof artifact a verifier can check without trusting the operator.
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -18,7 +18,7 @@
   <meta property="og:title" content="{% if page and page.title and not page.is_homepage %}{{ page.title }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
   <meta property="og:description" content="{{ page_desc }}">
   <meta property="og:url" content="{{ page_url }}">
-  <meta property="og:image" content="https://cmcp.agentrust-io.com/docs/assets/og.png">
+  <meta property="og:image" content="{{ config.site_url }}assets/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="cMCP: an AgenTrust open standard">
@@ -26,7 +26,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{% if page and page.title and not page.is_homepage %}{{ page.title }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
   <meta name="twitter:description" content="{{ page_desc }}">
-  <meta name="twitter:image" content="https://cmcp.agentrust-io.com/docs/assets/og.png">
+  <meta name="twitter:image" content="{{ config.site_url }}assets/og.png">
 
   <script type="application/ld+json">
   {


### PR DESCRIPTION
Two SEO defects found by auditing the live sites, not from a code read.

## The social card image has never worked

`overrides/main.html` pointed `og:image` and `twitter:image` at
`https://cmcp.agentrust-io.com/docs/assets/og.png`. That URL returns **404**.

```
/docs/assets/og.png   404
/assets/og.png        200
```

mkdocs strips the `docs/` prefix at build time, so the asset is served from
`/assets/`. Every share of `cmcp.agentrust-io.com` on LinkedIn, X or Slack has
been rendering a card with no image.

The template was almost certainly copied from `trace` or `ca2a`, where assets
genuinely **do** live under `/docs/`. Both of those are correct as they stand, so
this is a cMCP-only defect. Fixed by deriving the URL from `config.site_url`
rather than hardcoding it, so it cannot drift again.

## The homepage title was just "cMCP"

Material uses `site_name` verbatim as `<title>` when a page has no front-matter
title. So the flagship page of the project was titled `cMCP`.

Nobody searches for "cMCP". They search for secure MCP, confidential MCP, MCP
security. `site_description` in `mkdocs.yml` already says exactly that:

> "The secure, confidential way to run MCP: hardware-attested, TEE-enforced tool-call policy..."

That language was sitting in the meta description while the title, the strongest
ranking signal available, wasted it.

Adds a front-matter `title` so the homepage renders as:

```
The secure, confidential way to run MCP - cMCP
```

`site_name` stays short, so the nav header and breadcrumbs are unchanged.

## Also

`docs/README.md` carried a UTF-8 BOM. Left in place it would have broken YAML
front-matter parsing, so it is stripped.

## Verification

Built locally with `mkdocs build` rather than reasoned about:

- `<title>` renders as `The secure, confidential way to run MCP - cMCP`
- emitted `og:image` is `https://cmcp.agentrust-io.com/assets/og.png`
- that path exists in the build output
- caught and fixed a double slash on the first attempt, because mkdocs normalises
  `site_url` with a trailing slash already

## Context

Part of a wider audit of the AgenTrust sites. The same bare-acronym title problem
affects `ca2a`, `trace`, `manifest` and `tests`, and `ca2a`, `governance` and
`tests` have no Open Graph tags at all. Separate PRs to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)