### PR TITLE
docs(adopters): drop the placeholder row

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,7 +1,7 @@
 # Adopters
 
-Organizations using cMCP in production or evaluation. Open a PR to add your organization.
+Organizations using cMCP in production or evaluation are listed here.
 
-| Organization | Use Case | Since |
-|---|---|---|
-| Your org here | - | - |
+To add yours, open a PR adding a line with your organization, the use case, and the month you started. Anything you are not able to say publicly, leave out; a one-line entry is worth more than a case study you have to get approved.
+
+If you are running cMCP but cannot be named, we would still like to hear where it bends: open a [Discussion](https://github.com/orgs/agentrust-io/discussions) or contact the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).


### PR DESCRIPTION
Response-plan list 1, P2.

`ADOPTERS.md` published a table whose only row was `| Your org here | - | - |`. On a public repo that advertises zero adoption more loudly than having no table at all: the reader sees the shape of a list, then sees it is empty.

Table removed, contribution instructions kept, plus an invitation for people running it who cannot be named publicly to tell us where it bends. The table comes back with the first real entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
