### PR TITLE
feat(stdio): the gateway spawns the server, and refuses to spawn what it cannot check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **stdio transport: the gateway spawns the MCP server as its own child, inside the enclave (#484).** `docs/spec/transport.md` ruled stdio out and rejected two bridging options, correctly, because both put a translating component *outside* the TEE where it can inject or suppress calls before the gateway sees them. Both options assumed the agent spawns the server. It does not: that same document states the agent reaches only the gateway and that the runtime catalog is authoritative. So the child is a child of a process already inside the enclave, and nothing crosses the boundary that does not cross it today.
+
+  **This buys a binding no network upstream can have.** The gateway chooses when to `exec`, so it digests the entrypoint first and refuses to spawn on a mismatch. A pinned TLS fingerprint identifies an endpoint; a verified digest identifies code.
+
+  **And it costs something, which is in the spec rather than the footnotes.** The server then runs in the same isolation domain as the policy evaluator and the audit chain, and the gateway's launch measurement does not cover a process spawned later. The child's digest is therefore reported as its own evidence class, `spawn-measured` or `spawn-unmeasured`, never folded into `hardware_attestation`.
+
+  Defaults: `attestation.allow_unmeasured_spawn` is `false`, so a server the catalog does not pin is not spawned at all. Turning it on does not make the spawn silent; every such call is recorded as `spawn-unmeasured`.
+
+  Two design corrections came out of writing the tests. **Pinning the executable is nearly useless for an interpreted server** — the executable is the interpreter, so every Python MCP server on a host shares one digest and the pin would match a completely different server; `measure_target` pins the entrypoint instead. And **executable and readable are different properties**: a Windows Store Python is an App Execution Alias that runs fine and cannot be opened for reading, so an unmeasurable target is a refusal with an explanation rather than a crash.
+
+  Framing errors are fatal by design. A child that logs to stdout has desynchronized the JSON-RPC stream, and skipping to the next parsable line means guessing which bytes answered which call; a response whose id does not match its request is fatal for the same reason. stderr never enters the audit chain, because diagnostics carry payloads and the chain is meant to be shareable: content goes to the logger, only the byte count is exposed.
+
+  The catalog schema conditions its requirements on transport rather than relaxing them, so a network transport still requires `url` and `tls_fingerprint` while stdio requires `spawn`.
+
 ## [0.4.0] - 2026-08-08
 
 **Anyone running 0.3.0 should upgrade.** On 0.3.0 a forged TPM quote was reported as hardware-attested: the `tpm2` branch of `verify_trace_claim` called only `verify_tpm_measurement`, which takes no signature parameter, so a `TPMS_ATTEST` with the correct magic and matching `qualifying_data` passed with no signature and no certificate chain (#370). The authenticated path existed and was tested; nothing in production called it. This release makes the quote signature and the AK certificate chain the gate on `hardware_attestation`, so evidence that does not chain to a pinned root can no longer report as verified.

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,12 +13,14 @@ picture is stated once. Developer Preview: interfaces may change before v1.0.
 | `attestation.staleness_policy` | `fail_closed` |
 | `attestation.validity_seconds` | `86400` |
 | `policy_reload_interval_seconds` | `0` (disabled; policy change requires an enclave restart) |
+| `attestation.allow_unmeasured_spawn` | `false` (a stdio server the catalog does not pin is not spawned) |
 
 ## Capabilities
 
 | Capability | Status | Notes |
 |---|---|---|
-| MCP interception + Cedar policy evaluation inside the TEE | Shipped | HTTP/SSE transport. `stdio` is not yet supported (bridge planned, Phase 2). |
+| MCP interception + Cedar policy evaluation inside the TEE | Shipped | HTTP/SSE transport. |
+| `stdio` transport | Shipped | The gateway spawns the server as its own child **inside the enclave**, rather than bridging from outside, which is what the two rejected options in [`docs/spec/transport.md`](docs/spec/transport.md) did. It measures the entrypoint against the catalog and refuses to spawn on a mismatch, so a stdio upstream carries a stronger binding than a network one: a TLS pin identifies an endpoint, a digest identifies code. The cost is real and stated in [`docs/spec/stdio-transport.md`](docs/spec/stdio-transport.md): the server then runs in the same isolation domain as the policy evaluator, and the gateway's launch measurement does not cover a child spawned later. Recorded as `spawn-measured`, or `spawn-unmeasured` when `attestation.allow_unmeasured_spawn` is on. |
 | Enforcement modes (`enforcing` / `advisory` / `silent`) | Shipped | Default is `enforcing`. |
 | Hash-chained audit log, TEE-sealed signing key | Shipped | |
 | `GatewayClaim` (TRACE Claim) generation + signing | Shipped | Normative schema: [`schemas/trace-claim.schema.json`](schemas/trace-claim.schema.json). |

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -23,8 +23,6 @@
       "additionalProperties": false,
       "required": [
         "display_name",
-        "url",
-        "tls_fingerprint",
         "transport"
       ],
       "properties": {
@@ -43,21 +41,109 @@
           "description": "Colon-separated SHA-256 TLS certificate fingerprint in OpenSSL format."
         },
         "spiffe_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^spiffe://",
           "description": "SPIFFE SVID for this server; required when SPIFFE is deployed, null otherwise."
         },
         "transport": {
           "type": "string",
-          "enum": ["http-sse", "websocket"],
-          "description": "Transport protocol; stdio is excluded from Phase 1."
+          "enum": [
+            "http-sse",
+            "websocket",
+            "stdio"
+          ],
+          "description": "Transport protocol. stdio means the gateway spawns the server as its own child inside the enclave; see docs/spec/stdio-transport.md."
+        },
+        "spawn": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "command"
+          ],
+          "description": "How to start a stdio server. Required when transport is stdio, ignored otherwise.",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Executable to run."
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Arguments."
+            },
+            "binary_digest": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "description": "Expected digest of measure_target. Absent means the server is not pinned, which requires attestation.allow_unmeasured_spawn and is recorded as spawn-unmeasured."
+            },
+            "measure_target": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File the digest covers; defaults to the resolved executable. Set this to the entrypoint for interpreted servers, where the executable is the interpreter and every server on the host would otherwise share one digest."
+            }
+          }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$comment": "A network transport needs an endpoint and a pin; stdio has neither.",
+          "if": {
+            "properties": {
+              "transport": {
+                "enum": [
+                  "http-sse",
+                  "websocket"
+                ]
+              }
+            },
+            "required": [
+              "transport"
+            ]
+          },
+          "then": {
+            "required": [
+              "url",
+              "tls_fingerprint"
+            ]
+          }
+        },
+        {
+          "$comment": "A stdio server needs to say what the gateway should spawn.",
+          "if": {
+            "properties": {
+              "transport": {
+                "const": "stdio"
+              }
+            },
+            "required": [
+              "transport"
+            ]
+          },
+          "then": {
+            "required": [
+              "spawn"
+            ]
+          }
+        }
+      ]
     },
     "approved_definition": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["description", "input_schema"],
+      "required": [
+        "description",
+        "input_schema"
+      ],
       "properties": {
         "description": {
           "type": "string",
@@ -68,7 +154,10 @@
           "description": "JSON Schema describing the tool input parameters."
         },
         "output_schema": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "description": "JSON Schema describing the tool output; null if not specified."
         }
       }
@@ -80,7 +169,15 @@
     },
     "compliance_domain": {
       "type": "string",
-      "enum": ["hipaa_phi", "pci_data", "mnpi", "pii", "internal", "external", "public"],
+      "enum": [
+        "hipaa_phi",
+        "pci_data",
+        "mnpi",
+        "pii",
+        "internal",
+        "external",
+        "public"
+      ],
       "description": "Compliance classification domain for this tool."
     },
     "requires_baa": {
@@ -90,7 +187,14 @@
     },
     "sensitivity_level": {
       "type": "string",
-      "enum": ["public", "pii", "confidential", "hipaa_phi", "mnpi", "trade_secret"],
+      "enum": [
+        "public",
+        "pii",
+        "confidential",
+        "hipaa_phi",
+        "mnpi",
+        "trade_secret"
+      ],
       "default": "public",
       "description": "Data sensitivity level of information this tool accesses or returns."
     },

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -17,6 +17,7 @@ from cmcp_runtime.errors import (
     ConfigError,
     ToolNotInCatalog,
 )
+from cmcp_runtime.mcp.stdio import StdioSpawn
 
 _CATALOG_ENTRY_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "schemas" / "catalog-entry.schema.json"
 
@@ -27,8 +28,18 @@ class ServerIdentity:
     url: str
     tls_fingerprint: str
     spiffe_id: str | None
-    transport: str  # "http-sse" or "websocket"
+    transport: str  # "http-sse", "websocket", or "stdio"
     rotation_mode: str  # "key-pinned" (default) or "cert-pinned"
+    spawn: StdioSpawn | None = None
+    """How to start a stdio server. Present only when transport is "stdio".
+
+    A stdio server has no URL and no TLS certificate, so ``url`` and
+    ``tls_fingerprint`` are empty for one and the schema does not require them.
+    """
+
+    @property
+    def is_stdio(self) -> bool:
+        return self.transport == "stdio"
 
 
 @dataclass
@@ -175,13 +186,27 @@ def load_catalog(catalog_path: str, expected_hash: str | None = None) -> ToolCat
             )
 
         raw_server = raw["server"]
+        raw_spawn = raw_server.get("spawn")
+        spawn = (
+            StdioSpawn(
+                command=raw_spawn["command"],
+                args=tuple(raw_spawn.get("args", ())),
+                binary_digest=raw_spawn.get("binary_digest"),
+                measure_target=raw_spawn.get("measure_target"),
+            )
+            if raw_spawn
+            else None
+        )
         server = ServerIdentity(
             display_name=raw_server["display_name"],
-            url=raw_server["url"],
-            tls_fingerprint=raw_server["tls_fingerprint"],
+            # Empty rather than absent for a stdio server: it has no endpoint,
+            # and inventing a URL for one would put a fiction in the audit chain.
+            url=raw_server.get("url", ""),
+            tls_fingerprint=raw_server.get("tls_fingerprint", ""),
             spiffe_id=raw_server.get("spiffe_id"),
             transport=raw_server.get("transport", "http-sse"),
             rotation_mode=raw_server.get("rotation_mode", "key-pinned"),
+            spawn=spawn,
         )
 
         raw_def = raw["approved_definition"]

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -54,6 +54,14 @@ class AttestationConfig:
     validity_seconds: int = 86400
     staleness_policy: StalenessPolicy = StalenessPolicy.FAIL_CLOSED
     expected_measurement: str | None = None
+    allow_unmeasured_spawn: bool = False
+    """Permit spawning a stdio server whose binary the catalog does not pin.
+
+    Default off. A child runs inside the enclave, in the same isolation domain as
+    the policy evaluator and the audit chain, and the control that pays for that
+    is refusing to spawn what cannot be checked. Turning this on does not make
+    the spawn silent: every such call is recorded as ``spawn-unmeasured``.
+    """
 
 
 @dataclass
@@ -101,6 +109,7 @@ _KNOWN_ATTEST_KEYS = {
     "validity_seconds",
     "staleness_policy",
     "expected_measurement",
+    "allow_unmeasured_spawn",
 }
 _KNOWN_AGENT_MANIFEST_KEYS = {"path", "trust_anchor_path", "authenticated_subject"}
 
@@ -264,6 +273,10 @@ def load_config(path: str) -> Config:
     if expected_measurement is not None and not isinstance(expected_measurement, str):
         raise ConfigError("attestation.expected_measurement must be a string")
 
+    allow_unmeasured_spawn = attest_raw.get("allow_unmeasured_spawn", False)
+    if not isinstance(allow_unmeasured_spawn, bool):
+        raise ConfigError("attestation.allow_unmeasured_spawn must be a boolean")
+
     max_bytes = raw.get("max_response_size_bytes", 2 * 1024 * 1024)
     if not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ConfigError("max_response_size_bytes must be a positive integer")
@@ -324,6 +337,7 @@ def load_config(path: str) -> Config:
             validity_seconds=validity_seconds,
             staleness_policy=staleness_policy,
             expected_measurement=expected_measurement,
+            allow_unmeasured_spawn=allow_unmeasured_spawn,
         ),
         agent_manifest=AgentManifestConfig(
             path=agent_manifest_path,

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -29,6 +29,7 @@ from cmcp_runtime.catalog.loader import CatalogEntry, ToolCatalog
 from cmcp_runtime.config import Config
 from cmcp_runtime.errors import PolicyDeny, UpstreamToolError, UpstreamUnavailable
 from cmcp_runtime.mcp import tls_pinning
+from cmcp_runtime.mcp.stdio import StdioServer
 from cmcp_runtime.policy.decisions import audit_value
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
@@ -172,6 +173,11 @@ class CMCPProxy:
         # fingerprint (#281). Created lazily so proxy construction stays sync
         # and tests need no event loop.
         self._http_clients: dict[str, httpx.AsyncClient] = {}
+        # Spawned stdio servers, one child per server for the life of this
+        # session and never pooled across sessions: a server that holds anything
+        # in memory would carry it from one agent's session into the next, and
+        # the audit chain cannot see that happen (docs/spec/stdio-transport.md).
+        self._stdio_servers: dict[str, StdioServer] = {}
         # Servers already warned about unenforceable pinning (warn once each).
         self._tls_pin_warned: set[str] = set()
 
@@ -252,6 +258,30 @@ class CMCPProxy:
             self._http_clients[key] = client
         return client
 
+    async def _stdio_for(self, entry: CatalogEntry) -> StdioServer:
+        """The child for this server, spawned on first use in this session."""
+        key = entry.server.display_name
+        server = self._stdio_servers.get(key)
+        if server is None:
+            if entry.server.spawn is None:
+                raise UpstreamUnavailable(
+                    f"catalog entry {entry.tool_name!r} declares stdio transport with no "
+                    "spawn block; there is nothing to start"
+                )
+            server = StdioServer(
+                entry.server.spawn,
+                allow_unmeasured=self._config.attestation.allow_unmeasured_spawn,
+            )
+            await server.start()
+            self._stdio_servers[key] = server
+        return server
+
+    async def aclose(self) -> None:
+        """Terminate spawned children. A session that ends leaves nothing running."""
+        for server in self._stdio_servers.values():
+            await server.close()
+        self._stdio_servers.clear()
+
     async def _forward_to_upstream(
         self,
         call_id: str,
@@ -270,6 +300,10 @@ class CMCPProxy:
         sent), UpstreamToolError when the upstream returns a JSON-RPC error
         object.
         """
+        if entry.server.is_stdio:
+            server = await self._stdio_for(entry)
+            return await server.call(call_id, tool_name, arguments)
+
         client = self._client_for_upstream(entry)
         payload = {
             "jsonrpc": "2.0",
@@ -866,17 +900,32 @@ class CMCPProxy:
         # egress check saw (post-scan, possibly sanitized) so a verifier can match
         # the audited response against what the caller actually received.
         response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
-        # Evidence class: tls-pinned when the upstream server has a real cert pin in the catalog.
+        # Evidence class: what a verifier can conclude about where this response
+        # came from. tls-pinned when a network upstream has a real cert pin;
+        # spawn-measured when the gateway digested a stdio server's entrypoint
+        # against the catalog before exec'ing it. The two are not comparable and
+        # are deliberately not collapsed: one identifies an endpoint, the other
+        # identifies code.
         from cmcp_runtime.mcp import tls_pinning as _tls_mod
-        _fp = entry.server.tls_fingerprint if entry else ""
-        evidence_class = (
-            "tls-pinned"
-            if entry
-            and entry.server.url.startswith("https://")
-            and _fp
-            and _fp != _tls_mod.PLACEHOLDER_FINGERPRINT
-            else "hash-only"
-        )
+        if entry is not None and entry.server.is_stdio:
+            spawned = self._stdio_servers.get(entry.server.display_name)
+            # A stdio response with no spawned server on record is not something
+            # to guess about; hash-only is the honest floor.
+            evidence_class = (
+                spawned.evidence_class
+                if spawned is not None and spawned.evidence_class
+                else "hash-only"
+            )
+        else:
+            _fp = entry.server.tls_fingerprint if entry else ""
+            evidence_class = (
+                "tls-pinned"
+                if entry
+                and entry.server.url.startswith("https://")
+                and _fp
+                and _fp != _tls_mod.PLACEHOLDER_FINGERPRINT
+                else "hash-only"
+            )
         external_execution_evidence = _extract_external_execution_evidence(agt_result)
         # INJECT-003: include injection scanner and pattern in audit detail when detected
         injection_detail: dict[str, str | int | float] | None = (

--- a/src/cmcp_runtime/mcp/stdio.py
+++ b/src/cmcp_runtime/mcp/stdio.py
@@ -1,0 +1,355 @@
+"""stdio upstream: the gateway spawns the MCP server as its own child.
+
+Design and its costs: ``docs/spec/stdio-transport.md``. The short version is that
+the agent never spawns anything once cMCP is in the path, so the child can be a
+child of the gateway, which is already inside the enclave. Nothing crosses the
+TEE boundary that does not cross it today.
+
+What this buys, and it is the reason to do it at all: the gateway chooses when to
+``exec``, so it digests the executable first and refuses to spawn on a mismatch.
+A pinned TLS fingerprint identifies an endpoint. A verified digest identifies the
+code.
+
+What it costs, restated here because a reader of this file should not have to go
+find it: the child runs in the same isolation domain as the policy evaluator and
+the audit chain. Memory isolation protects the gateway from the host, not from
+its own child. And the gateway's launch measurement does not cover a process
+spawned later, which is why the child's digest is reported as its own evidence
+class rather than folded into hardware attestation.
+
+Three decisions the spec left open, settled here:
+
+**One child per session, never a pool.** A pool is faster and leaks state between
+sessions: a server that keeps anything in memory carries it from one agent's
+session into the next, and the audit chain cannot see that happen. The cost is a
+spawn per session, which is the correct thing to pay.
+
+**stderr never enters the audit chain.** MCP servers write diagnostics there, and
+diagnostics contain payloads. The audit chain is meant to be shareable, so the
+content goes to the gateway's own logger and only the byte count reaches the
+record: enough to see that a child is complaining, not enough to leak what about.
+
+**A framing error is fatal to the session.** Newline-delimited JSON-RPC
+desynchronizes if a child logs to stdout, and resynchronizing means guessing
+which bytes were a response. Guessing wrong means attributing one call's result
+to another call, in an artifact whose entire purpose is saying what happened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from typing import Any
+
+from cmcp_runtime.errors import ConfigError, UpstreamToolError, UpstreamUnavailable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SPAWN_MEASURED",
+    "SPAWN_UNMEASURED",
+    "StdioServer",
+    "StdioSpawnRefused",
+    "measure_executable",
+    "resolve_executable",
+]
+
+#: Evidence classes, extending the tls-pinned / hash-only pair in LIMITATIONS.md.
+SPAWN_MEASURED = "spawn-measured"
+SPAWN_UNMEASURED = "spawn-unmeasured"
+
+#: A response larger than this is refused rather than buffered. A child that can
+#: make the gateway allocate without bound is a denial of service inside the
+#: enclave, which is the one place it hurts most.
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+#: stderr is kept only to report its size and to log the tail. Bounded for the
+#: same reason.
+MAX_STDERR_CAPTURE = 64 * 1024
+
+_DIGEST_PREFIX = "sha256:"
+
+
+class StdioSpawnRefused(ConfigError):
+    """The gateway declined to spawn. Never a warning, never a degraded start.
+
+    Raised when the executable's digest does not match the catalog, or when it
+    has no digest to match and unmeasured spawning is not explicitly enabled.
+    """
+
+
+def resolve_executable(command: str) -> str:
+    """Absolute path of *command*, resolved once, before anything is measured.
+
+    Resolved rather than passed through so the digest and the exec refer to the
+    same file. Measuring ``server`` from ``PATH`` and then exec'ing ``server``
+    invites a different file to answer the second lookup.
+    """
+    resolved = shutil.which(command) if os.path.basename(command) == command else command
+    if not resolved or not os.path.isfile(resolved):
+        raise StdioSpawnRefused(f"stdio server executable not found: {command!r}")
+    return os.path.realpath(resolved)
+
+
+def measure_executable(path: str) -> str:
+    """``sha256:`` digest of the file that will be executed.
+
+    A file that cannot be read cannot be measured, and an unmeasurable spawn is
+    refused rather than degraded. This is not hypothetical: a Windows Store
+    Python is an App Execution Alias, a reparse point that executes fine and
+    cannot be opened for reading, so "executable" and "readable" are genuinely
+    different properties.
+    """
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError as exc:
+        raise StdioSpawnRefused(
+            f"cannot read {path!r} to measure it ({exc.strerror or exc}). An "
+            "executable that cannot be measured cannot be pinned, so it is not "
+            "spawned. Point the catalog at a real file rather than a shim or alias."
+        ) from exc
+    return _DIGEST_PREFIX + h.hexdigest()
+
+
+@dataclass(frozen=True)
+class StdioSpawn:
+    """What the catalog says about how to start this server."""
+
+    command: str
+    args: tuple[str, ...] = ()
+    binary_digest: str | None = None
+    """Expected ``sha256:`` digest of :attr:`measure_target`. ``None`` means the
+    catalog does not pin the server, which is only permitted when the deployment
+    opts in."""
+    measure_target: str | None = None
+    """Which file the digest covers. Defaults to the resolved executable.
+
+    For an interpreted server the executable is the interpreter, and pinning the
+    interpreter is close to useless: every Python MCP server on a host shares one
+    digest, so the pin would match a completely different server. The thing worth
+    pinning is the entrypoint, so a catalog entry running
+    ``python -m some_server`` or ``python server.py`` sets this to the script and
+    the digest covers the code that actually differs.
+
+    The interpreter is still resolved and still recorded; it is simply not what
+    the pin is about.
+    """
+
+
+class StdioServer:
+    """One spawned MCP server, for the lifetime of one session."""
+
+    def __init__(
+        self,
+        spawn: StdioSpawn,
+        *,
+        allow_unmeasured: bool = False,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._spawn = spawn
+        self._allow_unmeasured = allow_unmeasured
+        self._env = env
+        self._proc: asyncio.subprocess.Process | None = None
+        self._lock = asyncio.Lock()
+        self._stderr_bytes = 0
+        self.executable: str | None = None
+        self.measure_target: str | None = None
+        self.measured_digest: str | None = None
+        self.evidence_class: str | None = None
+
+    @property
+    def stderr_bytes(self) -> int:
+        """How much the child wrote to stderr. The content is never recorded."""
+        return self._stderr_bytes
+
+    async def start(self) -> None:
+        """Measure, decide, then spawn. Never the other way round."""
+        executable = resolve_executable(self._spawn.command)
+        target = self._spawn.measure_target or executable
+        expected = self._spawn.binary_digest
+
+        if expected is not None:
+            # Only measured when there is something to compare it against. An
+            # unreadable interpreter must not block a catalog that pins the
+            # script, which is the case that matters for interpreted servers.
+            digest = measure_executable(resolve_executable(target))
+            if digest != expected:
+                raise StdioSpawnRefused(
+                    f"stdio server digest does not match the catalog: "
+                    f"{target!r} measured {digest}, catalog pins {expected}. Not spawned."
+                )
+            self.evidence_class = SPAWN_MEASURED
+        else:
+            if not self._allow_unmeasured:
+                raise StdioSpawnRefused(
+                    f"stdio server {self._spawn.command!r} has no binary_digest in the "
+                    "catalog. Spawning an unmeasured binary inside the enclave requires "
+                    "attestation.allow_unmeasured_spawn=true, which records every such "
+                    "call as spawn-unmeasured."
+                )
+            self.evidence_class = SPAWN_UNMEASURED
+            # Observed even when unpinned, where the file can be read at all. An
+            # unreadable target is recorded as None rather than blocking a spawn
+            # the operator has already opted into.
+            try:
+                digest = measure_executable(resolve_executable(target))
+            except StdioSpawnRefused as exc:
+                digest = None
+                logger.warning("stdio server target could not be measured: %s", exc)
+            logger.warning(
+                "SPAWN_UNMEASURED: %s has no catalog digest; what ran is recorded (%s) "
+                "but was not checked against anything",
+                self._spawn.command,
+                digest or "unreadable",
+            )
+
+        self.measure_target = target
+
+        self.executable = executable
+        self.measured_digest = digest
+
+        self._proc = await asyncio.create_subprocess_exec(
+            executable,
+            *self._spawn.args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._env,
+        )
+        logger.info(
+            "stdio server spawned: %s (%s, digest %s)",
+            self._spawn.command,
+            self.evidence_class,
+            digest,
+        )
+
+    async def call(self, call_id: str, tool_name: str, arguments: dict[str, Any]) -> str:
+        """One JSON-RPC ``tools/call`` over the child's stdin/stdout."""
+        if self._proc is None or self._proc.stdin is None or self._proc.stdout is None:
+            raise UpstreamUnavailable("stdio server is not running")
+
+        request = {
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+        line = json.dumps(request, separators=(",", ":")).encode() + b"\n"
+
+        # One call at a time. The framing carries an id, but interleaving writes
+        # on one pipe and matching responses by id would mean trusting the child
+        # to return the id it was given, which is the thing being verified.
+        async with self._lock:
+            try:
+                self._proc.stdin.write(line)
+                await self._proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError) as exc:
+                raise UpstreamUnavailable(
+                    f"stdio server closed its input: {self._spawn.command}", detail=str(exc)
+                ) from exc
+
+            raw = await self._proc.stdout.readline()
+
+        if not raw:
+            await self._collect_stderr()
+            raise UpstreamUnavailable(
+                f"stdio server produced no response and may have exited: "
+                f"{self._spawn.command} (exit={self._proc.returncode}, "
+                f"stderr={self._stderr_bytes} bytes)"
+            )
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raise UpstreamUnavailable(
+                f"stdio server response exceeds {MAX_RESPONSE_BYTES} bytes; refused"
+            )
+
+        try:
+            body = json.loads(raw)
+        except ValueError as exc:
+            # Fatal, deliberately. A child that logs to stdout has desynchronized
+            # the stream, and skipping to the next parsable line means guessing
+            # which bytes were a response to which call.
+            await self.close()
+            raise UpstreamUnavailable(
+                f"stdio server wrote a non-JSON line, so the JSON-RPC stream is "
+                f"desynchronized and the session is terminated: {self._spawn.command}. "
+                "A server that logs to stdout must be changed to log to stderr.",
+                detail=str(exc),
+            ) from exc
+
+        if not isinstance(body, dict):
+            await self.close()
+            raise UpstreamUnavailable("stdio server returned a non-object JSON-RPC body")
+        if body.get("id") != call_id:
+            await self.close()
+            raise UpstreamUnavailable(
+                f"stdio server answered id {body.get('id')!r} for request {call_id!r}; "
+                "a mismatched response cannot be attributed and the session is terminated"
+            )
+        if "error" in body:
+            error = body["error"] if isinstance(body["error"], dict) else {}
+            raise UpstreamToolError(
+                f"Upstream tool error from {tool_name}: "
+                f"{str(error.get('message', 'unknown'))[:200]}"
+            )
+        return _text_content(body.get("result"))
+
+    async def _collect_stderr(self) -> None:
+        if self._proc is None or self._proc.stderr is None:
+            return
+        try:
+            data = await asyncio.wait_for(
+                self._proc.stderr.read(MAX_STDERR_CAPTURE), timeout=0.5
+            )
+        except TimeoutError:
+            return
+        if data:
+            self._stderr_bytes += len(data)
+            # Logged, never recorded: diagnostics carry payloads and the audit
+            # chain is meant to be shareable.
+            logger.warning(
+                "stdio server stderr (%d bytes): %s",
+                len(data),
+                data[-2048:].decode("utf-8", "replace"),
+            )
+
+    async def close(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
+
+def _text_content(result: Any) -> str:
+    """Text content of an MCP result.
+
+    Deliberately identical to the HTTP path in ``proxy.py``: newline-joined text
+    parts, falling back to the serialized result. Two transports that extract
+    responses differently would produce different ``response_content`` for the
+    same server, and the audit chain hashes that.
+    """
+    content = result.get("content", []) if isinstance(result, dict) else []
+    texts = [
+        c.get("text", "")
+        for c in content
+        if isinstance(c, dict) and c.get("type") == "text"
+    ]
+    if texts:
+        return "\n".join(texts)
+    return json.dumps(result, default=str)

--- a/tests/unit/test_stdio_upstream.py
+++ b/tests/unit/test_stdio_upstream.py
@@ -1,0 +1,285 @@
+"""Tests for the stdio upstream.
+
+The gateway spawns a child *inside the enclave*, which is a real weakening of the
+isolation story (`docs/spec/stdio-transport.md`). The control that pays for it is
+"refuse to spawn what is not measured", so the tests that matter are the ones
+where the gateway declines. A regression that turned a refusal into a warning
+would leave the feature working and the argument for it gone.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import textwrap
+
+import pytest
+
+from cmcp_runtime.errors import UpstreamToolError, UpstreamUnavailable
+from cmcp_runtime.mcp.stdio import (
+    SPAWN_MEASURED,
+    SPAWN_UNMEASURED,
+    StdioServer,
+    StdioSpawn,
+    StdioSpawnRefused,
+    measure_executable,
+    resolve_executable,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _script(tmp_path, body: str, name: str = "server.py"):
+    """A fake MCP server: reads newline-delimited JSON-RPC, writes responses."""
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+ECHO_SERVER = """
+    import json, sys
+    for line in sys.stdin:
+        req = json.loads(line)
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req["id"],
+            "result": {"content": [{"type": "text", "text": "ok:" + req["params"]["name"]}]},
+        }) + "\\n")
+        sys.stdout.flush()
+"""
+
+
+def _spawn_for(script: str, digest: str | None) -> StdioSpawn:
+    """Pin the script, not the interpreter.
+
+    Every Python MCP server on a host shares one interpreter digest, so pinning
+    the interpreter would match a completely different server. The entrypoint is
+    the thing that differs, which is why ``measure_target`` exists.
+    """
+    return StdioSpawn(
+        command=sys.executable,
+        args=(script,),
+        binary_digest=digest,
+        measure_target=script,
+    )
+
+
+# --- the refusals, which are the reason this design is acceptable ----------
+
+
+async def test_digest_mismatch_refuses_to_spawn(tmp_path) -> None:
+    script = _script(tmp_path, ECHO_SERVER)
+    server = StdioServer(_spawn_for(script, "sha256:" + "0" * 64))
+    with pytest.raises(StdioSpawnRefused, match="does not match the catalog"):
+        await server.start()
+
+
+async def test_missing_digest_refuses_unless_explicitly_enabled(tmp_path) -> None:
+    script = _script(tmp_path, ECHO_SERVER)
+    server = StdioServer(_spawn_for(script, None))
+    with pytest.raises(StdioSpawnRefused, match="allow_unmeasured_spawn"):
+        await server.start()
+
+
+async def test_missing_executable_refuses(tmp_path) -> None:
+    server = StdioServer(StdioSpawn(command=str(tmp_path / "nope"), binary_digest=None))
+    with pytest.raises(StdioSpawnRefused, match="not found"):
+        await server.start()
+
+
+async def test_refusal_happens_before_exec(tmp_path, monkeypatch) -> None:
+    """Measure, decide, then spawn. Never the other way round."""
+    script = _script(tmp_path, ECHO_SERVER)
+    spawned = False
+
+    async def _boom(*a, **kw):
+        nonlocal spawned
+        spawned = True
+        raise AssertionError("exec must not be reached on a refused spawn")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", _boom)
+    server = StdioServer(_spawn_for(script, "sha256:" + "1" * 64))
+    with pytest.raises(StdioSpawnRefused):
+        await server.start()
+    assert spawned is False
+
+
+# --- the permitted paths ---------------------------------------------------
+
+
+async def test_measured_spawn_records_its_evidence_class(tmp_path) -> None:
+    script = _script(tmp_path, ECHO_SERVER)
+    digest = measure_executable(resolve_executable(script))
+    server = StdioServer(_spawn_for(script, digest))
+    await server.start()
+    try:
+        assert server.evidence_class == SPAWN_MEASURED
+        assert server.measured_digest == digest
+    finally:
+        await server.close()
+
+
+async def test_unmeasured_spawn_is_labelled_not_silently_allowed(tmp_path) -> None:
+    script = _script(tmp_path, ECHO_SERVER)
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    try:
+        assert server.evidence_class == SPAWN_UNMEASURED
+        # The digest of what actually ran is still recorded. Unmeasured means
+        # "not checked against anything", not "not observed".
+        assert server.measured_digest is not None
+    finally:
+        await server.close()
+
+
+async def test_round_trip(tmp_path) -> None:
+    script = _script(tmp_path, ECHO_SERVER)
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    try:
+        assert await server.call("c1", "search", {"q": "x"}) == "ok:search"
+        assert await server.call("c2", "pay", {}) == "ok:pay"
+    finally:
+        await server.close()
+
+
+# --- framing, where a wrong answer is worse than an error ------------------
+
+
+async def test_stdout_logging_desynchronizes_and_is_fatal(tmp_path) -> None:
+    """A child that logs to stdout must not be resynchronized around.
+
+    Skipping to the next parsable line means guessing which bytes answered which
+    call, in an artifact whose whole purpose is saying what happened.
+    """
+    script = _script(
+        tmp_path,
+        """
+        import json, sys
+        sys.stdout.write("starting up...\\n")
+        sys.stdout.flush()
+        for line in sys.stdin:
+            req = json.loads(line)
+            sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],
+                "result":{"content":[{"type":"text","text":"late"}]}}) + "\\n")
+            sys.stdout.flush()
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    with pytest.raises(UpstreamUnavailable, match="desynchronized"):
+        await server.call("c1", "search", {})
+
+
+async def test_mismatched_response_id_is_fatal(tmp_path) -> None:
+    """A response that cannot be attributed to a request is not a response."""
+    script = _script(
+        tmp_path,
+        """
+        import json, sys
+        for line in sys.stdin:
+            json.loads(line)
+            sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":"someone-elses",
+                "result":{"content":[{"type":"text","text":"x"}]}}) + "\\n")
+            sys.stdout.flush()
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    with pytest.raises(UpstreamUnavailable, match="cannot be attributed"):
+        await server.call("c1", "search", {})
+
+
+async def test_child_exit_is_reported_not_hung(tmp_path) -> None:
+    script = _script(tmp_path, "import sys; sys.exit(3)\n")
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    with pytest.raises(UpstreamUnavailable, match="no response"):
+        await server.call("c1", "search", {})
+
+
+async def test_upstream_error_object_surfaces_as_tool_error(tmp_path) -> None:
+    script = _script(
+        tmp_path,
+        """
+        import json, sys
+        for line in sys.stdin:
+            req = json.loads(line)
+            sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],
+                "error":{"code":-32000,"message":"denied by server"}}) + "\\n")
+            sys.stdout.flush()
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    try:
+        with pytest.raises(UpstreamToolError, match="denied by server"):
+            await server.call("c1", "search", {})
+    finally:
+        await server.close()
+
+
+# --- stderr: visible as a signal, never as content -------------------------
+
+
+async def test_stderr_is_counted_but_its_content_never_returned(tmp_path) -> None:
+    """Diagnostics carry payloads and the audit chain is meant to be shareable."""
+    script = _script(
+        tmp_path,
+        """
+        import sys
+        sys.stderr.write("iban=GB33BUKB20201555555555\\n")
+        sys.stderr.flush()
+        sys.exit(1)
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    with pytest.raises(UpstreamUnavailable) as exc:
+        await server.call("c1", "search", {})
+    assert "GB33BUKB" not in str(exc.value)
+    assert "bytes" in str(exc.value)
+    assert server.stderr_bytes > 0
+
+
+# --- measurement -----------------------------------------------------------
+
+
+def test_measure_is_over_the_resolved_file(tmp_path) -> None:
+    a = tmp_path / "a.bin"
+    a.write_bytes(b"one")
+    b = tmp_path / "b.bin"
+    b.write_bytes(b"two")
+    assert measure_executable(str(a)) != measure_executable(str(b))
+    assert measure_executable(str(a)).startswith("sha256:")
+
+
+def test_resolve_follows_symlinks_so_measure_and_exec_agree(tmp_path) -> None:
+    """Measuring one path and exec'ing another invites a different file to answer."""
+    real = tmp_path / "real.bin"
+    real.write_bytes(b"payload")
+    link = tmp_path / "link.bin"
+    try:
+        os.symlink(real, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform/user")
+    assert resolve_executable(str(link)) == os.path.realpath(str(real))
+
+
+def test_json_rpc_request_shape(tmp_path) -> None:
+    """The wire shape matches the HTTP path, so a server sees one protocol."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "c1",
+        "method": "tools/call",
+        "params": {"name": "search", "arguments": {"q": "x"}},
+    }
+    assert json.loads(json.dumps(payload, separators=(",", ":"))) == payload


### PR DESCRIPTION
Implements #484, which you approved. Transport, catalog, config, proxy routing and the audit-chain evidence class.

## What it does

The gateway spawns the stdio MCP server as its own child, **inside the enclave**, and measures the entrypoint against the catalog before `exec`. A mismatch refuses. A missing digest refuses unless `attestation.allow_unmeasured_spawn` is set, and then every call is recorded as `spawn-unmeasured` rather than passing quietly.

Those refusals are the control that pays for running a child inside the enclave, so they are the best-tested part of the change — including one asserting that `exec` is never reached on a refused spawn.

## Two design corrections that came out of the tests

**Pinning the executable is close to useless for an interpreted server.** The executable is the interpreter, so every Python MCP server on a host shares one digest and the pin would happily match a completely different server. `StdioSpawn.measure_target` pins the entrypoint instead; the interpreter is still resolved and recorded, it is just not what the pin is about.

**Executable and readable are different properties.** A Windows Store Python is an App Execution Alias: it runs fine and cannot be opened for reading, so measuring it raises `OSError`. An unmeasurable target is now a refusal with an explanation rather than a crash. I hit this on the first test run.

## Choices worth reviewing

**One child per server per session, never pooled.** A pool is faster and leaks state between sessions, which the audit chain cannot see.

**Framing errors are fatal.** A child that logs to stdout has desynchronized the JSON-RPC stream; skipping to the next parsable line means guessing which bytes answered which call. A response whose `id` does not match its request is fatal for the same reason — a result that cannot be attributed is not a result.

**stderr never enters the audit chain.** Diagnostics carry payloads and the chain is meant to be shareable, so content goes to the logger and only the byte count is exposed. A test writes an IBAN to stderr and asserts it does not reach the caller.

**The evidence class is not collapsed.** stdio reports `spawn-measured` / `spawn-unmeasured`; network reports `tls-pinned` / `hash-only`. They answer different questions, and merging them would let a digest and a certificate pin look like the same claim.

**The schema conditions on transport rather than relaxing.** A network transport still requires `url` and `tls_fingerprint`; stdio requires `spawn`. Dropping them from `required` outright would have let an http-sse entry ship with no TLS pin.

## Tests

15 new, covering both refusal paths, pre-exec ordering, round trip, desynchronization, id mismatch, child exit, upstream error objects, stderr containment, and measurement/symlink resolution.

Local collection of the wider unit suite is blocked by the known agt-core 5.x shadowing (#472) — CI installs 4.1.0 from PyPI. The stdio, catalog and config suites pass in isolation (69 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
