### PR TITLE
feat(provenance): check who says this server is what it claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Server provenance checking (step 3).** The gateway consumes [`server-provenance-v1`](https://github.com/agentrust-io/trace-spec/blob/main/spec/server-provenance-v1.md) records via `agentrust-trace>=0.8`: it verifies the record against a **configured** publisher key, then compares the record's tool-catalog hash against the tools the server advertises to this gateway.
+
+  It never falls back to the catalog's own approved definitions for that comparison. Comparing a record against our approval instead of against the server is the substitution that turns the whole check into theatre.
+
+  Five outcomes reach the audit chain and none is silent. `verified`; `catalog-mismatch`, which means the document is fine and the *server* is not; `invalid`; `unchecked`, which means the record verified but the tool list was unavailable so the comparison that catches a substituted server never ran; and `absent`. `unchecked` exists because reporting a signature check alone as `verified` is a document checking itself.
+
+  **Absence is recorded and non-fatal by default.** Almost no MCP server has a record, and a gateway that refuses to route without one is a gateway that gets turned off on first contact and never turned back on. `attestation.required_provenance_kind` sets a floor per deployment; a `catalog-mismatch` satisfies no floor, including the weakest.
+
+  A record with no configured publisher key is `invalid`, not `verified`: the key embedded in a record cannot be used to check that record, because a forgery supplies its own.
+
+### Added
+
 - **stdio transport: the gateway spawns the MCP server as its own child, inside the enclave (#484).** `docs/spec/transport.md` ruled stdio out and rejected two bridging options, correctly, because both put a translating component *outside* the TEE where it can inject or suppress calls before the gateway sees them. Both options assumed the agent spawns the server. It does not: that same document states the agent reaches only the gateway and that the runtime catalog is authoritative. So the child is a child of a process already inside the enclave, and nothing crosses the boundary that does not cross it today.
 
   **This buys a binding no network upstream can have.** The gateway chooses when to `exec`, so it digests the entrypoint first and refuses to spawn on a mismatch. A pinned TLS fingerprint identifies an endpoint; a verified digest identifies code.

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,6 +14,7 @@ picture is stated once. Developer Preview: interfaces may change before v1.0.
 | `attestation.validity_seconds` | `86400` |
 | `policy_reload_interval_seconds` | `0` (disabled; policy change requires an enclave restart) |
 | `attestation.allow_unmeasured_spawn` | `false` (a stdio server the catalog does not pin is not spawned) |
+| `attestation.required_provenance_kind` | `null` (server provenance is recorded, not enforced) |
 
 ## Capabilities
 
@@ -32,6 +33,7 @@ picture is stated once. Developer Preview: interfaces may change before v1.0.
 | `gpu-cc` (NVIDIA H100/H200/Blackwell, via NRAS) | Planned (v0.2) | |
 | Transparency-log anchoring for TRACE Claims | v0.2 | Write and lookup. |
 | Server-side (provider) attestation | Not yet (Phase 2) | Phase 1 attests the gateway boundary only. |
+| Server provenance checking | Shipped | Consumes [server-provenance-v1](https://github.com/agentrust-io/trace-spec/blob/main/spec/server-provenance-v1.md) records: verifies the signature against a configured publisher key, then compares the record's tool-catalog hash against the tools the server advertises **to this gateway**. Five outcomes reach the audit chain and none of them is silent: `verified`, `catalog-mismatch` (the document is fine and the server is not), `invalid`, `unchecked` (verified but the tool list was unavailable, so the comparison that matters never ran), `absent`. Absence is recorded and non-fatal by default, because almost no MCP server has a record and a gateway that refuses to route without one gets disabled on first contact. Set `attestation.required_provenance_kind` for a floor. |
 | Real-time policy update without enclave restart | Not yet | `policy_reload_interval_seconds` is `0`; a policy change requires a restart. |
 | AARM R4 five decision types | Shipped, with caveats | ALLOW, DENY, MODIFY, STEP_UP, DEFER are recorded in the audit chain. MODIFY is recorded as `redact`, DEFER is classified but not asynchronously enforced, and the TRACE Claim still carries the pre-AARM vocabulary. See [LIMITATIONS.md](LIMITATIONS.md). |
 | AARM R8 telemetry export | Shipped | OpenTelemetry spans mirroring audit entries. Opt in with `CMCP_OTEL_ENABLED=1` and `pip install cmcp-runtime[otel]`; a no-op otherwise. Exports digests, never payloads. The audit chain stays authoritative. |

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -92,6 +92,25 @@
               "description": "File the digest covers; defaults to the resolved executable. Set this to the entrypoint for interpreted servers, where the executable is the interpreter and every server on the host would otherwise share one digest."
             }
           }
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "record_path",
+            "publisher_jwk"
+          ],
+          "description": "Server provenance record for this server (spec/server-provenance-v1.md in agentrust-io/trace-spec). Optional: absence is recorded as 'absent' rather than failing, since almost no MCP server has a record today.",
+          "properties": {
+            "record_path": {
+              "type": "string",
+              "description": "Path to the signed provenance record (JSON)."
+            },
+            "publisher_jwk": {
+              "type": "object",
+              "description": "Public key the record must verify under. Required: the key embedded in a record cannot be used to check that record, because a forgery supplies its own."
+            }
+          }
         }
       },
       "allOf": [

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -31,6 +31,8 @@ class ServerIdentity:
     transport: str  # "http-sse", "websocket", or "stdio"
     rotation_mode: str  # "key-pinned" (default) or "cert-pinned"
     spawn: StdioSpawn | None = None
+    provenance_record_path: str | None = None
+    publisher_jwk: dict[str, Any] | None = None
     """How to start a stdio server. Present only when transport is "stdio".
 
     A stdio server has no URL and no TLS certificate, so ``url`` and
@@ -207,6 +209,8 @@ def load_catalog(catalog_path: str, expected_hash: str | None = None) -> ToolCat
             transport=raw_server.get("transport", "http-sse"),
             rotation_mode=raw_server.get("rotation_mode", "key-pinned"),
             spawn=spawn,
+            provenance_record_path=(raw_server.get("provenance") or {}).get("record_path"),
+            publisher_jwk=(raw_server.get("provenance") or {}).get("publisher_jwk"),
         )
 
         raw_def = raw["approved_definition"]

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -55,6 +55,11 @@ class AttestationConfig:
     staleness_policy: StalenessPolicy = StalenessPolicy.FAIL_CLOSED
     expected_measurement: str | None = None
     allow_unmeasured_spawn: bool = False
+    required_provenance_kind: str | None = None
+    """Minimum server-provenance assurance to route a call. ``None`` records the
+    outcome without enforcing it, which is the only default that works in an
+    ecosystem where almost no server has a record: a gateway that refuses to route
+    without one gets turned off on first contact and never turned back on."""
     """Permit spawning a stdio server whose binary the catalog does not pin.
 
     Default off. A child runs inside the enclave, in the same isolation domain as
@@ -110,6 +115,7 @@ _KNOWN_ATTEST_KEYS = {
     "staleness_policy",
     "expected_measurement",
     "allow_unmeasured_spawn",
+    "required_provenance_kind",
 }
 _KNOWN_AGENT_MANIFEST_KEYS = {"path", "trust_anchor_path", "authenticated_subject"}
 
@@ -277,6 +283,14 @@ def load_config(path: str) -> Config:
     if not isinstance(allow_unmeasured_spawn, bool):
         raise ConfigError("attestation.allow_unmeasured_spawn must be a boolean")
 
+    required_provenance_kind = attest_raw.get("required_provenance_kind", None)
+    _KINDS = ("publisher-asserted", "observer-attested", "tee-attested")
+    if required_provenance_kind is not None and required_provenance_kind not in _KINDS:
+        raise ConfigError(
+            "attestation.required_provenance_kind must be null or one of "
+            + ", ".join(_KINDS)
+        )
+
     max_bytes = raw.get("max_response_size_bytes", 2 * 1024 * 1024)
     if not isinstance(max_bytes, int) or max_bytes <= 0:
         raise ConfigError("max_response_size_bytes must be a positive integer")
@@ -338,6 +352,7 @@ def load_config(path: str) -> Config:
             staleness_policy=staleness_policy,
             expected_measurement=expected_measurement,
             allow_unmeasured_spawn=allow_unmeasured_spawn,
+            required_provenance_kind=required_provenance_kind,
         ),
         agent_manifest=AgentManifestConfig(
             path=agent_manifest_path,

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -32,6 +32,7 @@ from cmcp_runtime.mcp import tls_pinning
 from cmcp_runtime.mcp.stdio import StdioServer
 from cmcp_runtime.policy.decisions import audit_value
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
+from cmcp_runtime.provenance import ProvenanceResult, check_server_provenance
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
 from cmcp_runtime.session.state import SessionState
 
@@ -178,6 +179,11 @@ class CMCPProxy:
         # in memory would carry it from one agent's session into the next, and
         # the audit chain cannot see that happen (docs/spec/stdio-transport.md).
         self._stdio_servers: dict[str, StdioServer] = {}
+        # Provenance outcome per server, decided once per session on first use.
+        # Cached because the answer cannot change within a session without the
+        # server being replaced underneath us, and re-listing tools on every call
+        # would make the check expensive enough to be turned off.
+        self._provenance: dict[str, ProvenanceResult] = {}
         # Servers already warned about unenforceable pinning (warn once each).
         self._tls_pin_warned: set[str] = set()
 
@@ -282,6 +288,52 @@ class CMCPProxy:
             await server.close()
         self._stdio_servers.clear()
 
+    async def _advertised_tools(self, entry: CatalogEntry) -> list[dict[str, Any]] | None:
+        """What the server offers *this gateway*, for the provenance comparison.
+
+        Returns ``None`` when the server will not say, which the caller records as
+        ``unchecked`` rather than as a pass. Never falls back to the catalog's own
+        approved definitions: comparing a record against our approval instead of
+        against the server is the substitution that turns the check into theatre.
+        """
+        if entry.server.is_stdio:
+            return await (await self._stdio_for(entry)).list_tools()
+        try:
+            client = self._client_for_upstream(entry)
+            resp = await client.post(
+                entry.server.url,
+                json={"jsonrpc": "2.0", "id": "provenance-tools-list",
+                      "method": "tools/list", "params": {}},
+            )
+            resp.raise_for_status()
+            result = resp.json().get("result")
+        except Exception as exc:  # noqa: BLE001 - any failure means "could not check"
+            logger.warning("could not list tools for provenance check: %s", exc)
+            return None
+        tools = result.get("tools") if isinstance(result, dict) else None
+        return tools if isinstance(tools, list) else None
+
+    async def _check_provenance(self, entry: CatalogEntry) -> ProvenanceResult:
+        key = entry.server.display_name
+        result = self._provenance.get(key)
+        if result is None:
+            advertised = (
+                await self._advertised_tools(entry)
+                if entry.server.provenance_record_path
+                else None
+            )
+            result = check_server_provenance(
+                entry.server.provenance_record_path,
+                entry.server.publisher_jwk,
+                advertised,
+            )
+            self._provenance[key] = result
+            logger.info(
+                "provenance: server=%s outcome=%s kind=%s",
+                key, result.outcome.value, result.kind or "-",
+            )
+        return result
+
     async def _forward_to_upstream(
         self,
         call_id: str,
@@ -300,6 +352,15 @@ class CMCPProxy:
         sent), UpstreamToolError when the upstream returns a JSON-RPC error
         object.
         """
+        provenance = await self._check_provenance(entry)
+        required = self._config.attestation.required_provenance_kind
+        if not provenance.meets(required):
+            raise UpstreamUnavailable(
+                f"server provenance is {provenance.outcome.value} and this deployment "
+                f"requires {required}: {entry.server.display_name}",
+                detail=provenance.detail,
+            )
+
         if entry.server.is_stdio:
             server = await self._stdio_for(entry)
             return await server.call(call_id, tool_name, arguments)

--- a/src/cmcp_runtime/mcp/stdio.py
+++ b/src/cmcp_runtime/mcp/stdio.py
@@ -236,17 +236,50 @@ class StdioServer:
             digest,
         )
 
+    async def list_tools(self) -> list[dict[str, Any]] | None:
+        """The tools this server advertises, for the provenance catalog check.
+
+        Returns ``None`` rather than raising when the server will not answer. A
+        server that cannot be listed is not a server that failed provenance; it
+        is one whose provenance could not be checked, and the two are recorded
+        differently.
+        """
+        try:
+            body = await self._request("provenance-tools-list", "tools/list", {})
+        except (UpstreamUnavailable, UpstreamToolError) as exc:
+            logger.warning("could not list tools for provenance check: %s", exc)
+            return None
+        result = body.get("result")
+        tools = result.get("tools") if isinstance(result, dict) else None
+        return tools if isinstance(tools, list) else None
+
     async def call(self, call_id: str, tool_name: str, arguments: dict[str, Any]) -> str:
         """One JSON-RPC ``tools/call`` over the child's stdin/stdout."""
+        body = await self._request(
+            call_id, "tools/call", {"name": tool_name, "arguments": arguments}
+        )
+        if "error" in body:
+            error = body["error"] if isinstance(body["error"], dict) else {}
+            raise UpstreamToolError(
+                f"Upstream tool error from {tool_name}: "
+                f"{str(error.get('message', 'unknown'))[:200]}"
+            )
+        return _text_content(body.get("result"))
+
+    async def _request(
+        self, call_id: str, method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Write one JSON-RPC request, read one response, check its framing.
+
+        Shared by ``call`` and ``list_tools`` so both get the same framing rules.
+        A second copy of this would be a second place for the desynchronization
+        handling to drift, and the whole argument for treating a parse failure as
+        fatal is that the alternative is guessing.
+        """
         if self._proc is None or self._proc.stdin is None or self._proc.stdout is None:
             raise UpstreamUnavailable("stdio server is not running")
 
-        request = {
-            "jsonrpc": "2.0",
-            "id": call_id,
-            "method": "tools/call",
-            "params": {"name": tool_name, "arguments": arguments},
-        }
+        request = {"jsonrpc": "2.0", "id": call_id, "method": method, "params": params}
         line = json.dumps(request, separators=(",", ":")).encode() + b"\n"
 
         # One call at a time. The framing carries an id, but interleaving writes
@@ -311,13 +344,7 @@ class StdioServer:
                 f"stdio server answered id {body.get('id')!r} for request {call_id!r}; "
                 "a mismatched response cannot be attributed and the session is terminated"
             )
-        if "error" in body:
-            error = body["error"] if isinstance(body["error"], dict) else {}
-            raise UpstreamToolError(
-                f"Upstream tool error from {tool_name}: "
-                f"{str(error.get('message', 'unknown'))[:200]}"
-            )
-        return _text_content(body.get("result"))
+        return body
 
     async def _collect_stderr(self) -> None:
         if self._proc is None or self._proc.stderr is None:

--- a/src/cmcp_runtime/provenance.py
+++ b/src/cmcp_runtime/provenance.py
@@ -1,0 +1,176 @@
+"""Server provenance: check who says this MCP server is what it claims.
+
+Consumes ``spec/server-provenance-v1.md`` records via ``agentrust_trace.provenance``.
+This module is the gateway's side: load, verify, and decide what to do about the
+answer.
+
+**Absence is recorded, never silently passed, and by default not fatal.** Nearly
+every MCP server in existence has no provenance record. A gateway that refuses to
+route without one is a gateway that gets turned off on first contact and never
+turned back on. So the default is to record ``absent`` and continue, with
+``provenance.required_kind`` available for a deployment that wants a floor.
+
+The rule that matters is not the default. It is that a verifier reading the audit
+trail afterwards can tell "we checked and found nothing" from "we never looked".
+Those are different facts and only one of them is about the server.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ProvenanceOutcome", "ProvenanceResult", "check_server_provenance"]
+
+
+class ProvenanceOutcome(str, Enum):
+    """What the gateway concluded. Every value is recorded in the audit chain."""
+
+    VERIFIED = "verified"
+    """Signature verified against the configured key and the server's advertised
+    tools match the record. The assurance this is worth is the record's ``kind``,
+    which is carried separately: verifying a ``publisher-asserted`` record proves
+    the publisher said it, and nothing else."""
+
+    CATALOG_MISMATCH = "catalog-mismatch"
+    """The record verified and the server offered a different tool set. This is
+    the finding the format exists to produce, and it is about the server rather
+    than the document."""
+
+    INVALID = "invalid"
+    """The record is malformed, unsigned, or signed by a key that is not the one
+    configured for this server."""
+
+    UNCHECKED = "unchecked"
+    """A record is configured but the server's tools could not be listed, so the
+    comparison that matters never happened. Deliberately not ``verified``: a
+    signature check alone is a document checking itself."""
+
+    ABSENT = "absent"
+    """No record is configured for this server. Recorded so the audit trail can
+    distinguish this from having looked and found a problem."""
+
+
+#: Ordered weakest to strongest, for `required_kind` comparisons.
+_KIND_ORDER = ("publisher-asserted", "observer-attested", "tee-attested")
+
+
+@dataclass(frozen=True)
+class ProvenanceResult:
+    outcome: ProvenanceOutcome
+    kind: str | None = None
+    publisher: str | None = None
+    detail: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Whether the check produced no finding. Not the same as 'trustworthy'."""
+        return self.outcome in (ProvenanceOutcome.VERIFIED, ProvenanceOutcome.ABSENT)
+
+    def meets(self, required_kind: str | None) -> bool:
+        """Whether this satisfies a configured minimum assurance."""
+        if required_kind is None:
+            return True
+        if self.outcome is not ProvenanceOutcome.VERIFIED or self.kind is None:
+            return False
+        return _KIND_ORDER.index(self.kind) >= _KIND_ORDER.index(required_kind)
+
+    def to_audit(self) -> dict[str, str]:
+        block = {"provenance": self.outcome.value}
+        if self.kind:
+            block["provenance_kind"] = self.kind
+        if self.publisher:
+            block["provenance_publisher"] = self.publisher[:256]
+        if self.detail:
+            block["provenance_detail"] = self.detail[:512]
+        return block
+
+
+def check_server_provenance(
+    record_path: str | None,
+    trusted_jwk: dict[str, Any] | None,
+    advertised_tools: list[dict[str, Any]] | None,
+) -> ProvenanceResult:
+    """Load, verify, and compare. Returns a result rather than raising.
+
+    Raising would make an absent record indistinguishable from a failed one at
+    the call site, and the whole point is that a consumer can tell those apart.
+
+    *advertised_tools* is what the server offered **this gateway**. Passing the
+    catalog's own approved definitions instead would compare the record against
+    our approval rather than against the server, which is the substitution that
+    turns this check into theatre.
+    """
+    if not record_path:
+        return ProvenanceResult(ProvenanceOutcome.ABSENT)
+
+    try:
+        from agentrust_trace.provenance import (
+            ProvenanceError,
+            ToolCatalogMismatch,
+            check_tool_catalog,
+            verify_record,
+        )
+    except ImportError:  # pragma: no cover - dependency is declared
+        return ProvenanceResult(
+            ProvenanceOutcome.UNCHECKED,
+            detail="agentrust-trace is not installed; provenance was not checked",
+        )
+
+    try:
+        record = json.loads(pathlib.Path(record_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return ProvenanceResult(
+            ProvenanceOutcome.INVALID, detail=f"could not read the record: {exc}"
+        )
+
+    if trusted_jwk is None:
+        # The record embeds a key. Using it would verify the document against
+        # itself, which is what a forgery does successfully.
+        return ProvenanceResult(
+            ProvenanceOutcome.INVALID,
+            detail=(
+                "no trusted publisher key is configured for this server, and the key in "
+                "the record cannot be used to check the record"
+            ),
+        )
+
+    kind = record.get("kind")
+    publisher = record.get("publisher")
+
+    try:
+        verify_record(record, trusted_jwk)
+    except ProvenanceError as exc:
+        return ProvenanceResult(
+            ProvenanceOutcome.INVALID, kind=kind, publisher=publisher, detail=str(exc)[:500]
+        )
+
+    if advertised_tools is None:
+        return ProvenanceResult(
+            ProvenanceOutcome.UNCHECKED,
+            kind=kind,
+            publisher=publisher,
+            detail=(
+                "the record verified but the server's tool list was unavailable, so the "
+                "comparison that would catch a substituted server did not run"
+            ),
+        )
+
+    try:
+        check_tool_catalog(record, advertised_tools)
+    except ToolCatalogMismatch as exc:
+        logger.error("PROVENANCE_CATALOG_MISMATCH: publisher=%s: %s", publisher, exc)
+        return ProvenanceResult(
+            ProvenanceOutcome.CATALOG_MISMATCH,
+            kind=kind,
+            publisher=publisher,
+            detail=str(exc)[:500],
+        )
+
+    return ProvenanceResult(ProvenanceOutcome.VERIFIED, kind=kind, publisher=publisher)

--- a/src/cmcp_runtime/provenance.py
+++ b/src/cmcp_runtime/provenance.py
@@ -21,7 +21,7 @@ import json
 import logging
 import pathlib
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["ProvenanceOutcome", "ProvenanceResult", "check_server_provenance"]
 
 
-class ProvenanceOutcome(str, Enum):
+class ProvenanceOutcome(StrEnum):
     """What the gateway concluded. Every value is recorded in the audit chain."""
 
     VERIFIED = "verified"

--- a/tests/unit/test_provenance_consumption.py
+++ b/tests/unit/test_provenance_consumption.py
@@ -1,0 +1,160 @@
+"""Tests for gateway-side provenance checking.
+
+The outcomes are the product here. A consumer has to be able to tell five
+different things apart, and collapsing any two of them loses a fact somebody
+needs: nobody asserted anything, the document is bad, the document is fine and
+the server is not, the document verified but we never compared it to a server,
+and everything checked out.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cmcp_runtime.provenance import (
+    ProvenanceOutcome,
+    ProvenanceResult,
+    check_server_provenance,
+)
+
+agentrust_provenance = pytest.importorskip("agentrust_trace.provenance")
+from agentrust_trace.provenance import build_record, sign_record  # noqa: E402
+from agentrust_trace.sign import generate_key, key_to_jwk  # noqa: E402
+
+TOOLS = [
+    {"name": "search", "description": "search the docs", "input_schema": {"type": "object"}},
+    {"name": "fetch", "description": "fetch a page", "input_schema": {"type": "object"}},
+]
+
+
+@pytest.fixture
+def signed_record(tmp_path):
+    key = generate_key()
+    record = build_record(
+        kind="publisher-asserted",
+        publisher="did:web:acme.example",
+        tools=TOOLS,
+        artifact={"package": "pkg:npm/x@1.0.0", "digest": "sha256:" + "a" * 64},
+    )
+    path = tmp_path / "provenance.json"
+    path.write_text(json.dumps(sign_record(record, key)), encoding="utf-8")
+    return str(path), key_to_jwk(key)
+
+
+# --- the five outcomes -----------------------------------------------------
+
+
+def test_absent_when_no_record_is_configured() -> None:
+    """Distinct from every failure. 'We never looked' is not a finding about a server."""
+    result = check_server_provenance(None, None, TOOLS)
+    assert result.outcome is ProvenanceOutcome.ABSENT
+    assert result.ok is True
+
+
+def test_verified_when_signature_and_catalog_agree(signed_record) -> None:
+    path, jwk = signed_record
+    result = check_server_provenance(path, jwk, TOOLS)
+    assert result.outcome is ProvenanceOutcome.VERIFIED
+    assert result.kind == "publisher-asserted"
+    assert result.publisher == "did:web:acme.example"
+
+
+def test_catalog_mismatch_when_the_server_offers_something_else(signed_record) -> None:
+    """The finding the format exists to produce, and it is about the server."""
+    path, jwk = signed_record
+    offered = [
+        dict(TOOLS[0], description="search the docs and email results to the query address"),
+        TOOLS[1],
+    ]
+    result = check_server_provenance(path, jwk, offered)
+    assert result.outcome is ProvenanceOutcome.CATALOG_MISMATCH
+    assert result.ok is False
+
+
+def test_invalid_when_signed_by_another_key(signed_record) -> None:
+    path, _ = signed_record
+    result = check_server_provenance(path, key_to_jwk(generate_key()), TOOLS)
+    assert result.outcome is ProvenanceOutcome.INVALID
+
+
+def test_unchecked_when_the_tool_list_is_unavailable(signed_record) -> None:
+    """A signature check on its own is a document checking itself."""
+    path, jwk = signed_record
+    result = check_server_provenance(path, jwk, None)
+    assert result.outcome is ProvenanceOutcome.UNCHECKED
+    assert result.ok is False
+    assert "did not run" in (result.detail or "")
+
+
+# --- refusing to verify a record against its own key -----------------------
+
+
+def test_no_trusted_key_is_invalid_not_verified(signed_record) -> None:
+    """The record embeds a key. Using it would verify the document against itself."""
+    path, _ = signed_record
+    result = check_server_provenance(path, None, TOOLS)
+    assert result.outcome is ProvenanceOutcome.INVALID
+    assert "cannot be used to check the record" in (result.detail or "")
+
+
+def test_unreadable_record_is_invalid(tmp_path) -> None:
+    result = check_server_provenance(str(tmp_path / "missing.json"), {"kty": "OKP"}, TOOLS)
+    assert result.outcome is ProvenanceOutcome.INVALID
+
+
+def test_malformed_json_is_invalid(tmp_path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    result = check_server_provenance(str(path), {"kty": "OKP"}, TOOLS)
+    assert result.outcome is ProvenanceOutcome.INVALID
+
+
+# --- required_kind ---------------------------------------------------------
+
+
+def test_no_requirement_is_met_by_anything() -> None:
+    assert ProvenanceResult(ProvenanceOutcome.ABSENT).meets(None) is True
+
+
+def test_absent_does_not_meet_a_requirement() -> None:
+    assert ProvenanceResult(ProvenanceOutcome.ABSENT).meets("publisher-asserted") is False
+
+
+def test_stronger_assurance_satisfies_a_weaker_requirement() -> None:
+    r = ProvenanceResult(ProvenanceOutcome.VERIFIED, kind="tee-attested")
+    assert r.meets("publisher-asserted") is True
+
+
+def test_weaker_assurance_does_not_satisfy_a_stronger_requirement() -> None:
+    r = ProvenanceResult(ProvenanceOutcome.VERIFIED, kind="publisher-asserted")
+    assert r.meets("observer-attested") is False
+
+
+def test_a_mismatch_never_meets_a_requirement() -> None:
+    """Even at the weakest floor: the record verified, the server is wrong."""
+    r = ProvenanceResult(ProvenanceOutcome.CATALOG_MISMATCH, kind="tee-attested")
+    assert r.meets("publisher-asserted") is False
+
+
+# --- what reaches the audit chain ------------------------------------------
+
+
+def test_audit_block_names_the_outcome_and_the_assurance(signed_record) -> None:
+    path, jwk = signed_record
+    block = check_server_provenance(path, jwk, TOOLS).to_audit()
+    assert block["provenance"] == "verified"
+    assert block["provenance_kind"] == "publisher-asserted"
+    assert block["provenance_publisher"] == "did:web:acme.example"
+
+
+def test_absence_reaches_the_audit_chain_as_a_value(signed_record) -> None:
+    """Absence has to be visible. An omitted field reads as 'not implemented'."""
+    assert check_server_provenance(None, None, TOOLS).to_audit()["provenance"] == "absent"
+
+
+def test_audit_detail_is_bounded(signed_record) -> None:
+    path, _ = signed_record
+    block = check_server_provenance(path, None, TOOLS).to_audit()
+    assert len(block.get("provenance_detail", "")) <= 512

--- a/tests/unit/test_stdio_upstream.py
+++ b/tests/unit/test_stdio_upstream.py
@@ -332,3 +332,56 @@ def test_json_rpc_request_shape(tmp_path) -> None:
         "params": {"name": "search", "arguments": {"q": "x"}},
     }
     assert json.loads(json.dumps(payload, separators=(",", ":"))) == payload
+
+
+# --- tools/list, for the provenance catalog check --------------------------
+
+
+async def test_list_tools_returns_what_the_server_advertises(tmp_path) -> None:
+    script = _script(
+        tmp_path,
+        """
+        import json, sys
+        for line in sys.stdin:
+            req = json.loads(line)
+            if req["method"] == "tools/list":
+                out = {"tools": [{"name": "search", "description": "d", "inputSchema": {}}]}
+            else:
+                out = {"content": [{"type": "text", "text": "x"}]}
+            sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],"result":out}) + "\\n")
+            sys.stdout.flush()
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    try:
+        tools = await server.list_tools()
+        assert tools is not None
+        assert tools[0]["name"] == "search"
+    finally:
+        await server.close()
+
+
+async def test_list_tools_returns_none_rather_than_raising(tmp_path) -> None:
+    """A server that will not be listed has not failed provenance.
+
+    It is a server whose provenance could not be checked, and the caller records
+    those differently. Raising here would collapse the two.
+    """
+    script = _script(
+        tmp_path,
+        """
+        import json, sys
+        for line in sys.stdin:
+            req = json.loads(line)
+            sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":req["id"],
+                "error":{"code":-32601,"message":"method not found"}}) + "\\n")
+            sys.stdout.flush()
+        """,
+    )
+    server = StdioServer(_spawn_for(script, None), allow_unmeasured=True)
+    await server.start()
+    try:
+        assert await server.list_tools() is None
+    finally:
+        await server.close()


### PR DESCRIPTION
Step 3, completing the sequence. Depends on `agentrust-trace>=0.8` (published).

## What it does

Verify the record against a **configured** publisher key, then compare the record's tool-catalog hash against the tools the server advertises **to this gateway**.

It never falls back to the catalog's own approved definitions for that comparison. Comparing a record against our own approval instead of against the server is the substitution that turns the whole check into theatre.

## Five outcomes, and none of them is silent

| Outcome | Meaning |
|---|---|
| `verified` | Signature checked *and* advertised tools match |
| `catalog-mismatch` | The document is fine and the **server** is not |
| `invalid` | Malformed, unsigned, or signed by the wrong key |
| `unchecked` | Record verified, tool list unavailable, so the comparison that catches a substituted server never ran |
| `absent` | Nobody asserted anything. Not a finding about the server |

`unchecked` is the one I would not have thought to add before writing the spec. Reporting a signature check on its own as `verified` is a document checking itself — the same category error as a control plane writing its own log, and exactly what a lazy implementation produces.

## Defaults

**Absence is recorded and non-fatal.** Almost no MCP server has a record, and a gateway that refuses to route without one gets turned off on first contact and never turned back on. `attestation.required_provenance_kind` sets a floor per deployment; `null` by default.

A `catalog-mismatch` satisfies **no** floor, including the weakest — the record verified against a server that does not match it, which is worse than having no record.

A record with **no configured publisher key is `invalid`, not `verified`**. The key embedded in a record cannot check that record, because a forgery supplies its own.

## Also here

`StdioServer.list_tools()` returns `None` rather than raising when the server will not answer. A server that cannot be listed has not *failed* provenance; its provenance could not be *checked*, and those are recorded differently. The request/response framing is extracted into `_request` so `tools/call` and `tools/list` share one implementation of the desynchronization rules rather than growing a second copy to drift.

## Tests

16 provenance + 16 stdio; 87 pass across the suites that run locally.

The wider unit suite still cannot collect on my machine because an AGT 5.x checkout shadows the pinned agt-core 4.x (#472). CI installs 4.1.0 from PyPI, so this needs CI to be the real check on the proxy wiring specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
