### PR TITLE
docs(status): the attestation default is stronger than the table claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`STATUS.md` understated the attestation default in two ways.** It gave the probe order as `tpm -> sev-snp -> tdx`, missing `azure-cvm`, which is probed *first* and exists precisely so an Azure confidential VM is not mistaken for a plain TPM host. And it said nothing about what happens when no hardware is found, which is the question an evaluator is actually asking.
+
+  The answer is better than the omission implied and is now stated: **auto never degrades to software.** With no hardware detected the gateway refuses to start unless `CMCP_DEV_MODE=1`, and `provider: software-only` requires that flag as well, so a software-mode gateway is always a deployment that asked for one rather than a silent downgrade. `tests/unit/test_tee.py` pins both, including that setting `CMCP_DEV_MODE` in the environment *after* config load does not bypass it.
+
+  Documentation only. No behaviour changed; the behaviour was already correct and the defaults table was selling it short.
+
 ### Added
 
 - **Server provenance checking (step 3).** The gateway consumes [`server-provenance-v1`](https://github.com/agentrust-io/trace-spec/blob/main/spec/server-provenance-v1.md) records via `agentrust-trace>=0.8`: it verifies the record against a **configured** publisher key, then compares the record's tool-catalog hash against the tools the server advertises to this gateway.

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,7 +8,7 @@ picture is stated once. Developer Preview: interfaces may change before v1.0.
 
 | Setting | Default |
 |---|---|
-| `attestation.provider` | `auto` (probe order `tpm -> sev-snp -> tdx`) |
+| `attestation.provider` | `auto` (probe order `azure-cvm -> tpm -> sev-snp -> tdx`). **Auto never degrades to software.** With no hardware detected the gateway refuses to start unless `CMCP_DEV_MODE=1`, and `provider: software-only` requires that flag too, so a software-mode gateway is always a deployment that asked for one. |
 | `attestation.enforcement_mode` | `enforcing` |
 | `attestation.staleness_policy` | `fail_closed` |
 | `attestation.validity_seconds` | `86400` |


### PR DESCRIPTION
The response plan's "hardware is a validated capability, not the default" item. **The code side turns out to be done** — what was left was a defaults table selling it short.

## What the row said

```
| attestation.provider | auto (probe order tpm -> sev-snp -> tdx) |
```

Two problems. It omits `azure-cvm`, which is probed **first** and exists precisely so an Azure confidential VM is not mistaken for a plain TPM host and quietly reduced to a vTPM quote that loses the SNP silicon root. And it says nothing about what happens when no hardware is found — the question anyone reading a defaults table is actually asking.

## What is true

**Auto never degrades to software.** With no hardware detected the gateway refuses to start unless `CMCP_DEV_MODE=1`, and `provider: software-only` requires that flag as well. A software-mode gateway is always a deployment that asked for one, never a silent downgrade.

`tests/unit/test_tee.py` already pins both — including `test_detect_env_var_alone_does_not_bypass_config`, which proves setting `CMCP_DEV_MODE` in the environment *after* config load does not bypass the check. 23 tests pass.

cA2A is the same: `ca2a start` defaults to `provider: auto` and `auto` refuses to fall back, so a software-mode listener is always a config that names `software-only`.

Documentation only. No behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)