### PR TITLE
feat: let a deployment add its own sensitivity labels alongside the built in six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable sensitivity vocabulary (#479).** The six built in sensitivity labels (`public`, `pii`, `confidential`, `hipaa_phi`, `mnpi`, `trade_secret`) were the only ones a catalog entry could ever declare, so a regulated deployment whose own scheme names a tier above `trade_secret`, an Open/Confidential/Secret/Top Secret ladder for example, had no way to catalogue it truthfully.
+
+  `sensitivity.vocabulary` in config now lets a deployment add new labels at any rank. It is additive only and enforced at two layers: config parsing rejects a vocabulary key that names a built in label outright, and `session/state.py`'s `effective_sensitivity_order()` merges the built in table in last regardless, so a built in name can never be shadowed even by a bug elsewhere in the chain. That guarantee is not cosmetic: response inspection's content pattern detectors emit the built in tags `pii` and `hipaa_phi` directly when they spot an SSN, an email, a diagnosis code and so on, and if either name had silently dropped out of the effective vocabulary those detections would have ranked at 0, the same fail open hole #478 closed for the catalog schema.
+
+  `SessionManager` and `PolicyEvaluator` each derive the effective vocabulary once from the same `Config`, so a session's `max_sensitivity` string and the `sensitivity_level` integer Cedar evaluates can never disagree about what a custom label ranks as. The catalog schema's `sensitivity_level` enum moved from the static JSON schema into a Python level check at load time against this same effective set, so the vocabulary stays closed, just not hardcoded.
+
+  Per call classification, letting a single call declare a class narrower than its tool's catalogued default, is the second half of #479 and is left for a follow up change.
+
 - **Server provenance checking (step 3).** The gateway consumes [`server-provenance-v1`](https://github.com/agentrust-io/trace-spec/blob/main/spec/server-provenance-v1.md) records via `agentrust-trace>=0.8`: it verifies the record against a **configured** publisher key, then compares the record's tool-catalog hash against the tools the server advertises to this gateway.
 
   It never falls back to the catalog's own approved definitions for that comparison. Comparing a record against our approval instead of against the server is the substitution that turns the whole check into theatre.

--- a/docs/spec/session-policy.md
+++ b/docs/spec/session-policy.md
@@ -20,6 +20,17 @@ public < pii < confidential < hipaa_phi = mnpi = trade_secret
 
 `hipaa_phi`, `mnpi`, and `trade_secret` are all at the highest level. There is no ordering among them: a session that has seen MNPI is equally restricted as one that has seen PHI. Once a session reaches any of the three, the same egress rules apply.
 
+These six are fixed and always present. A deployment that needs to express a classification scheme its own regulation names, for example a public sector Open/Confidential/Secret/Top Secret ladder, adds new labels alongside them via `sensitivity.vocabulary` in config, rather than replacing the built in set (#479):
+
+```yaml
+sensitivity:
+  vocabulary:
+    secret: 4
+    top_secret: 5
+```
+
+This is additive only. A vocabulary key that names a built in label is rejected at config load, since response inspection's pattern based detectors (see [response-inspection.md](response-inspection.md)) emit the built in tags directly, `pii` and `hipaa_phi` among them, and those tags must always resolve to their real rank rather than an unrecognised one. `SessionManager` and `PolicyEvaluator` each derive the same effective vocabulary from the same config, so a session's `max_sensitivity` and the `sensitivity_level` integer Cedar sees can never disagree about what a custom label ranks as. The tool catalog's `sensitivity_level` field is validated at load time against this same effective set, so it stays a closed vocabulary, just not a hardcoded one.
+
 ### State Transitions
 
 State is monotonically increasing within a session. It never decreases automatically. The only way to return to a lower state is an explicit operator-authorized session reset (see below).

--- a/docs/tutorials/tool-catalog-authoring.md
+++ b/docs/tutorials/tool-catalog-authoring.md
@@ -121,6 +121,8 @@ Boolean. When `true`, Cedar policies can enforce that a Business Associate Agree
 
 String label for the data sensitivity of this tool's outputs. Common values: `"public"`, `"internal"`, `"confidential"`, `"pii"`. The session sensitivity tracker uses this: after a session calls a `"pii"` tool, all subsequent calls in the session carry `session_sensitivity: "pii"` in Cedar context.
 
+The legal set of values is the built in vocabulary plus anything a deployment has added in config under `sensitivity.vocabulary` (see [session-policy.md](../spec/session-policy.md#session-sensitivity-state-machine)), so a regulator specific top tier can be catalogued once that config addition is in place. An entry naming a level outside that set fails to load, closed by design.
+
 ### `added_at`
 
 ISO 8601 timestamp when this entry was approved. Included in the canonical hash and surfaced in the TRACE claim.

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -206,16 +206,8 @@
     },
     "sensitivity_level": {
       "type": "string",
-      "enum": [
-        "public",
-        "pii",
-        "confidential",
-        "hipaa_phi",
-        "mnpi",
-        "trade_secret"
-      ],
       "default": "public",
-      "description": "Data sensitivity level of information this tool accesses or returns."
+      "description": "Data sensitivity level of information this tool accesses or returns. Validated at catalog load time against the built in vocabulary plus any deployment configured additions (#479), not enumerated here, since the legal set is config dependent."
     },
     "added_at": {
       "type": "string",

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -18,6 +18,7 @@ from cmcp_runtime.errors import (
     ToolNotInCatalog,
 )
 from cmcp_runtime.mcp.stdio import StdioSpawn
+from cmcp_runtime.session.state import SENSITIVITY_ORDER
 
 _CATALOG_ENTRY_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "schemas" / "catalog-entry.schema.json"
 
@@ -145,13 +146,22 @@ def _validate_entry(raw: dict[str, Any], schema: dict[str, Any] | None) -> None:
         raise ConfigError(f"Catalog entry '{raw.get('tool_name', '?')}' schema violation: {exc.message}") from exc
 
 
-def load_catalog(catalog_path: str, expected_hash: str | None = None) -> ToolCatalog:
+def load_catalog(
+    catalog_path: str,
+    expected_hash: str | None = None,
+    extra_sensitivity_levels: frozenset[str] = frozenset(),
+) -> ToolCatalog:
     """
     Load and validate the tool catalog from a JSON file.
 
     Raises CatalogHashMismatch if expected_hash is provided and doesn't match.
     Raises CatalogToolNameCollision if two entries share a tool_name.
     Raises ConfigError on schema violation or file errors.
+
+    extra_sensitivity_levels (#479): deployment configured additions to the
+    built in sensitivity vocabulary, from Config.sensitivity.vocabulary. A
+    catalog entry's sensitivity_level must be a built in label or one of these,
+    or loading fails closed, same as the fixed six value set used to.
     """
     path = Path(catalog_path)
     try:
@@ -172,6 +182,14 @@ def load_catalog(catalog_path: str, expected_hash: str | None = None) -> ToolCat
             raise ConfigError("Each catalog entry must be a JSON object")
 
         _validate_entry(raw, entry_schema)
+
+        sensitivity_level = raw.get("sensitivity_level", "public")
+        allowed_sensitivity_levels = frozenset(SENSITIVITY_ORDER) | extra_sensitivity_levels
+        if sensitivity_level not in allowed_sensitivity_levels:
+            raise ConfigError(
+                f"Catalog entry '{raw.get('tool_name', '?')}' sensitivity_level "
+                f"'{sensitivity_level}' is not one of {sorted(allowed_sensitivity_levels)}"
+            )
 
         tool_name: str = raw["tool_name"]
         # POLICY-002: enforce lowercase-only tool names so ingress canonicalization

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -12,6 +12,7 @@ from typing import Any
 import yaml
 
 from cmcp_runtime.errors import ConfigError
+from cmcp_runtime.session.state import SENSITIVITY_ORDER
 
 # TEE-002: read exactly once at import time so the value is immutable for the
 # lifetime of the process. No code may call os.environ.get("CMCP_DEV_MODE")
@@ -48,6 +49,19 @@ class KillSwitchConfig:
 
 
 @dataclass
+class SensitivityConfig:
+    """Deployment supplied additions to the built in sensitivity vocabulary (#479).
+
+    Additive only: a key here must not collide with a built in SENSITIVITY_ORDER
+    name (enforced when config loads), so a deployment can add new labels,
+    including tiers above trade_secret, without ever being able to remove or
+    rename a built in one. See session/state.py's effective_sensitivity_order().
+    """
+
+    vocabulary: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
 class AttestationConfig:
     provider: TEEProvider = TEEProvider.AUTO
     enforcement_mode: EnforcementMode = EnforcementMode.ENFORCING
@@ -81,6 +95,7 @@ class Config:
     attestation: AttestationConfig = field(default_factory=AttestationConfig)
     agent_manifest: AgentManifestConfig = field(default_factory=AgentManifestConfig)
     kill_switch: KillSwitchConfig = field(default_factory=KillSwitchConfig)
+    sensitivity: SensitivityConfig = field(default_factory=SensitivityConfig)
     policy_bundle_path: str = "policies/"
     catalog_path: str = "catalog.json"
     listen_addr: str = "0.0.0.0:8443"
@@ -95,6 +110,7 @@ _KNOWN_TOP_KEYS = {
     "attestation",
     "agent_manifest",
     "kill_switch",
+    "sensitivity",
     "policy_bundle_path",
     "catalog_path",
     "listen_addr",
@@ -108,6 +124,7 @@ _KNOWN_KILL_SWITCH_KEYS = {
     "deny_rate_threshold",
     "min_calls",
 }
+_KNOWN_SENSITIVITY_KEYS = {"vocabulary"}
 _KNOWN_ATTEST_KEYS = {
     "provider",
     "enforcement_mode",
@@ -253,6 +270,37 @@ def load_config(path: str) -> Config:
     if not isinstance(ks_min_calls, int) or ks_min_calls <= 0:
         raise ConfigError("kill_switch.min_calls must be a positive integer")
 
+    sens_raw = raw.get("sensitivity", {})
+    if sens_raw is None:
+        sens_raw = {}
+    if not isinstance(sens_raw, dict):
+        raise ConfigError("'sensitivity' must be a mapping")
+    for key in sens_raw:
+        if key not in _KNOWN_SENSITIVITY_KEYS:
+            raise ConfigError(
+                f"Unknown sensitivity key '{key}'. Valid keys: {sorted(_KNOWN_SENSITIVITY_KEYS)}"
+            )
+    vocab_raw = sens_raw.get("vocabulary", {})
+    if vocab_raw is None:
+        vocab_raw = {}
+    if not isinstance(vocab_raw, dict):
+        raise ConfigError("sensitivity.vocabulary must be a mapping")
+    sensitivity_vocabulary: dict[str, int] = {}
+    for label, rank in vocab_raw.items():
+        if not isinstance(label, str) or not label:
+            raise ConfigError("sensitivity.vocabulary keys must be non empty strings")
+        if label in SENSITIVITY_ORDER:
+            raise ConfigError(
+                f"sensitivity.vocabulary key '{label}' collides with a built in "
+                "sensitivity label. Custom labels may only add to the built in "
+                "set, never rename or replace one."
+            )
+        if isinstance(rank, bool) or not isinstance(rank, int) or rank < 0:
+            raise ConfigError(
+                f"sensitivity.vocabulary['{label}'] must be a non negative integer"
+            )
+        sensitivity_vocabulary[label] = rank
+
     try:
         provider = TEEProvider(attest_raw.get("provider", "auto"))
     except ValueError as err:
@@ -365,6 +413,7 @@ def load_config(path: str) -> Config:
             deny_rate_threshold=float(ks_threshold),
             min_calls=ks_min_calls,
         ),
+        sensitivity=SensitivityConfig(vocabulary=sensitivity_vocabulary),
         policy_bundle_path=policy_bundle_path,
         catalog_path=catalog_path,
         listen_addr=listen_addr,

--- a/src/cmcp_runtime/policy/evaluator.py
+++ b/src/cmcp_runtime/policy/evaluator.py
@@ -19,7 +19,7 @@ from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.annotations import parse_policy_annotations
 from cmcp_runtime.policy.bundle import PolicyBundle, PolicyStore
 from cmcp_runtime.policy.decisions import Decision, decision_for_deny
-from cmcp_runtime.session.state import SENSITIVITY_ORDER
+from cmcp_runtime.session.state import effective_sensitivity_order
 
 if TYPE_CHECKING:
     from cmcp_runtime.session.state import SessionState
@@ -59,6 +59,10 @@ class PolicyEvaluator:
 
     def __init__(self, bundle: PolicyBundle | PolicyStore, config: Config) -> None:
         self._mode = config.attestation.enforcement_mode
+        # #479: same effective vocabulary SessionManager derives from this same
+        # Config, so a session's max_sensitivity and this sensitivity_level_int
+        # can never disagree about what a custom label ranks as.
+        self._sensitivity_order = effective_sensitivity_order(config.sensitivity.vocabulary)
 
         # Normalise: always work with a PolicyStore internally.
         if isinstance(bundle, PolicyStore):
@@ -240,7 +244,7 @@ class PolicyEvaluator:
             # allowed tool response would be denied on the way back.
             "resource": tool_name,
             "egress": True,
-            "sensitivity_level": SENSITIVITY_ORDER.get(session.max_sensitivity, 0),
+            "sensitivity_level": self._sensitivity_order.get(session.max_sensitivity, 0),
             "injection_events": len(session.injection_events),
             "reset_count": session.reset_count,
             "response_size_bytes": len(response_bytes),

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -26,13 +26,13 @@ from cmcp_runtime.audit.trace_claim import (
     ToolTranscriptEntry,
     generate_trace_claim,
 )
-from cmcp_runtime.config import KillSwitchConfig
+from cmcp_runtime.config import KillSwitchConfig, SensitivityConfig
 from cmcp_runtime.errors import KillSwitchTripped, TeeFault
 from cmcp_runtime.kill_switch import KillSwitchEvaluator
 from cmcp_runtime.observability.otel import otel_sink_from_env
 from cmcp_runtime.policy.decisions import claim_value
 from cmcp_runtime.session.call_log import CallLog, SessionCallLog
-from cmcp_runtime.session.state import SessionState
+from cmcp_runtime.session.state import SessionState, effective_sensitivity_order
 from cmcp_runtime.startup import RuntimeContext
 from cmcp_runtime.tee.base import AttestationReport, make_audit_bound_nonce
 
@@ -73,6 +73,13 @@ class SessionManager:
         if not isinstance(ks_cfg, KillSwitchConfig):
             ks_cfg = KillSwitchConfig()  # disabled by default if not configured
         self._kill_switch = KillSwitchEvaluator(ks_cfg)
+        sens_cfg = getattr(ctx.config, "sensitivity", None)
+        vocabulary = sens_cfg.vocabulary if isinstance(sens_cfg, SensitivityConfig) else {}
+        # #479: computed once so every session in this process shares one
+        # effective vocabulary, the same one PolicyEvaluator derives from the
+        # same Config, so a session's max_sensitivity and Cedar's
+        # sensitivity_level_int can never disagree about a custom label's rank.
+        self._sensitivity_order = effective_sensitivity_order(vocabulary)
         # AARM R8: telemetry export. Built once here rather than per session so
         # every chain shares one exporter, and empty unless CMCP_OTEL_ENABLED
         # asks for it. Sinks run after an entry is durable and cannot break the
@@ -109,7 +116,7 @@ class SessionManager:
             )
 
         session_id = str(uuid4())
-        state = SessionState(session_id=session_id)
+        state = SessionState(session_id=session_id, sensitivity_order=self._sensitivity_order)
         chain = AuditChain(
             session_id=session_id,
             store=self._ctx.audit_store,

--- a/src/cmcp_runtime/session/state.py
+++ b/src/cmcp_runtime/session/state.py
@@ -19,9 +19,26 @@ SENSITIVITY_ORDER: dict[str, int] = {
 }
 
 
-def _max_sensitivity(a: str, b: str) -> str:
+def effective_sensitivity_order(extra: dict[str, int] | None = None) -> dict[str, int]:
+    """Built in vocabulary plus any deployment configured additions (#479).
+
+    Additive only: extra can add new labels, for example a regulator's own top
+    tier, but can never remove or shadow a built in name. SENSITIVITY_ORDER is
+    merged in last so a built in name always keeps its built in rank even if
+    something upstream of this function failed to reject a colliding key, since
+    config.py's parser is expected to reject that collision before this ever
+    runs. This matters because response inspection emits hardcoded tags such as
+    pii and hipaa_phi (inspection/pipeline.py); if one of those names silently
+    dropped out of the effective vocabulary it would rank at 0 by
+    SENSITIVITY_ORDER.get(tag, 0)'s fail open default, the same class of hole
+    the schema validation at catalog load time closes for #478.
+    """
+    return {**(extra or {}), **SENSITIVITY_ORDER}
+
+
+def _max_sensitivity(a: str, b: str, order: dict[str, int] = SENSITIVITY_ORDER) -> str:
     """Return whichever sensitivity level is higher. Ties return 'a'."""
-    if SENSITIVITY_ORDER.get(b, 0) > SENSITIVITY_ORDER.get(a, 0):
+    if order.get(b, 0) > order.get(a, 0):
         return b
     return a
 
@@ -57,6 +74,11 @@ class SessionState:
     attestation_stale: bool = False
     catalog_drift: bool = False
     kill_switch_triggered: bool = False
+    # #479: the effective vocabulary this session ranks tags against. Defaults to
+    # the built in table; SessionManager passes the deployment's configured one.
+    sensitivity_order: dict[str, int] = field(
+        default_factory=lambda: SENSITIVITY_ORDER, repr=False, compare=False
+    )
     # AUTH-002: guards concurrent mutations from tool-call coroutines and session-reset requests
     mutation_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False, compare=False)
 
@@ -73,7 +95,7 @@ class SessionState:
         Called by InspectionPipeline after all stages complete.
         """
         for tag in sensitivity_tags:
-            new_max = _max_sensitivity(self.max_sensitivity, tag)
+            new_max = _max_sensitivity(self.max_sensitivity, tag, self.sensitivity_order)
             if new_max != self.max_sensitivity:
                 self.max_sensitivity = new_max
                 self.sensitivity_raised_at = datetime.now(tz=UTC).isoformat()

--- a/src/cmcp_runtime/startup.py
+++ b/src/cmcp_runtime/startup.py
@@ -387,7 +387,11 @@ def run_startup(config_path: str) -> RuntimeContext:
         )
         sys.exit(1)
     try:
-        catalog = load_catalog(config.catalog_path, expected_hash=catalog_expected_hash)
+        catalog = load_catalog(
+            config.catalog_path,
+            expected_hash=catalog_expected_hash,
+            extra_sensitivity_levels=frozenset(config.sensitivity.vocabulary),
+        )
     except CatalogHashMismatch as exc:
         _fatal(
             "CATALOG_HASH_MISMATCH",

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -192,3 +192,30 @@ def test_every_known_sensitivity_level_loads(catalog_file):
         entry = dict(ENTRY_1, sensitivity_level=level)
         cat = load_catalog(catalog_file([entry]))
         assert cat.entries["crm.query"].sensitivity_level == level
+
+
+# ── #479: configurable sensitivity vocabulary ──────────────────────────────────
+
+
+def test_custom_sensitivity_level_rejected_without_extension(catalog_file):
+    """A deployment configured label is not legal until load_catalog is told
+    about it, same fail closed default as an unknown level."""
+    entry = dict(ENTRY_1, sensitivity_level="top_secret")
+    with pytest.raises(ConfigError, match="is not one of"):
+        load_catalog(catalog_file([entry]))
+
+
+def test_custom_sensitivity_level_accepted_with_extension(catalog_file):
+    entry = dict(ENTRY_1, sensitivity_level="top_secret")
+    cat = load_catalog(
+        catalog_file([entry]), extra_sensitivity_levels=frozenset({"top_secret"})
+    )
+    assert cat.entries["crm.query"].sensitivity_level == "top_secret"
+
+
+def test_extra_sensitivity_levels_does_not_loosen_built_in_check(catalog_file):
+    """extra_sensitivity_levels only adds labels, an unrelated typo is still
+    rejected even when some extension set is configured."""
+    entry = dict(ENTRY_1, sensitivity_level="secret")
+    with pytest.raises(ConfigError, match="is not one of"):
+        load_catalog(catalog_file([entry]), extra_sensitivity_levels=frozenset({"top_secret"}))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -97,6 +97,61 @@ def test_unknown_agent_manifest_key_raises(config_file):
         load_config(path)
 
 
+# ── #479: configurable sensitivity vocabulary ──────────────────────────────────
+
+
+def test_sensitivity_vocabulary_loads(config_file):
+    path = config_file("sensitivity:\n  vocabulary:\n    top_secret: 4\n    secret: 5\n")
+    cfg = load_config(path)
+    assert cfg.sensitivity.vocabulary == {"top_secret": 4, "secret": 5}
+
+
+def test_sensitivity_vocabulary_defaults_to_empty(config_file):
+    path = config_file("attestation:\n  provider: tpm\n")
+    cfg = load_config(path)
+    assert cfg.sensitivity.vocabulary == {}
+
+
+def test_unknown_sensitivity_key_raises(config_file):
+    path = config_file("sensitivity:\n  surprise: value\n")
+    with pytest.raises(ConfigError, match="surprise"):
+        load_config(path)
+
+
+def test_sensitivity_vocabulary_non_mapping_raises(config_file):
+    path = config_file("sensitivity:\n  vocabulary: not_a_mapping\n")
+    with pytest.raises(ConfigError, match="mapping"):
+        load_config(path)
+
+
+def test_sensitivity_vocabulary_negative_rank_raises(config_file):
+    path = config_file("sensitivity:\n  vocabulary:\n    top_secret: -1\n")
+    with pytest.raises(ConfigError, match="non negative"):
+        load_config(path)
+
+
+def test_sensitivity_vocabulary_non_integer_rank_raises(config_file):
+    path = config_file("sensitivity:\n  vocabulary:\n    top_secret: high\n")
+    with pytest.raises(ConfigError, match="non negative"):
+        load_config(path)
+
+
+def test_sensitivity_vocabulary_boolean_rank_raises(config_file):
+    """A bool is an int subclass in Python, so True/False must be rejected
+    explicitly or a typo'd yaml boolean would silently become rank 0 or 1."""
+    path = config_file("sensitivity:\n  vocabulary:\n    top_secret: true\n")
+    with pytest.raises(ConfigError, match="non negative"):
+        load_config(path)
+
+
+def test_sensitivity_vocabulary_collision_with_built_in_raises(config_file):
+    """The additive only guarantee (#479): a deployment cannot rename or
+    shadow a built in label, only add new ones alongside it."""
+    path = config_file("sensitivity:\n  vocabulary:\n    confidential: 9\n")
+    with pytest.raises(ConfigError, match="collides"):
+        load_config(path)
+
+
 def test_agent_manifest_path_requires_trust_anchor(config_file):
     path = config_file("agent_manifest:\n  path: /etc/cmcp/agent-manifest.json\n")
     with pytest.raises(ConfigError, match="set together"):

--- a/tests/unit/test_egress_policy.py
+++ b/tests/unit/test_egress_policy.py
@@ -161,6 +161,32 @@ def test_authorize_egress_passes_sensitivity_level_in_context():
     assert called_ctx["response_size_bytes"] == len(b"data")
 
 
+def test_authorize_egress_passes_custom_sensitivity_level_in_context():
+    """#479: a PolicyEvaluator built from a Config carrying a custom sensitivity
+    vocabulary ranks a deployment configured label correctly in Cedar context,
+    the same effective order SessionManager derives from that same Config."""
+    from cmcp_runtime.session.state import effective_sensitivity_order
+
+    with patch("cmcp_runtime.policy.evaluator.CedarBackend") as MockBackend:
+        mock = MagicMock()
+        mock.evaluate.return_value = MagicMock(
+            allowed=True, reason=None, evaluation_ms=0.1
+        )
+        MockBackend.return_value = mock
+
+        config = _make_config()
+        config.sensitivity.vocabulary = {"top_secret": 4}
+        evaluator = PolicyEvaluator(_make_bundle(), config)
+        custom_order = effective_sensitivity_order(config.sensitivity.vocabulary)
+        session = SessionState(
+            session_id="s3", max_sensitivity="top_secret", sensitivity_order=custom_order
+        )
+        evaluator.authorize_egress("crm.query", b"data", session)
+
+    called_ctx = mock.evaluate.call_args[0][0]
+    assert called_ctx["sensitivity_level"] == 4
+
+
 def test_authorize_egress_passes_injection_and_reset_counts():
     """injection_events count and reset_count are forwarded to Cedar context."""
     with patch("cmcp_runtime.policy.evaluator.CedarBackend") as MockBackend:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -6,7 +6,12 @@ import asyncio
 
 import pytest
 
-from cmcp_runtime.session.state import SENSITIVITY_ORDER, SessionState, _max_sensitivity
+from cmcp_runtime.session.state import (
+    SENSITIVITY_ORDER,
+    SessionState,
+    _max_sensitivity,
+    effective_sensitivity_order,
+)
 
 # ── _max_sensitivity ──────────────────────────────────────────────────────────
 
@@ -26,6 +31,29 @@ def test_sensitivity_order_monotonic():
     levels = ["public", "pii", "confidential"]
     for i in range(len(levels) - 1):
         assert SENSITIVITY_ORDER[levels[i]] < SENSITIVITY_ORDER[levels[i + 1]]
+
+
+# ── effective_sensitivity_order (#479) ─────────────────────────────────────────
+
+
+def test_effective_sensitivity_order_adds_new_labels():
+    order = effective_sensitivity_order({"top_secret": 4})
+    assert order["top_secret"] == 4
+    assert order["trade_secret"] == 3  # built ins untouched
+
+
+def test_effective_sensitivity_order_defaults_to_built_in_only():
+    assert effective_sensitivity_order(None) == SENSITIVITY_ORDER
+    assert effective_sensitivity_order({}) == SENSITIVITY_ORDER
+
+
+def test_effective_sensitivity_order_built_in_wins_on_collision():
+    """Defense in depth: even if a caller passes a colliding key, which
+    config.py's parser is supposed to reject before this ever runs, the built
+    in rank must win so a hardcoded inspection tag such as pii can never
+    silently rank at 0."""
+    order = effective_sensitivity_order({"pii": 99})
+    assert order["pii"] == SENSITIVITY_ORDER["pii"]
 
 
 # ── SessionState ──────────────────────────────────────────────────────────────
@@ -111,6 +139,26 @@ def test_update_highest_tag_wins_per_update():
     state.update_from_inspection("c1", ["pii", "mnpi", "confidential"], False, True)
     assert state.max_sensitivity in ("mnpi", "hipaa_phi", "trade_secret")
     assert SENSITIVITY_ORDER[state.max_sensitivity] == 3
+
+
+def test_update_ranks_against_custom_sensitivity_order():
+    """#479: a session built with a deployment configured vocabulary ranks a
+    new label correctly, and can rise above every built in label."""
+    custom_order = effective_sensitivity_order({"top_secret": 4})
+    state = SessionState(session_id="s1", sensitivity_order=custom_order)
+    state.update_from_inspection("c1", ["trade_secret"], False, True)
+    assert state.max_sensitivity == "trade_secret"
+    state.update_from_inspection("c2", ["top_secret"], False, True)
+    assert state.max_sensitivity == "top_secret"
+
+
+def test_update_default_sensitivity_order_does_not_know_custom_labels():
+    """Without a configured vocabulary, an unrecognised label ranks at 0, same
+    fail open default as any other unknown tag - the safety net is the catalog
+    schema check at load time (#478/#479), not this ranking function."""
+    state = SessionState(session_id="s1")
+    state.update_from_inspection("c1", ["top_secret"], False, True)
+    assert state.max_sensitivity == "public"
 
 
 # ── AUTH-002: asyncio.Lock guards concurrent mutations ────────────────────────


### PR DESCRIPTION
## Summary

Part of #479, the configurable vocabulary piece. Per call classification, the second piece of that issue, is left for a follow up.

The sensitivity vocabulary was six hardcoded labels, public, pii, confidential, hipaa_phi, mnpi, trade_secret, in SENSITIVITY_ORDER, and the catalog schema validated sensitivity_level against exactly that literal enum. A deployment whose own regulation names a tier above trade_secret, an Open, Confidential, Secret, Top Secret ladder for example, had no way to catalogue it truthfully.

sensitivity.vocabulary in config now lets a deployment add new labels at any rank.

## Design decision worth flagging

The vocabulary is additive only, not a full replacement. Response inspection's content pattern detectors emit the built in tags pii and hipaa_phi directly when they spot an SSN, an email, a diagnosis code and so on. If a deployment's configured vocabulary could drop either of those names, those detections would rank at 0 by the ordinary unknown tag default, the same fail open hole #478 closed for the catalog schema, just moved to a different door.

So a vocabulary key that names a built in label is rejected at config load, and effective_sensitivity_order merges the built in table in last regardless of what config parsing did, so a built in name can never be shadowed even by a mistake elsewhere in the chain.

SessionManager and PolicyEvaluator each derive the effective vocabulary once from the same Config, so a session's max_sensitivity string and the sensitivity_level integer Cedar evaluates can never disagree about what a custom label ranks as.

## Changes

- src/cmcp_runtime/config.py: new SensitivityConfig, sensitivity.vocabulary parsing, additive only guarantee enforced at parse time.
- src/cmcp_runtime/session/state.py: effective_sensitivity_order(), SessionState.sensitivity_order field, _max_sensitivity takes an optional order parameter.
- src/cmcp_runtime/session/manager.py, src/cmcp_runtime/policy/evaluator.py: both derive the effective vocabulary once from the same Config and thread it through.
- schemas/catalog-entry.schema.json, src/cmcp_runtime/catalog/loader.py: sensitivity_level enum moved out of the static JSON schema into a Python level check at load time against the effective set, so it stays closed, just not hardcoded. Same error message shape as before, existing tests unchanged.
- src/cmcp_runtime/startup.py: wires config.sensitivity.vocabulary into load_catalog.
- docs/spec/session-policy.md, docs/tutorials/tool-catalog-authoring.md, CHANGELOG.md.

## Test plan

- [x] pytest tests/unit/ passes locally, 996 passed, 8 skipped
- [x] ruff check src/ tests/ clean
- [x] mypy src/cmcp_runtime/ src/cmcp_verify/ clean
- [x] bandit -r src/ clean
- [x] manual check: custom vocabulary loads, collision with a built in label rejected, catalog entry with a custom label rejected without the extension and accepted with it, session ranks a custom label correctly, built in tags like hipaa_phi still rank correctly with a custom vocabulary configured