### PR TITLE
feat: let a call declare its own sensitivity class via _cmcp.data_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Per call classification, letting a single call declare a class narrower than its tool's catalogued default, is the second half of #479 and is left for a follow up change.
 
+- **Per call sensitivity classification (#479).** One catalogued tool can serve many classes of data, a model call tool catalogued at `pii` might, on a specific call, actually carry `confidential` data (agentrust-io/demos#36 is the motivating example). The signed transcript could only ever show the tool's single catalogued value, and the session's own sensitivity tracking never rose past what the catalog alone said either, an enforcement gap for later calls in the session, not only a record keeping one.
+
+  A call may now declare a class for itself via `_cmcp.data_class` on the request. It composes with the vocabulary work above: a deployment adds a label in config, a call declares it per call. The declared value needs no separate validation, `_max_sensitivity` already is the validator: it returns whichever of two labels ranks higher and ties favour the catalog value, so an unrecognised or lower declared value is harmless by construction, and a legitimately higher one raises both the session's `max_sensitivity` and, independently, that specific call's own row in the signed transcript, without inheriting whatever the session had already accumulated from earlier calls.
+
+  `AuditEntry` gained one new field, `effective_data_class`, `None` on every call that never declares one, so nothing changes for a caller that does not use `_cmcp.data_class`.
+
 - **Server provenance checking (step 3).** The gateway consumes [`server-provenance-v1`](https://github.com/agentrust-io/trace-spec/blob/main/spec/server-provenance-v1.md) records via `agentrust-trace>=0.8`: it verifies the record against a **configured** publisher key, then compares the record's tool-catalog hash against the tools the server advertises to this gateway.
 
   It never falls back to the catalog's own approved definitions for that comparison. Comparing a record against our approval instead of against the server is the substitution that turns the whole check into theatre.

--- a/docs/spec/session-policy.md
+++ b/docs/spec/session-policy.md
@@ -31,6 +31,8 @@ sensitivity:
 
 This is additive only. A vocabulary key that names a built in label is rejected at config load, since response inspection's pattern based detectors (see [response-inspection.md](response-inspection.md)) emit the built in tags directly, `pii` and `hipaa_phi` among them, and those tags must always resolve to their real rank rather than an unrecognised one. `SessionManager` and `PolicyEvaluator` each derive the same effective vocabulary from the same config, so a session's `max_sensitivity` and the `sensitivity_level` integer Cedar sees can never disagree about what a custom label ranks as. The tool catalog's `sensitivity_level` field is validated at load time against this same effective set, so it stays a closed vocabulary, just not a hardcoded one.
 
+A single call can also declare its own class above its tool's catalogued floor, via `_cmcp.data_class` on the request (see [connecting-agent-frameworks.md](../tutorials/connecting-agent-frameworks.md#declare-a-per-call-data-class)), for a tool whose catalogued level is a floor rather than the true class of every call it serves. The two pieces compose: a deployment adds a label via `sensitivity.vocabulary`, and a call declares that label via `_cmcp.data_class` in the same session. The declaration can only raise the effective class, both for the session's `max_sensitivity` and for that call's own row in the signed transcript, never lower it, the same `_max_sensitivity` comparison this vocabulary section describes is what enforces that.
+
 ### State Transitions
 
 State is monotonically increasing within a session. It never decreases automatically. The only way to return to a lower state is an explicit operator-authorized session reset (see below).

--- a/docs/tutorials/connecting-agent-frameworks.md
+++ b/docs/tutorials/connecting-agent-frameworks.md
@@ -118,6 +118,25 @@ Set `_cmcp.workflow_id` in the request `params` to associate tool calls with a n
 
 `workflow_id` appears in the audit chain entries for every call made under that identifier.
 
+### Declare a per call data class
+
+Set `_cmcp.data_class` in the request `params` when a specific call touches data more sensitive than the tool's own catalogued `sensitivity_level`, for example one model call tool that sometimes carries `pii` and sometimes `confidential` data (#479):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "model.chat",
+    "arguments": {"prompt": "..."},
+    "_cmcp": {"data_class": "confidential"}
+  }
+}
+```
+
+The declared value can only raise the effective class for this call above the tool's catalogued floor, never lower it, and it composes with any labels a deployment has added under `sensitivity.vocabulary` in config. An unrecognised value is silently ignored rather than rejected, the same treatment an unrecognised built in content pattern tag gets: it simply cannot rank above the catalogued floor. The effective class, not the raw declaration, is what appears in the signed transcript for that call, and it also raises the session's own `max_sensitivity` for the rest of the session.
+
 ---
 
 ## Raw `httpx` client

--- a/src/cmcp_runtime/audit/chain.py
+++ b/src/cmcp_runtime/audit/chain.py
@@ -76,6 +76,11 @@ class AuditEntry:
     # independent authority attested. Serialized uniformly (null when absent),
     # so receipt-less entries remain deterministic and schema-stable.
     external_execution_evidence: dict[str, str] | None = None
+    # #479 piece 2: this call's own data class, catalog floor raised by any
+    # _cmcp.data_class declaration, already validated by construction since
+    # _max_sensitivity can only return the higher of the two. None when no
+    # declaration was made, the transcript falls back to the catalog value.
+    effective_data_class: str | None = None
     entry_hash: str = field(default="")  # computed after construction
 
     def _canonical_body(self) -> bytes:
@@ -213,6 +218,7 @@ class AuditChain:
         detail: dict[str, str | int | float] | None = None,
         workflow_id: str | None = None,
         external_execution_evidence: dict[str, str] | None = None,
+        effective_data_class: str | None = None,
     ) -> AuditEntry:
         prev_hash = self._entries[-1].entry_hash if self._entries else "genesis"
         now = datetime.now(tz=UTC)
@@ -241,6 +247,7 @@ class AuditChain:
             detail=detail,
             workflow_id=workflow_id,
             external_execution_evidence=external_execution_evidence,
+            effective_data_class=effective_data_class,
             prev_entry_hash=prev_hash,
         )
         entry.entry_hash = entry.compute_hash()

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -34,7 +34,7 @@ from cmcp_runtime.policy.decisions import audit_value
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.provenance import ProvenanceResult, check_server_provenance
 from cmcp_runtime.session.call_log import CallLog, CallRecord, SessionCallLog
-from cmcp_runtime.session.state import SessionState
+from cmcp_runtime.session.state import SessionState, _max_sensitivity
 
 logger = logging.getLogger(__name__)
 
@@ -546,6 +546,7 @@ class CMCPProxy:
         tool_name: str,
         arguments: dict[str, Any],
         workflow_id: str | None = None,
+        declared_data_class: str | None = None,
     ) -> CallResult:
         """
         Execute one MCP tool call through the full enforcement pipeline.
@@ -558,6 +559,13 @@ class CMCPProxy:
           5. Audit chain write
           6. Session state update
           7. Call log record + suspicious-sequence check
+
+        declared_data_class (#479 piece 2): an optional class the caller declares
+        for this specific call via _cmcp.data_class, raising this call's effective
+        class above the tool's catalogued sensitivity_level. It can never lower
+        the effective class and an unrecognised value is harmless: both properties
+        fall directly out of _max_sensitivity's semantics, no separate validation
+        needed here.
 
         Returns CallResult regardless of allow/deny so the caller can always
         write a complete audit entry.
@@ -624,6 +632,18 @@ class CMCPProxy:
                 latency_us=int(elapsed_ms * 1000),
                 audit_entry_hash=self._audit.chain_tip,
             )
+
+        # #479 piece 2: this call's own class, catalog floor raised by any
+        # declared_data_class. _max_sensitivity can only return the higher of
+        # the two labels, ties favour the catalog value, so an unrecognised or
+        # lower declared value is harmless without any separate validation.
+        effective_data_class: str | None = (
+            _max_sensitivity(
+                entry.sensitivity_level, declared_data_class, self._session.sensitivity_order
+            )
+            if declared_data_class is not None
+            else None
+        )
 
         # Step 1b: break-glass warning - log and audit every call via an exception entry
         if entry.catalog_exception:
@@ -852,7 +872,11 @@ class CMCPProxy:
             async with self._session.mutation_lock:
                 self._session.update_from_inspection(
                     call_id=call_id,
-                    sensitivity_tags=[entry.sensitivity_level],
+                    sensitivity_tags=(
+                        [entry.sensitivity_level, declared_data_class]
+                        if declared_data_class is not None
+                        else [entry.sensitivity_level]
+                    ),
                     injection_detected=injection_detected,
                     response_allowed=False,
                 )
@@ -871,6 +895,7 @@ class CMCPProxy:
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
                 workflow_id=workflow_id,
+                effective_data_class=effective_data_class,
             )
             elapsed_ms = (time.perf_counter() - t0) * 1000
             self._record_call(
@@ -899,8 +924,13 @@ class CMCPProxy:
 
         # Step 4: session update from response sensitivity
         # AUTH-002: lock protects against race with concurrent session reset requests.
-        # Sensitivity comes from the attested catalog entry's declared level.
-        response_sensitivity = [entry.sensitivity_level]
+        # Sensitivity comes from the attested catalog entry's declared level, raised
+        # by declared_data_class if the caller declared one (#479 piece 2).
+        response_sensitivity = (
+            [entry.sensitivity_level, declared_data_class]
+            if declared_data_class is not None
+            else [entry.sensitivity_level]
+        )
         injection_scanner = "agt_response_scanner" if injection_detected else None
         injection_pattern = (
             ",".join(sorted({str(t.get("category", "unknown")) for t in scan.threats}))
@@ -1015,6 +1045,7 @@ class CMCPProxy:
             workflow_id=workflow_id,
             detail=injection_detail,
             external_execution_evidence=external_execution_evidence,
+            effective_data_class=effective_data_class,
         )
 
         # Step 6: call log record + suspicious-sequence check

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -299,9 +299,20 @@ class MCPServer:
             cmcp_params = {}
         raw_workflow = cmcp_params.get("workflow_id")
         workflow_id: str | None = raw_workflow if isinstance(raw_workflow, str) else None
+        # #479 piece 2: the caller may declare a class for this specific call.
+        raw_data_class = cmcp_params.get("data_class")
+        declared_data_class: str | None = (
+            raw_data_class if isinstance(raw_data_class, str) else None
+        )
 
         try:
-            result = await self._proxy.call_tool(call_id, tool_name, arguments, workflow_id=workflow_id)
+            result = await self._proxy.call_tool(
+                call_id,
+                tool_name,
+                arguments,
+                workflow_id=workflow_id,
+                declared_data_class=declared_data_class,
+            )
         except Exception as exc:
             logger.error("TEE_FAULT during call_tool: call_id=%s error=%s", call_id, exc)
             return JSONResponse(

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -282,7 +282,9 @@ class SessionManager:
             if e.tool_name is None:
                 continue
             catalog_entry = catalog.entries.get(e.tool_name)
-            data_class = (
+            # #479 piece 2: prefer this call's own class, catalog floor already
+            # raised by any _cmcp.data_class declaration, over the catalog default.
+            data_class = e.effective_data_class or (
                 catalog_entry.sensitivity_level if catalog_entry is not None else "unknown"
             )
             transcript_entries.append(

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -157,6 +157,62 @@ async def test_proxy_updates_session_state_on_allow():
 
 
 @pytest.mark.asyncio
+async def test_declared_data_class_raises_session_above_catalog_floor():
+    """#479 piece 2: a declared_data_class above the catalog floor raises
+    session.max_sensitivity past what the catalog alone would give."""
+    entry = _make_entry()
+    entry.sensitivity_level = "pii"
+    catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
+    proxy, session, _ = _make_proxy(catalog=catalog)
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="confidential")
+    assert session.max_sensitivity == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_declared_data_class_below_floor_does_not_lower_session():
+    """A declared_data_class ranked below the catalog floor must not lower the
+    effective class - only ever raise, never lower."""
+    entry = _make_entry()
+    entry.sensitivity_level = "confidential"
+    catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
+    proxy, session, _ = _make_proxy(catalog=catalog)
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="pii")
+    assert session.max_sensitivity == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_declared_data_class_is_harmless():
+    """An unrecognised declared_data_class ranks 0 and cannot beat a real
+    catalog floor - no separate validation needed."""
+    entry = _make_entry()
+    entry.sensitivity_level = "pii"
+    catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
+    proxy, session, _ = _make_proxy(catalog=catalog)
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="not_a_real_label")
+    assert session.max_sensitivity == "pii"
+
+
+@pytest.mark.asyncio
+async def test_audit_entry_carries_effective_data_class_when_declared():
+    proxy, _, chain = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="confidential")
+    tool_call_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert tool_call_entries[-1].effective_data_class == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_audit_entry_effective_data_class_none_when_not_declared():
+    """No behaviour change for callers that never use _cmcp.data_class."""
+    proxy, _, chain = _make_proxy()
+    await proxy.call_tool("c1", "test.tool", {})
+    tool_call_entries = [e for e in chain.entries if e.entry_type == "tool_call"]
+    assert tool_call_entries[-1].effective_data_class is None
+
+
+@pytest.mark.asyncio
 async def test_proxy_advisory_deny_returns_allowed_with_flag():
     evaluator = _make_evaluator(allow=True, would_deny=True)
     proxy, _, _ = _make_proxy(evaluator=evaluator, mode=EnforcementMode.ADVISORY)

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -387,3 +387,42 @@ def test_close_session_fails_closed_on_hardware_platform_when_tee_fails() -> Non
 
     with pytest.raises(TeeFault, match="chain-root commitment"):
         mgr.close_session(state.session_id, state, chain)
+
+
+# ── #479 piece 2: per call data class in the transcript ────────────────────────
+
+
+def _fake_catalog_entry(sensitivity_level: str) -> MagicMock:
+    entry = MagicMock()
+    entry.sensitivity_level = sensitivity_level
+    entry.compliance_domain = "external"
+    return entry
+
+
+def test_transcript_prefers_effective_data_class_over_catalog() -> None:
+    ctx = _make_ctx()
+    ctx.catalog.entries = {"t": _fake_catalog_entry("pii")}
+    mgr = SessionManager(ctx)
+    state, chain = mgr.create_session()
+    chain.append(
+        "tool_call",
+        call_id="c1",
+        tool_name="t",
+        policy_decision="allow",
+        effective_data_class="confidential",
+    )
+    claim = mgr.close_session(state.session_id, state, chain)
+    entries = claim["trace"]["tool_transcript"]["entries"]
+    assert entries[0]["data_class"] == "confidential"
+
+
+def test_transcript_falls_back_to_catalog_when_no_effective_data_class() -> None:
+    """No behaviour change for calls that never declared a class (#479 piece 2)."""
+    ctx = _make_ctx()
+    ctx.catalog.entries = {"t": _fake_catalog_entry("pii")}
+    mgr = SessionManager(ctx)
+    state, chain = mgr.create_session()
+    chain.append("tool_call", call_id="c1", tool_name="t", policy_decision="allow")
+    claim = mgr.close_session(state.session_id, state, chain)
+    entries = claim["trace"]["tool_transcript"]["entries"]
+    assert entries[0]["data_class"] == "pii"

--- a/tests/unit/test_workflow_scope.py
+++ b/tests/unit/test_workflow_scope.py
@@ -154,9 +154,15 @@ async def test_server_extracts_workflow_id_from_cmcp_params():
     original = proxy.call_tool
     captured: dict = {}
 
-    async def _spy(call_id, tool_name, arguments, *, workflow_id=None):
+    async def _spy(call_id, tool_name, arguments, *, workflow_id=None, declared_data_class=None):
         captured["workflow_id"] = workflow_id
-        return await original(call_id, tool_name, arguments, workflow_id=workflow_id)
+        return await original(
+            call_id,
+            tool_name,
+            arguments,
+            workflow_id=workflow_id,
+            declared_data_class=declared_data_class,
+        )
 
     proxy.call_tool = _spy
 
@@ -175,6 +181,88 @@ async def test_server_extracts_workflow_id_from_cmcp_params():
     })
     assert resp.status_code == 200
     assert captured.get("workflow_id") == "workflow_x"
+
+
+@pytest.mark.asyncio
+async def test_server_extracts_data_class_from_cmcp_params():
+    """#479 piece 2: MCPServer passes data_class from request _cmcp field to
+    call_tool as declared_data_class."""
+    from starlette.testclient import TestClient
+
+    from cmcp_runtime.mcp.server import MCPServer
+
+    proxy, _, chain = _make_proxy()
+    original = proxy.call_tool
+    captured: dict = {}
+
+    async def _spy(call_id, tool_name, arguments, *, workflow_id=None, declared_data_class=None):
+        captured["declared_data_class"] = declared_data_class
+        return await original(
+            call_id,
+            tool_name,
+            arguments,
+            workflow_id=workflow_id,
+            declared_data_class=declared_data_class,
+        )
+
+    proxy.call_tool = _spy
+
+    server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=True)
+
+    resp = client.post("/mcp", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "test.tool",
+            "arguments": {},
+            "_cmcp": {"data_class": "confidential"},
+        },
+    })
+    assert resp.status_code == 200
+    assert captured.get("declared_data_class") == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_server_malformed_data_class_does_not_fail_call():
+    """A non string _cmcp.data_class must not 500 the call path, same treatment
+    as a malformed workflow_id."""
+    from starlette.testclient import TestClient
+
+    from cmcp_runtime.mcp.server import MCPServer
+
+    proxy, _, chain = _make_proxy()
+    original = proxy.call_tool
+    captured: dict = {}
+
+    async def _spy(call_id, tool_name, arguments, *, workflow_id=None, declared_data_class=None):
+        captured["declared_data_class"] = declared_data_class
+        return await original(
+            call_id,
+            tool_name,
+            arguments,
+            workflow_id=workflow_id,
+            declared_data_class=declared_data_class,
+        )
+
+    proxy.call_tool = _spy
+
+    server = MCPServer(proxy)
+    client = TestClient(server.app, raise_server_exceptions=True)
+
+    resp = client.post("/mcp", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "test.tool",
+            "arguments": {},
+            "_cmcp": {"data_class": 12345},
+        },
+    })
+    assert resp.status_code == 200
+    assert captured.get("declared_data_class") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #479, the second piece, per call classification. Part one, configurable vocabulary, merged in #489.

One catalogued tool can serve many classes of data, a model call tool catalogued at pii might, on a specific call, actually carry confidential data, agentrust-io/demos#36 is the motivating example. The signed transcript could only ever show the tool's single catalogued value, and the session's own sensitivity tracking never rose past what the catalog alone said either, which is an enforcement gap for later calls in the session, not only a record keeping one.

A call may now declare a class for itself via _cmcp.data_class on the request, following the exact pattern _cmcp.workflow_id already uses.

## Why no extra validation was needed

_max_sensitivity, already in session/state.py from part one, turns out to already be the validator. It returns whichever of two labels ranks higher and ties favour the catalog value, so an unrecognised or lower declared value is harmless by construction and a legitimately higher one raises the effective class, no separate check needed anywhere. Full reasoning is in the code comments at the computation site in proxy.py.

## The two effects are computed separately on purpose

The declared value raises both the session's max_sensitivity (composing multiple tags the same way update_from_inspection already did, no change needed there) and, independently, that specific call's own row in the signed transcript. The transcript value is deliberately not read back from session state, since max_sensitivity is monotonic across the whole session, so by the time call 2 runs it may already reflect call 1's history, and call 2's transcript row needs to describe call 2's own class, not the session's accumulated one. Verified manually end to end, see test plan below.

## Changes

- src/cmcp_runtime/audit/chain.py: new AuditEntry.effective_data_class field, threaded through AuditChain.append.
- src/cmcp_runtime/mcp/proxy.py: call_tool takes declared_data_class, computed once per call and used at both response classification sites.
- src/cmcp_runtime/mcp/server.py: parses _cmcp.data_class the same way _cmcp.workflow_id already is parsed.
- src/cmcp_runtime/session/manager.py: close_session's transcript loop prefers effective_data_class over the catalog default when present.
- docs/tutorials/connecting-agent-frameworks.md, docs/spec/session-policy.md, CHANGELOG.md.

## Test plan

- [x] pytest tests/unit/ passes locally, 1034 passed, 8 skipped
- [x] ruff check src/ tests/ clean
- [x] mypy src/cmcp_runtime/ src/cmcp_verify/ clean
- [x] bandit -r src/ clean
- [x] manual end to end check: a call declaring top_secret (composing with a custom vocabulary from part one) raises the session and shows top_secret in its own transcript row; a second call on the same tool with no declaration in the same session correctly shows the tool's own catalogued public in its own row, unaffected by the session's accumulated maximum
- [x] found and closed a real pre-existing gap while writing this: close_session's transcript building loop had no test coverage at all before this change, now has both the new-field case and the existing-fallback case