### PR TITLE
fix: reject malformed JSON-RPC shapes at ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The MCP ingress now rejects non-object JSON-RPC messages, non-string methods, and non-object `tools/call` parameters with a bounded `MCP_INVALID_REQUEST` response. Structurally invalid attacker input no longer reaches attribute errors, HTTP 500 responses, or exception trace logging.
+
 ### Changed
 
 - **`STATUS.md` understated the attestation default in two ways.** It gave the probe order as `tpm -> sev-snp -> tdx`, missing `azure-cvm`, which is probed *first* and exists precisely so an Azure confidential VM is not mistaken for a plain TPM host. And it said nothing about what happens when no hardware is found, which is the question an evaluator is actually asking.

--- a/docs/spec/error-codes.md
+++ b/docs/spec/error-codes.md
@@ -20,6 +20,7 @@ This is the normative registry for all error codes used across the cMCP Runtime.
 | `CATALOG_TOOL_NAME_COLLISION` | 500 | FATAL | Two catalog entries register the same `tool_name` | [tool-identity.md](tool-identity.md) |
 | `CATALOG_DRIFT_DETECTED` | 409 | ERROR | Upstream server changed a tool definition since catalog was sealed | [attestation.md §5](attestation.md) |
 | `MCP_PARSE_FAILURE` | 400 | WARN | Incoming MCP JSON-RPC message failed to parse | [failure-modes.md FM-5](failure-modes.md) |
+| `MCP_INVALID_REQUEST` | 400 | WARN | Parsed JSON is not a valid JSON-RPC request shape | [failure-modes.md FM-5](failure-modes.md) |
 | `RESPONSE_SIZE_EXCEEDED` | 413 | WARN | Tool response exceeds `max_response_size_bytes` | [response-inspection.md Stage 1](response-inspection.md) |
 | `RESPONSE_INJECTION_DETECTED` | 403 | ERROR | Response inspection detected indirect injection pattern | [response-inspection.md Stage 4](response-inspection.md) |
 | `RESPONSE_SCHEMA_VIOLATION_STRICT` | 409 | WARN | Tool response contains fields outside approved `output_schema` (strict mode) | [response-inspection.md Stage 2](response-inspection.md) |

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -42,6 +42,22 @@ logger = logging.getLogger(__name__)
 _AUTH_EXEMPT_PATHS = {"/health", "/readyz"}
 
 
+def _invalid_request(rpc_id: Any = None) -> JSONResponse:
+    """Return a bounded JSON-RPC Invalid Request response."""
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request",
+                "data": {"error_code": "MCP_INVALID_REQUEST"},
+            },
+            "id": rpc_id,
+        },
+        status_code=400,
+    )
+
+
 async def _unhandled_error_handler(request: Request, exc: Exception) -> Response:
     """NET-004: return generic 500 without leaking exception class or message."""
     logger.error(
@@ -254,11 +270,18 @@ class MCPServer:
                 status_code=400,
             )
 
+        if not isinstance(msg, dict):
+            return _invalid_request()
+
         rpc_id = msg.get("id")
         method = msg.get("method", "")
+        if not isinstance(method, str):
+            return _invalid_request(rpc_id)
         params = msg.get("params", {})
 
         if method == "tools/call":
+            if not isinstance(params, dict):
+                return _invalid_request(rpc_id)
             return await self._handle_tool_call(rpc_id, params)
         if method == "tools/list":
             return await self._handle_tools_list(rpc_id)

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from cmcp_runtime.mcp.server import MCPServer
@@ -123,6 +124,34 @@ def test_content_length_check_rejects_before_body_read():
         headers={"Content-Type": "application/json", "Content-Length": "9999"},
     )
     assert resp.status_code == 413
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        "valid JSON but not an object",
+        1,
+        {"jsonrpc": "2.0", "method": [], "id": 1},
+        {"jsonrpc": "2.0", "method": "tools/call", "params": [], "id": 1},
+    ],
+)
+def test_structurally_invalid_json_rpc_returns_bounded_400(payload):
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+
+    response = client.post("/mcp", json=payload)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "error": {
+            "code": -32600,
+            "message": "Invalid Request",
+            "data": {"error_code": "MCP_INVALID_REQUEST"},
+        },
+        "id": payload.get("id") if isinstance(payload, dict) else None,
+    }
 
 
 # ── NET-002: /health rate limit ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Validate parsed JSON-RPC structure before accessing fields or dispatching `tools/call`. Non-object messages, non-string methods, and non-object `tools/call.params` now receive a bounded JSON-RPC `-32600 Invalid Request` response with `MCP_INVALID_REQUEST`.

## Root cause

The ingress bounded request bytes and handled malformed JSON syntax, but assumed every successfully parsed value was an object with object-shaped tool parameters. Valid JSON arrays, scalars, or list parameters raised `AttributeError`, producing HTTP 500 responses and server-side exception traces from attacker-controlled requests.

## Validation

- Added five malformed-structure regression cases
- Focused server tests: 28 passed
- Full clean-environment unit suite: 1055 passed, 8 skipped
- Ruff: clean
- mypy: clean
- `git diff --check`: clean

## Documentation

- Added `MCP_INVALID_REQUEST` to the error-code specification
- Added an Unreleased security changelog entry