### PR TITLE
fix: bind upstream caches to immutable server identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The MCP ingress now rejects non-object JSON-RPC messages, non-string methods, and non-object `tools/call` parameters with a bounded `MCP_INVALID_REQUEST` response. Structurally invalid attacker input no longer reaches attribute errors, HTTP 500 responses, or exception trace logging.
 - The unauthenticated health/readiness rate limiter now expires inactive source-address entries and caps tracked clients at 10,000. Source-address churn can no longer grow the in-memory limiter map for the lifetime of the gateway.
+- Upstream stdio children and provenance verdicts are now cached by complete execution and trust identity rather than the non-unique human-readable `display_name`. Distinct catalog servers sharing a label can no longer reuse another server's process or provenance result.
 
 ### Changed
 

--- a/docs/spec/stdio-transport.md
+++ b/docs/spec/stdio-transport.md
@@ -7,6 +7,13 @@ Supersedes: the stdio section of [transport.md](transport.md), if accepted
 Stability: Unstable, no code written
 ---
 
+## Cache identity
+
+Spawned children are pooled per session by executable, arguments, measurement
+target, and pinned digest—not by the server's human-readable display name.
+Display names need not be unique and are not security identities. Provenance
+verdicts additionally bind the configured record and publisher key.
+
 ## Why revisit a settled decision
 
 [`transport.md`](transport.md) records that stdio is out of scope, and its reasoning is

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -65,6 +65,43 @@ class CallResult:
     advice: dict[str, str] | None = None
 
 
+def _server_execution_key(entry: CatalogEntry) -> tuple[str, ...]:
+    """Return the security-relevant identity used to pool one upstream."""
+    server = entry.server
+    if server.is_stdio:
+        spawn = server.spawn
+        return (
+            "stdio",
+            spawn.command if spawn else "",
+            *(spawn.args if spawn else ()),
+            "measure_target=" + (spawn.measure_target if spawn and spawn.measure_target else ""),
+            "binary_digest=" + (spawn.binary_digest if spawn and spawn.binary_digest else ""),
+        )
+    return (
+        "network",
+        server.transport,
+        server.url,
+        server.tls_fingerprint,
+        server.spiffe_id or "",
+        server.rotation_mode,
+    )
+
+
+def _server_provenance_key(entry: CatalogEntry) -> tuple[str, ...]:
+    """Bind a cached provenance verdict to endpoint and configured authority."""
+    server = entry.server
+    publisher_key = (
+        json.dumps(server.publisher_jwk, sort_keys=True, separators=(",", ":"))
+        if server.publisher_jwk is not None
+        else ""
+    )
+    return (
+        *_server_execution_key(entry),
+        "record=" + (server.provenance_record_path or ""),
+        "publisher_jwk=" + publisher_key,
+    )
+
+
 def _cedar_safe(value: Any) -> Any:
     """
     Coerce a JSON value into types Cedar can ingest.
@@ -178,12 +215,12 @@ class CMCPProxy:
         # session and never pooled across sessions: a server that holds anything
         # in memory would carry it from one agent's session into the next, and
         # the audit chain cannot see that happen (docs/spec/stdio-transport.md).
-        self._stdio_servers: dict[str, StdioServer] = {}
+        self._stdio_servers: dict[tuple[str, ...], StdioServer] = {}
         # Provenance outcome per server, decided once per session on first use.
         # Cached because the answer cannot change within a session without the
         # server being replaced underneath us, and re-listing tools on every call
         # would make the check expensive enough to be turned off.
-        self._provenance: dict[str, ProvenanceResult] = {}
+        self._provenance: dict[tuple[str, ...], ProvenanceResult] = {}
         # Servers already warned about unenforceable pinning (warn once each).
         self._tls_pin_warned: set[str] = set()
 
@@ -266,7 +303,7 @@ class CMCPProxy:
 
     async def _stdio_for(self, entry: CatalogEntry) -> StdioServer:
         """The child for this server, spawned on first use in this session."""
-        key = entry.server.display_name
+        key = _server_execution_key(entry)
         server = self._stdio_servers.get(key)
         if server is None:
             if entry.server.spawn is None:
@@ -314,7 +351,7 @@ class CMCPProxy:
         return tools if isinstance(tools, list) else None
 
     async def _check_provenance(self, entry: CatalogEntry) -> ProvenanceResult:
-        key = entry.server.display_name
+        key = _server_provenance_key(entry)
         result = self._provenance.get(key)
         if result is None:
             advertised = (
@@ -969,7 +1006,7 @@ class CMCPProxy:
         # identifies code.
         from cmcp_runtime.mcp import tls_pinning as _tls_mod
         if entry is not None and entry.server.is_stdio:
-            spawned = self._stdio_servers.get(entry.server.display_name)
+            spawned = self._stdio_servers.get(_server_execution_key(entry))
             # A stdio response with no spawned server on record is not something
             # to guess about; hash-only is the honest floor.
             evidence_class = (

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -16,6 +16,7 @@ from cmcp_runtime.catalog.loader import (
 )
 from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
 from cmcp_runtime.errors import PolicyDeny
+from cmcp_runtime.mcp.proxy import _server_execution_key, _server_provenance_key
 from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
 from cmcp_runtime.session.state import SessionState
 from tests.unit.conftest import wire_mock_gateway
@@ -49,6 +50,32 @@ def _make_entry(tool_name: str = "test.tool") -> CatalogEntry:
 def _make_catalog(*tools: str) -> ToolCatalog:
     entries = {t: _make_entry(t) for t in (tools or ("test.tool",))}
     return ToolCatalog(entries=entries, catalog_hash="sha256:" + "1" * 64)
+
+
+def test_server_cache_keys_bind_actual_identity_not_display_label():
+    first = _make_entry("first.tool")
+    second = _make_entry("second.tool")
+    second.server.display_name = first.server.display_name
+    second.server.url = "https://different.example.com/mcp"
+
+    assert _server_execution_key(first) != _server_execution_key(second)
+    assert _server_provenance_key(first) != _server_provenance_key(second)
+
+
+def test_same_server_identity_is_reused_across_tools():
+    first = _make_entry("first.tool")
+    second = _make_entry("second.tool")
+
+    assert _server_execution_key(first) == _server_execution_key(second)
+
+
+def test_provenance_cache_key_binds_publisher_authority():
+    first = _make_entry("first.tool")
+    second = _make_entry("second.tool")
+    first.server.publisher_jwk = {"kty": "OKP", "x": "first"}
+    second.server.publisher_jwk = {"kty": "OKP", "x": "second"}
+
+    assert _server_provenance_key(first) != _server_provenance_key(second)
 
 
 def _make_evaluator(allow: bool = True, would_deny: bool = False) -> PolicyEvaluator:


### PR DESCRIPTION
## Summary

Key per-session stdio child pooling by executable, arguments, measurement target, and pinned digest. Key cached provenance verdicts by that execution/network identity plus the configured provenance record and publisher key.

## Root cause

Both caches previously used `server.display_name`, a human-readable catalog label that is not required to be unique. Distinct approved servers sharing a label could therefore reuse the first server's spawned process or provenance verdict.

## Validation

- Added regression coverage showing equal labels with different endpoints do not collide
- Verified the same server identity is still shared across multiple tools
- Verified different publisher authorities cannot share provenance cache entries
- Focused proxy/provenance tests: 50 passed
- Full clean-environment suite: 1053 passed, 8 skipped
- Ruff, mypy, and Bandit: clean
- `git diff --check`: clean

## Documentation

- Documented stdio and provenance cache identity requirements
- Added an Unreleased security changelog entry