### PR TITLE
fix: package and require the catalog validation schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The MCP ingress now rejects non-object JSON-RPC messages, non-string methods, and non-object `tools/call` parameters with a bounded `MCP_INVALID_REQUEST` response. Structurally invalid attacker input no longer reaches attribute errors, HTTP 500 responses, or exception trace logging.
 - The unauthenticated health/readiness rate limiter now expires inactive source-address entries and caps tracked clients at 10,000. Source-address churn can no longer grow the in-memory limiter map for the lifetime of the gateway.
 - Upstream stdio children and provenance verdicts are now cached by complete execution and trust identity rather than the non-unique human-readable `display_name`. Distinct catalog servers sharing a label can no longer reuse another server's process or provenance result.
+- Built wheels now include the catalog-entry JSON Schema, and catalog loading fails closed if that schema is absent or unreadable. Previously source-tree tests validated catalog structure, but installed wheels omitted the schema and silently skipped that validation.
 
 ### Changed
 

--- a/docs/tutorials/tool-catalog-authoring.md
+++ b/docs/tutorials/tool-catalog-authoring.md
@@ -2,6 +2,10 @@
 
 The tool catalog is the operator-controlled allowlist of MCP tools the gateway will route. Every entry is hashed into the TRACE claim at startup; adding, removing, or changing any field changes `catalog_hash` and invalidates prior attestations.
 
+The catalog-entry JSON Schema ships inside the Python distribution and is a
+mandatory startup dependency. CMCP refuses to load a catalog if the schema is
+missing or unreadable; it never degrades to partial hand-written validation.
+
 ## What you'll learn
 
 - The full structure of `catalog.json` and what each field controls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ Documentation = "https://github.com/agentrust-io/cmcp/tree/main/docs"
 [tool.hatch.build.targets.wheel]
 packages = ["src/cmcp_runtime", "src/cmcp_verify"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"schemas/catalog-entry.schema.json" = "cmcp_runtime/schemas/catalog-entry.schema.json"
+
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -20,7 +20,17 @@ from cmcp_runtime.errors import (
 from cmcp_runtime.mcp.stdio import StdioSpawn
 from cmcp_runtime.session.state import SENSITIVITY_ORDER
 
-_CATALOG_ENTRY_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "schemas" / "catalog-entry.schema.json"
+_PACKAGED_ENTRY_SCHEMA_PATH = (
+    Path(__file__).parent.parent / "schemas" / "catalog-entry.schema.json"
+)
+_SOURCE_ENTRY_SCHEMA_PATH = (
+    Path(__file__).parent.parent.parent.parent / "schemas" / "catalog-entry.schema.json"
+)
+_CATALOG_ENTRY_SCHEMA_PATH = (
+    _PACKAGED_ENTRY_SCHEMA_PATH
+    if _PACKAGED_ENTRY_SCHEMA_PATH.exists()
+    else _SOURCE_ENTRY_SCHEMA_PATH
+)
 
 
 @dataclass
@@ -131,15 +141,19 @@ def _catalog_hash(raw_entries: list[dict[str, Any]]) -> str:
     return f"sha256:{_sha256_hex(canonical.encode())}"
 
 
-def _load_entry_schema() -> dict[str, Any] | None:
-    if _CATALOG_ENTRY_SCHEMA_PATH.exists():
+def _load_entry_schema() -> dict[str, Any]:
+    if not _CATALOG_ENTRY_SCHEMA_PATH.is_file():
+        raise ConfigError(
+            "Catalog entry schema is missing from the CMCP installation; "
+            "refusing to load a catalog without structural validation"
+        )
+    try:
         return dict(json.loads(_CATALOG_ENTRY_SCHEMA_PATH.read_text()))
-    return None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"Cannot load catalog entry schema: {exc}") from exc
 
 
-def _validate_entry(raw: dict[str, Any], schema: dict[str, Any] | None) -> None:
-    if schema is None:
-        return
+def _validate_entry(raw: dict[str, Any], schema: dict[str, Any]) -> None:
     try:
         jsonschema.validate(raw, schema)
     except jsonschema.ValidationError as exc:

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import cmcp_runtime.catalog.loader as catalog_loader
 from cmcp_runtime.catalog.loader import ToolCatalog, load_catalog
 from cmcp_runtime.errors import (
     CatalogHashMismatch,
@@ -63,6 +64,14 @@ def catalog_file(tmp_path: Path):
         p.write_text(json.dumps(entries))
         return str(p)
     return _write
+
+
+def test_missing_catalog_schema_fails_closed(catalog_file, tmp_path, monkeypatch):
+    missing_schema = tmp_path / "missing-catalog-entry.schema.json"
+    monkeypatch.setattr(catalog_loader, "_CATALOG_ENTRY_SCHEMA_PATH", missing_schema)
+
+    with pytest.raises(ConfigError, match="schema is missing"):
+        load_catalog(catalog_file([ENTRY_1]))
 
 
 def test_load_valid_catalog(catalog_file):


### PR DESCRIPTION
## Summary

Include `catalog-entry.schema.json` in built wheels and resolve it from package data in installed environments. Catalog loading now fails closed when the schema is missing, unreadable, or malformed instead of silently skipping structural validation.

## Root cause

Source-tree execution found the repository-level `schemas/` directory, but the wheel target packaged only `src/cmcp_runtime` and `src/cmcp_verify`. `_load_entry_schema()` returned `None` when the external file was absent, and `_validate_entry()` treated that as permission to skip JSON Schema validation. Real wheel installs therefore had weaker catalog validation than tests and editable installs.

## Validation

- Built the wheel and confirmed `cmcp_runtime/schemas/catalog-entry.schema.json` is present
- Installed the exact wheel into a clean virtual environment outside the checkout
- Confirmed an entry with an unknown field is rejected by the installed package
- Added fail-closed missing-schema regression coverage
- Focused catalog tests: 21 passed
- Full clean-environment suite: 1051 passed, 8 skipped
- Ruff, mypy, and Bandit: clean
- `git diff --check`: clean

## Documentation

- Documented the mandatory packaged schema in the catalog-authoring tutorial
- Added an Unreleased security changelog entry