### PR TITLE
ci: install and verify exact Python release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,37 @@ jobs:
           python-version: "3.12"
 
       - name: Install build
-        run: python -m pip install build
+        run: python -m pip install build twine
 
       - name: Build distributions
         run: python -m build
+
+      - name: Verify distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Install and smoke-test wheel and sdist
+        shell: bash
+        run: |
+          expected_version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          if [[ "${{ github.event_name }}" == "release" ]] && [[ "${{ github.event.release.tag_name }}" != "v$expected_version" ]]; then
+            echo "release tag ${{ github.event.release.tag_name }} does not match package version $expected_version" >&2
+            exit 1
+          fi
+          index=0
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            index=$((index + 1))
+            venv="$RUNNER_TEMP/cmcp-dist-$index"
+            python -m venv "$venv"
+            "$venv/bin/python" -m pip install --disable-pip-version-check "$artifact"
+            (
+              cd "$RUNNER_TEMP"
+              "$venv/bin/python" "$GITHUB_WORKSPACE/scripts/verify_python_distribution.py" \
+                --expected-version "$expected_version" \
+                --forbidden-source-root "$GITHUB_WORKSPACE/src"
+              "$venv/bin/cmcp" --help >/dev/null
+            )
+          done
+          test "$index" -eq 2
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The unauthenticated health/readiness rate limiter now expires inactive source-address entries and caps tracked clients at 10,000. Source-address churn can no longer grow the in-memory limiter map for the lifetime of the gateway.
 - Upstream stdio children and provenance verdicts are now cached by complete execution and trust identity rather than the non-unique human-readable `display_name`. Distinct catalog servers sharing a label can no longer reuse another server's process or provenance result.
 - Built wheels now include the catalog-entry JSON Schema, and catalog loading fails closed if that schema is absent or unreadable. Previously source-tree tests validated catalog structure, but installed wheels omitted the schema and silently skipped that validation.
+- PyPI publication now installs and smoke-tests the exact wheel and source distribution before upload, including release-tag/version agreement, import provenance, runtime configuration, and the packaged CLI.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,13 @@ pytest tests/unit/ -v          # unit tests
 
 All four must pass before a PR is mergeable.
 
+### Release artifact verification
+
+The PyPI workflow installs the exact wheel and source distribution into separate
+clean environments before upload. It checks release-tag/version agreement,
+metadata and runtime versions, import provenance outside the checkout, core
+configuration construction, and the installed `cmcp` console entry point.
+
 ## Commit format
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/scripts/verify_python_distribution.py
+++ b/scripts/verify_python_distribution.py
@@ -1,0 +1,50 @@
+"""Smoke-test an installed CMCP distribution outside the checkout."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+import cmcp_runtime
+import cmcp_verify
+from cmcp_runtime.config import Config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--forbidden-source-root", required=True, type=Path)
+    args = parser.parse_args()
+
+    installed_version = version("cmcp-runtime")
+    if installed_version != args.expected_version:
+        raise SystemExit(
+            f"installed version {installed_version!r} != expected {args.expected_version!r}"
+        )
+    if cmcp_runtime.__version__ != installed_version:
+        raise SystemExit(
+            f"runtime version {cmcp_runtime.__version__!r} != metadata {installed_version!r}"
+        )
+
+    forbidden_root = args.forbidden_source_root.resolve()
+    for module in (cmcp_runtime, cmcp_verify):
+        module_path = Path(module.__file__).resolve()
+        if module_path.is_relative_to(forbidden_root):
+            raise SystemExit(
+                f"smoke test imported checkout source {module_path}, not the distribution"
+            )
+
+    config = Config()
+    if config.max_response_size_bytes <= 0:
+        raise SystemExit("installed Config produced an invalid response-size bound")
+
+    sys.stdout.write(
+        f"verified cmcp-runtime {installed_version} from "
+        f"{Path(cmcp_runtime.__file__).resolve()}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_release_distribution_smoke.py
+++ b/tests/unit/test_release_distribution_smoke.py
@@ -1,0 +1,26 @@
+"""Tests for the standalone installed-distribution release smoke check."""
+
+import subprocess
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+
+def test_distribution_smoke_script_exercises_installed_public_api(tmp_path: Path) -> None:
+    script = Path(__file__).parents[2] / "scripts" / "verify_python_distribution.py"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--expected-version",
+            version("cmcp-runtime"),
+            "--forbidden-source-root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "verified cmcp-runtime" in completed.stdout


### PR DESCRIPTION
## Summary

Gate PyPI publication on installing and exercising both exact artifacts to be uploaded: the wheel and source distribution. Each is installed in a separate clean environment and tested outside the checkout. Release tags must match package metadata.

The smoke test checks distribution/runtime version agreement, import provenance for both `cmcp_runtime` and `cmcp_verify`, core configuration construction, and the installed `cmcp` console entry point. Twine metadata validation is also part of the build job.

## Root cause

The previous workflow built archives and immediately uploaded them. Source-tree CI could not detect packaging omissions, stale build contents, broken console scripts, install-time dependency failures, or a release tag that disagreed with package metadata.

## Validation

- Built the 0.4.0 wheel and sdist
- Validated both with current Twine 7
- Installed each artifact into a separate clean environment
- Ran provenance/version/configuration smoke checks outside the checkout
- Invoked the installed CLI for both artifacts
- Added a focused smoke-script regression test
- Full clean-environment suite: 1051 passed, 8 skipped
- Ruff and mypy: clean
- `git diff --check`: clean

## Documentation

- Documented the artifact gate in CONTRIBUTING
- Added an Unreleased security changelog entry