### PR TITLE
fix: harden the CMCP runtime container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.pytest_cache
+.mypy_cache
+.ruff_cache
+__pycache__
+*.pyc
+*.db
+*.log
+dist
+build
+tests
+docs
+examples
+experiments
+benchmarks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ghcr.io/agentrust-io/cmcp-gateway:${{ github.sha }}
+          tags: |
+            ghcr.io/agentrust-io/cmcp-gateway:${{ steps.tag.outputs.tag || github.sha }}
+            ghcr.io/agentrust-io/cmcp-gateway:latest
 
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "src/**"
+      - "schemas/**"
+      - ".github/workflows/docker.yml"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -22,6 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -29,6 +38,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract tag name
+        if: startsWith(github.ref, 'refs/tags/')
         id: tag
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
@@ -37,20 +47,21 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
-          tags: |
-            ghcr.io/agentrust-io/cmcp-gateway:${{ steps.tag.outputs.tag }}
-            ghcr.io/agentrust-io/cmcp-gateway:latest
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: ghcr.io/agentrust-io/cmcp-gateway:${{ github.sha }}
 
       - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v3
 
       - name: Sign the image (keyless, by digest)
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes ghcr.io/agentrust-io/cmcp-gateway@${DIGEST}
 
       - name: Attest build provenance (SLSA)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/agentrust-io/cmcp-gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upstream stdio children and provenance verdicts are now cached by complete execution and trust identity rather than the non-unique human-readable `display_name`. Distinct catalog servers sharing a label can no longer reuse another server's process or provenance result.
 - Built wheels now include the catalog-entry JSON Schema, and catalog loading fails closed if that schema is absent or unreadable. Previously source-tree tests validated catalog structure, but installed wheels omitted the schema and silently skipped that validation.
 - PyPI publication now installs and smoke-tests the exact wheel and source distribution before upload, including release-tag/version agreement, import provenance, runtime configuration, and the packaged CLI.
+- The runtime container now uses a patch-pinned Python slim base, builds a non-editable production wheelhouse in a separate stage, excludes development dependencies and build tooling from the final image, and runs as an unprivileged numeric UID/GID.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,13 @@ clean environments before upload. It checks release-tag/version agreement,
 metadata and runtime versions, import provenance outside the checkout, core
 configuration construction, and the installed `cmcp` console entry point.
 
+### Release container build
+
+The release container uses a multi-stage build: the builder creates a wheelhouse
+from production dependencies only, while the runtime installs it offline and
+runs as numeric UID/GID 10001. Do not add editable installs, the `dev` extra, or
+root execution to the runtime stage.
+
 ## Commit format
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ The release container uses a multi-stage build: the builder creates a wheelhouse
 from production dependencies only, while the runtime installs it offline and
 runs as numeric UID/GID 10001. Do not add editable installs, the `dev` extra, or
 root execution to the runtime stage.
+Dockerfile, schema, and container-workflow pull requests build the image without
+registry credentials or a push; publishing, signing, and provenance attestation
+remain restricted to version tags.
 
 ## Commit format
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,33 @@
-FROM python:3.11-slim
+FROM python:3.11.15-slim-bookworm AS builder
 
-WORKDIR /app
+WORKDIR /build
 
-# Install package
-COPY pyproject.toml .
+COPY pyproject.toml README.md LICENSE ./
+COPY schemas/ schemas/
 COPY src/ src/
-RUN python -m pip install --upgrade pip setuptools && pip install -e ".[dev]"
 
-# Config, policy, catalog injected via volume mounts
-RUN mkdir -p /etc/cmcp
+# Resolve runtime dependencies and build a non-editable wheelhouse. Development
+# extras and build tooling never cross into the runtime stage.
+RUN python -m pip wheel --disable-pip-version-check --wheel-dir /wheels .
+
+
+FROM python:3.11.15-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system --gid 10001 cmcp \
+    && useradd --system --uid 10001 --gid cmcp --home-dir /var/lib/cmcp cmcp \
+    && mkdir -p /etc/cmcp /var/lib/cmcp \
+    && chown -R cmcp:cmcp /var/lib/cmcp
+
+COPY --from=builder /wheels /wheels
+RUN python -m pip install --disable-pip-version-check --no-index \
+        --find-links=/wheels cmcp-runtime \
+    && rm -rf /wheels
+
+WORKDIR /var/lib/cmcp
+USER 10001:10001
 
 EXPOSE 8443
 

--- a/tests/unit/test_container_hardening.py
+++ b/tests/unit/test_container_hardening.py
@@ -45,6 +45,8 @@ def test_container_prs_build_without_registry_write() -> None:
 
     assert "pull_request" in triggers
     assert build["with"]["push"] == "${{ startsWith(github.ref, 'refs/tags/') }}"
+    assert "steps.tag.outputs.tag || github.sha" in build["with"]["tags"]
+    assert "cmcp-gateway:latest" in build["with"]["tags"]
     assert all(
         "startsWith(github.ref, 'refs/tags/')" in step.get("if", "")
         for step in steps

--- a/tests/unit/test_container_hardening.py
+++ b/tests/unit/test_container_hardening.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import yaml
+
 
 def _dockerfile() -> str:
     return (Path(__file__).parents[2] / "Dockerfile").read_text(encoding="utf-8")
@@ -32,3 +34,24 @@ def test_runtime_image_pins_python_patch_and_distribution() -> None:
         "FROM python:3.11.15-slim-bookworm AS builder",
         "FROM python:3.11.15-slim-bookworm AS runtime",
     ]
+
+
+def test_container_prs_build_without_registry_write() -> None:
+    workflow_path = Path(__file__).parents[2] / ".github" / "workflows" / "docker.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    triggers = workflow[True]
+    steps = workflow["jobs"]["build-and-push"]["steps"]
+    build = next(step for step in steps if step.get("name") == "Build and push")
+
+    assert "pull_request" in triggers
+    assert build["with"]["push"] == "${{ startsWith(github.ref, 'refs/tags/') }}"
+    assert all(
+        "startsWith(github.ref, 'refs/tags/')" in step.get("if", "")
+        for step in steps
+        if step.get("name") in {
+            "Log in to GitHub Container Registry",
+            "Install cosign",
+            "Sign the image (keyless, by digest)",
+            "Attest build provenance (SLSA)",
+        }
+    )

--- a/tests/unit/test_container_hardening.py
+++ b/tests/unit/test_container_hardening.py
@@ -1,0 +1,34 @@
+"""Static release invariants for the CMCP runtime container."""
+
+from pathlib import Path
+
+
+def _dockerfile() -> str:
+    return (Path(__file__).parents[2] / "Dockerfile").read_text(encoding="utf-8")
+
+
+def test_runtime_image_uses_non_editable_production_install() -> None:
+    dockerfile = _dockerfile()
+
+    assert 'pip install -e ".[dev]"' not in dockerfile
+    assert "pip wheel" in dockerfile
+    assert "--no-index" in dockerfile
+
+
+def test_runtime_image_drops_root_privileges() -> None:
+    dockerfile = _dockerfile()
+
+    assert "USER 10001:10001" in dockerfile
+    assert "useradd --system --uid 10001" in dockerfile
+
+
+def test_runtime_image_pins_python_patch_and_distribution() -> None:
+    stages = [
+        line for line in _dockerfile().splitlines()
+        if line.startswith("FROM ")
+    ]
+
+    assert stages == [
+        "FROM python:3.11.15-slim-bookworm AS builder",
+        "FROM python:3.11.15-slim-bookworm AS runtime",
+    ]


### PR DESCRIPTION
## Summary

Replace the single-stage editable development install with a two-stage production build. The builder creates a runtime-only wheelhouse; the final image installs it offline, contains no development extras or build source, and runs as numeric UID/GID 10001 from a writable application-data directory.

The base is pinned to the current Python 3.11 patch and Debian suite (`python:3.11.15-slim-bookworm`), and `.dockerignore` excludes tests, docs, VCS metadata, databases, logs, and other non-build context.

## Root cause

The release image used `pip install -e ".[dev]"` directly in its final root-owned stage. That shipped test/security/build tools and an editable source tree into production, expanded the dependency and filesystem attack surface, and ran the network gateway as root. It also omitted the repository schema directory, which is why this PR is stacked on #503's packaged-schema fix.

## Validation

- Added static release invariants for production-only installation, offline wheelhouse use, non-root UID/GID, and patch/suite-pinned base stages
- Focused container/catalog tests: 24 passed
- Full clean-environment suite: 1054 passed, 8 skipped
- Ruff, mypy, and Bandit: clean
- `git diff --check`: clean

Docker is not installed in the local Windows environment, so the actual multi-stage build is delegated to the repository's existing Docker build-and-push workflow after the prerequisite branch is merged/retargeted.

## Dependency

Stacked on draft PR #503 because the final wheel must contain the mandatory catalog schema.

## Documentation

- Added container build invariants to CONTRIBUTING
- Added an Unreleased security changelog entry