### PR TITLE
Own Cedar enforcement adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,8 @@ dependencies = [
     # declaring ML-DSA-65 or hybrid crashed the verifier with an uncaught
     # RuntimeError on any install without the optional [pq] extra.
     "agent-manifest>=0.11",
-    # Cannot be raised past 48.x today, which leaves two reachable advisories
-    # unfixed. See #471: agent-governance-toolkit-core 4.x pins
-    # cryptography<49.0, and the only release that allows 49 (5.0.0) pins
-    # agentrust-trace<0.3.0 against the >=0.5 this package needs. Raising the
-    # floor here makes the dependency set unsatisfiable rather than secure.
+    # AGT's remaining gateway/scanner integrations currently constrain this;
+    # the Cedar enforcement path itself no longer depends on AGT (#472).
     "cryptography>=42.0",
     "pyyaml>=6.0",
     "httpx>=0.27",
@@ -44,13 +41,8 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.29",
     "click>=8.1",
-    # Held on the 4.x line deliberately, see #472. PolicyEvaluator imports
-    # agent_os.policies.backends.CedarBackend, which AGT removed in #3444 when
-    # the v4 policy language was replaced by ACS v5. 4.1.0 (tagged 2026-06-09)
-    # is the last release that ships it, and >=4.0 with no ceiling let pip pick
-    # a 5.x that would break policy evaluation entirely. The ceiling is the
-    # constraint that matters; the floor stays open so an agt-core 4.1.1 with
-    # the cryptography cap lift (#471) is taken automatically when it ships.
+    # Still required by MCPGateway and the optional security scanners. Cedar
+    # evaluation no longer imports AGT's removed v4 CedarBackend; see #472.
     "agent-governance-toolkit-core>=4.1.0,<5.0",
     "cedarpy>=4.0",
 ]

--- a/src/cmcp_runtime/policy/cedar.py
+++ b/src/cmcp_runtime/policy/cedar.py
@@ -1,0 +1,97 @@
+"""Small, fail-closed Cedar adapter owned by cMCP.
+
+This module preserves the request mapping cMCP previously received from AGT
+v4's ``CedarBackend`` while depending only on the real Cedar engine exposed by
+``cedarpy``.  Keeping the mapping here avoids coupling the enforcement path to
+AGT's removed v4 policy API or its unrelated v5 ACS lifecycle model.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any
+
+import cedarpy
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CedarDecision:
+    """The evaluation fields consumed by :class:`PolicyEvaluator`."""
+
+    allowed: bool
+    reason: str
+    evaluation_ms: float
+    policy_ids: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class CedarBackend:
+    """Evaluate cMCP's measured policy bytes with cedarpy.
+
+    The class name intentionally remains ``CedarBackend`` so existing test and
+    extension seams do not change.  There is no mock or permissive fallback: an
+    invalid policy, malformed request, or unavailable engine produces a deny.
+    """
+
+    def __init__(self, *, policy_content: str) -> None:
+        self._policy_content = policy_content
+
+    @staticmethod
+    def build_request(context: dict[str, Any]) -> dict[str, Any]:
+        """Map cMCP call context to the same Cedar entities used by AGT v4."""
+        agent_id = context.get("agent_id", 'Agent::"anonymous"')
+        resource = context.get("resource", 'Resource::"default"')
+
+        if "::" not in str(agent_id):
+            agent_id = f'Agent::"{agent_id}"'
+        if "::" not in str(resource):
+            resource = f'Resource::"{resource}"'
+
+        tool_name = str(context.get("tool_name", "unknown"))
+        action_name = "".join(part.capitalize() for part in tool_name.split("_"))
+        return {
+            "principal": agent_id,
+            "action": f'Action::"{action_name}"',
+            "resource": resource,
+            "context": {
+                key: value
+                for key, value in context.items()
+                if key not in ("agent_id", "tool_name", "resource")
+            },
+        }
+
+    def evaluate(self, context: dict[str, Any]) -> CedarDecision:
+        """Authorize one call, failing closed on every engine error."""
+        started = perf_counter()
+        try:
+            response = cedarpy.is_authorized(
+                request=self.build_request(context),
+                policies=self._policy_content,
+                entities=[],
+            )
+            allowed = response.decision == cedarpy.Decision.Allow
+            reasons = tuple(str(reason) for reason in response.diagnostics.reasons)
+            errors = tuple(str(error) for error in response.diagnostics.errors)
+            return CedarDecision(
+                allowed=allowed,
+                reason=(
+                    f"Cedar evaluation error: {'; '.join(errors)}"
+                    if errors
+                    else f"Cedar (cedarpy): {'allowed' if allowed else 'denied'}"
+                ),
+                evaluation_ms=(perf_counter() - started) * 1000,
+                policy_ids=reasons,
+                error="; ".join(errors) or None,
+            )
+        except Exception as exc:
+            logger.error("Cedar evaluation failed: %s", exc)
+            return CedarDecision(
+                allowed=False,
+                reason=f"Cedar evaluation error: {exc}",
+                evaluation_ms=(perf_counter() - started) * 1000,
+                error=str(exc),
+            )

--- a/src/cmcp_runtime/policy/evaluator.py
+++ b/src/cmcp_runtime/policy/evaluator.py
@@ -1,10 +1,4 @@
-"""
-Cedar policy evaluation via AGT's CedarBackend - implements issues #68, #73.
-
-AGT provides three evaluation modes: cedarpy (native Python), cli (subprocess),
-and builtin (mock). cMCP selects the best available mode at instantiation and
-measures the policy bundle hash into the TEE attestation report separately.
-"""
+"""Cedar policy evaluation for cMCP - implements issues #68, #73, #472."""
 
 from __future__ import annotations
 
@@ -12,12 +6,11 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from agent_os.policies.backends import CedarBackend
-
 from cmcp_runtime.config import Config, EnforcementMode
 from cmcp_runtime.errors import PolicyDeny
 from cmcp_runtime.policy.annotations import parse_policy_annotations
 from cmcp_runtime.policy.bundle import PolicyBundle, PolicyStore
+from cmcp_runtime.policy.cedar import CedarBackend
 from cmcp_runtime.policy.decisions import Decision, decision_for_deny
 from cmcp_runtime.session.state import effective_sensitivity_order
 
@@ -50,7 +43,7 @@ class PolicyDecision:
 
 class PolicyEvaluator:
     """
-    Wraps AGT's CedarBackend with cMCP enforcement modes.
+    Wraps cMCP's narrow Cedar adapter with cMCP enforcement modes.
 
     The bundle is loaded and hash-verified by load_policy_bundle() before this
     class is instantiated. CedarBackend receives the already-loaded policy content
@@ -83,11 +76,7 @@ class PolicyEvaluator:
             content for _, content in sorted(initial_bundle.policy_files.items())
         )
 
-        self._backend = CedarBackend(
-            policy_content=combined_policy,
-            mode="auto",  # cedarpy > cli > builtin
-        )
-        self._combined_policy = combined_policy
+        self._backend = CedarBackend(policy_content=combined_policy)
         self._annotations = parse_policy_annotations(combined_policy)
         logger.info(
             "PolicyEvaluator ready: bundle_hash=%s enforcement=%s backend=%s",
@@ -104,40 +93,25 @@ class PolicyEvaluator:
             combined_policy = "\n\n".join(
                 content for _, content in sorted(bundle.policy_files.items())
             )
-            self._backend = CedarBackend(policy_content=combined_policy, mode="auto")
-            self._combined_policy = combined_policy
+            self._backend = CedarBackend(policy_content=combined_policy)
             self._annotations = parse_policy_annotations(combined_policy)
             self._current_hash = bundle.bundle_hash
             logger.info("PolicyEvaluator backend refreshed: new_hash=%s", self._current_hash)
 
-    def _advice_for_deny(self, context: dict[str, Any]) -> dict[str, str]:
+    def _advice_for_deny(self, policy_ids: tuple[str, ...]) -> dict[str, str]:
         """
         Best-effort: recover the annotations of the forbid policies that caused
         a deny, to return as structured advice (e.g. HITL escalation payloads).
 
-        AGT's CedarBackend does not expose cedarpy's diagnostics.reasons, so
-        this re-evaluates the same request directly with cedarpy purely for
-        diagnostics - the authorization decision itself is never taken from
-        here. Runs only on the deny path; returns {} on any failure.
+        Matched policy ids come from the same cedarpy authorization result used
+        for the decision. This method remains best-effort and returns {} when
+        annotations or diagnostics are unavailable.
         """
         if not self._annotations:
             return {}
         try:
-            import cedarpy
-
-            request = self._backend._build_cedar_request(context)
-            response = cedarpy.is_authorized(
-                request={
-                    "principal": request["principal"],
-                    "action": request["action"],
-                    "resource": request["resource"],
-                    "context": request.get("context", {}),
-                },
-                policies=self._combined_policy,
-                entities=getattr(self._backend, "_entities", []),
-            )
             advice: dict[str, str] = {}
-            for policy_id in response.diagnostics.reasons:
+            for policy_id in policy_ids:
                 advice.update(self._annotations.get(policy_id, {}))
             return advice
         except Exception:
@@ -175,7 +149,7 @@ class PolicyEvaluator:
 
         # Cedar denied - recover advice annotations from the matched policies,
         # then apply enforcement mode.
-        advice = self._advice_for_deny(context)
+        advice = self._advice_for_deny(tuple(getattr(result, "policy_ids", ())))
 
         if self._mode == EnforcementMode.ENFORCING:
             raise PolicyDeny(

--- a/tests/unit/test_cedar_backend.py
+++ b/tests/unit/test_cedar_backend.py
@@ -1,0 +1,51 @@
+"""Parity and fail-closed tests for cMCP's Cedar adapter (#472)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cmcp_runtime.policy.cedar import CedarBackend
+
+
+def test_request_mapping_preserves_agt_v4_contract():
+    request = CedarBackend.build_request(
+        {
+            "agent_id": "agent-7",
+            "tool_name": "ehr.treatment_plan_writer",
+            "resource": "salesforce.contacts",
+            "workflow_id": "clinical",
+        }
+    )
+    assert request == {
+        "principal": 'Agent::"agent-7"',
+        "action": 'Action::"Ehr.treatmentPlanWriter"',
+        "resource": 'Resource::"salesforce.contacts"',
+        "context": {"workflow_id": "clinical"},
+    }
+
+
+def test_real_engine_returns_matched_policy_ids():
+    backend = CedarBackend(
+        policy_content='@id("blocked") forbid (principal, action, resource);'
+    )
+    result = backend.evaluate({"tool_name": "echo"})
+    assert result.allowed is False
+    # cedarpy assigns stable positional ids; cMCP's annotation parser uses the
+    # same ids to recover @reason and other structured advice.
+    assert result.policy_ids == ("policy0",)
+    assert result.error is None
+
+
+def test_engine_error_fails_closed():
+    backend = CedarBackend(policy_content="not cedar")
+    result = backend.evaluate({"tool_name": "echo"})
+    assert result.allowed is False
+    assert result.error is not None
+
+
+def test_unavailable_engine_fails_closed():
+    backend = CedarBackend(policy_content="permit (principal, action, resource);")
+    with patch("cmcp_runtime.policy.cedar.cedarpy.is_authorized", side_effect=RuntimeError("down")):
+        result = backend.evaluate({"tool_name": "echo"})
+    assert result.allowed is False
+    assert result.error == "down"


### PR DESCRIPTION
Closes #472.

## What changed

- replaces the removed AGT v4 CedarBackend enforcement dependency with a narrow cMCP-owned adapter over the existing direct cedarpy dependency
- preserves the AGT v4 request mapping for principals, PascalCase tool actions, resources, and context
- carries matched Cedar policy ids from the authorization result into structured deny advice without a second evaluation
- fails closed on malformed policy, request, or engine errors; there is no mock or permissive fallback
- keeps AGT 4.x only for the remaining MCPGateway and scanner integrations

## Why

AGT 5 moved runtime policy to ACS, which is a different manifest and intervention-point model rather than a drop-in Cedar backend. This removes the fragile deleted API from the cMCP enforcement path without silently changing existing Cedar policy semantics.

## Validation

- clean environment dependency resolution: pip install editable with dev dependencies
- full suite: 1147 passed, 24 skipped
- focused Cedar suite: 28 passed
- Ruff on changed files: passed
- mypy on src: passed
- Bandit on changed source files: passed
- git diff check: passed