### PR TITLE
Gate declared data class on the same call

### DIFF
--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -503,9 +503,17 @@ class CMCPProxy:
         tool_name: str,
         arguments: dict[str, Any],
         workflow_id: str | None = None,
+        call_data_class: str | None = None,
     ) -> dict[str, Any]:
-        """Build the Cedar evaluation context from call details + session state."""
+        """Build Cedar context, conservatively including this call's class."""
         entry = self._catalog.lookup(tool_name)
+        effective_sensitivity = self._session.max_sensitivity
+        if entry is not None:
+            effective_sensitivity = _max_sensitivity(
+                effective_sensitivity,
+                call_data_class or entry.sensitivity_level,
+                self._session.sensitivity_order,
+            )
         ctx: dict[str, Any] = {
             "tool_name": tool_name,
             # Cedar resource entity: the backend builds Resource::"<resource>" from
@@ -519,7 +527,10 @@ class CMCPProxy:
             "compliance_domain": entry.compliance_domain if entry else "external",
             "baa_covered": (not entry.requires_baa) if entry else False,
             "destination_class": "external",
-            "session_max_sensitivity": self._session.max_sensitivity,
+            # Policy sees the running session maximum raised by this call's
+            # effective class. A caller declaration is never trusted to lower
+            # either the catalog floor or sensitivity accumulated earlier.
+            "session_max_sensitivity": effective_sensitivity,
             "attestation_platform": self._attestation_platform,
         }
         if workflow_id is not None:
@@ -702,7 +713,9 @@ class CMCPProxy:
             )
 
         # Step 2: Cedar policy evaluation
-        cedar_context = self._build_cedar_context(tool_name, arguments, workflow_id)
+        cedar_context = self._build_cedar_context(
+            tool_name, arguments, workflow_id, effective_data_class
+        )
         policy_rule: str | None = None
         ingress_advice: dict[str, str] = {}
         try:

--- a/tests/unit/test_mcp_proxy.py
+++ b/tests/unit/test_mcp_proxy.py
@@ -197,6 +197,47 @@ async def test_declared_data_class_raises_session_above_catalog_floor():
 
 
 @pytest.mark.asyncio
+async def test_declared_data_class_gates_the_declaring_call():
+    """#506: Cedar must see the raised class on this call, not only the next."""
+    entry = _make_entry()
+    entry.sensitivity_level = "pii"
+    catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
+    evaluator = _make_evaluator()
+    proxy, _, _ = _make_proxy(catalog=catalog, evaluator=evaluator)
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="confidential")
+
+    context = evaluator.evaluate.call_args.args[0]
+    assert context["session_max_sensitivity"] == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_declared_data_class_cannot_lower_declaring_call_floor():
+    entry = _make_entry()
+    entry.sensitivity_level = "confidential"
+    catalog = ToolCatalog(entries={"test.tool": entry}, catalog_hash="sha256:" + "1" * 64)
+    evaluator = _make_evaluator()
+    proxy, _, _ = _make_proxy(catalog=catalog, evaluator=evaluator)
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="pii")
+
+    context = evaluator.evaluate.call_args.args[0]
+    assert context["session_max_sensitivity"] == "confidential"
+
+
+@pytest.mark.asyncio
+async def test_declared_data_class_cannot_lower_accumulated_session():
+    evaluator = _make_evaluator()
+    proxy, session, _ = _make_proxy(evaluator=evaluator)
+    session.max_sensitivity = "trade_secret"
+
+    await proxy.call_tool("c1", "test.tool", {}, declared_data_class="pii")
+
+    context = evaluator.evaluate.call_args.args[0]
+    assert context["session_max_sensitivity"] == "trade_secret"
+
+
+@pytest.mark.asyncio
 async def test_declared_data_class_below_floor_does_not_lower_session():
     """A declared_data_class ranked below the catalog floor must not lower the
     effective class - only ever raise, never lower."""


### PR DESCRIPTION
Closes #506.

Makes Cedar evaluate each call at the maximum of the accumulated session sensitivity, the catalogued tool floor, and the optional per-call data class declaration. Caller-controlled metadata can therefore only make enforcement stricter.

Evidence:
- regression failed before the fix: expected confidential, Cedar received public
- focused proxy and policy suite: 58 passed
- full suite: 1159 passed, 24 skipped
- Ruff and mypy passed
- git diff check passed