### PR TITLE
Support stateless MCP Streamable HTTP

### DIFF
--- a/docs/spec/transport.md
+++ b/docs/spec/transport.md
@@ -6,7 +6,23 @@ Last updated: 2026-06-04
 Stability: Unstable , expect breaking changes before v1.0
 ---
 
-Covers: Phase 1 transport scope, stdio gap analysis, SPIFFE-to-TEE attestation binding.
+Covers: Streamable HTTP scope, stdio gap analysis, SPIFFE-to-TEE attestation binding.
+
+## Current network transport
+
+cMCP speaks the stateless MCP 2026-07-28 Streamable HTTP contract to network
+servers. Every upstream request is a new POST carrying matching protocol
+metadata in the body and `MCP-Protocol-Version`, `Mcp-Method`, and (where
+applicable) `Mcp-Name` headers. The gateway advertises both JSON and SSE and
+accepts a request-scoped SSE stream only when it ends with the matching final
+JSON-RPC response. A missing response, malformed event, unsupported content
+type, or mismatched response id fails closed.
+
+The catalog value for new network entries is `streamable-http`. The
+`http-sse` value remains loadable for existing catalogs, but names the legacy
+2024-11-05 transport and should not be used for new entries. `websocket` is
+rejected because cMCP has no WebSocket implementation; silently sending such
+an entry over HTTP would misrepresent the measured catalog.
 
 Closes #20, #21.
 

--- a/docs/tutorials/tool-catalog-authoring.md
+++ b/docs/tutorials/tool-catalog-authoring.md
@@ -63,7 +63,7 @@ Identity of the upstream MCP server that provides this tool:
   "url": "https://salesforce-mcp.internal:443",
   "tls_fingerprint": "sha256:<hex of DER cert>",
   "spiffe_id": "spiffe://example.org/ns/prod/salesforce",
-  "transport": "http-sse",
+  "transport": "streamable-http",
   "rotation_mode": "key-pinned"
 }
 ```
@@ -74,7 +74,7 @@ Identity of the upstream MCP server that provides this tool:
 | `url` | Yes | Full URL including port |
 | `tls_fingerprint` | Yes | SHA-256 of the server's DER-encoded TLS certificate (see [TLS pinning](./tls-pinning.md)) |
 | `spiffe_id` | No | SPIFFE/SVID identity if the server uses workload identity |
-| `transport` | No | Default `"http-sse"` |
+| `transport` | Yes | Use `"streamable-http"` for current MCP servers, `"http-sse"` only for legacy 2024-11-05 deployments, or `"stdio"` for a measured child process. Unknown values fail startup. |
 | `rotation_mode` | No | Default `"key-pinned"` |
 
 ### `approved_definition`

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -52,7 +52,7 @@
           "type": "string",
           "enum": [
             "http-sse",
-            "websocket",
+            "streamable-http",
             "stdio"
           ],
           "description": "Transport protocol. stdio means the gateway spawns the server as its own child inside the enclave; see docs/spec/stdio-transport.md."
@@ -121,7 +121,7 @@
               "transport": {
                 "enum": [
                   "http-sse",
-                  "websocket"
+                  "streamable-http"
                 ]
               }
             },

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -39,7 +39,7 @@ class ServerIdentity:
     url: str
     tls_fingerprint: str
     spiffe_id: str | None
-    transport: str  # "http-sse", "websocket", or "stdio"
+    transport: str  # "streamable-http", legacy "http-sse", or "stdio"
     rotation_mode: str  # "key-pinned" (default) or "cert-pinned"
     spawn: StdioSpawn | None = None
     provenance_record_path: str | None = None

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -30,6 +30,11 @@ from cmcp_runtime.config import Config
 from cmcp_runtime.errors import PolicyDeny, UpstreamToolError, UpstreamUnavailable
 from cmcp_runtime.mcp import tls_pinning
 from cmcp_runtime.mcp.stdio import StdioServer
+from cmcp_runtime.mcp.streamable_http import (
+    build_request,
+    parameter_headers,
+    parse_response,
+)
 from cmcp_runtime.policy.decisions import audit_value
 from cmcp_runtime.policy.evaluator import PolicyEvaluator
 from cmcp_runtime.provenance import ProvenanceResult, check_server_provenance
@@ -337,13 +342,16 @@ class CMCPProxy:
             return await (await self._stdio_for(entry)).list_tools()
         try:
             client = self._client_for_upstream(entry)
+            payload, headers = build_request(
+                "provenance-tools-list", "tools/list", {}
+            )
             resp = await client.post(
                 entry.server.url,
-                json={"jsonrpc": "2.0", "id": "provenance-tools-list",
-                      "method": "tools/list", "params": {}},
+                json=payload,
+                headers=headers,
             )
             resp.raise_for_status()
-            result = resp.json().get("result")
+            result = parse_response(resp, "provenance-tools-list").get("result")
         except Exception as exc:  # noqa: BLE001 - any failure means "could not check"
             logger.warning("could not list tools for provenance check: %s", exc)
             return None
@@ -403,16 +411,19 @@ class CMCPProxy:
             return await server.call(call_id, tool_name, arguments)
 
         client = self._client_for_upstream(entry)
-        payload = {
-            "jsonrpc": "2.0",
-            "id": call_id,
-            "method": "tools/call",
-            "params": {"name": tool_name, "arguments": arguments},
-        }
+        payload, headers = build_request(
+            call_id,
+            "tools/call",
+            {"name": tool_name, "arguments": arguments},
+            name=tool_name,
+        )
         try:
-            resp = await client.post(entry.server.url, json=payload)
+            headers.update(
+                parameter_headers(entry.approved_definition.input_schema, arguments)
+            )
+            resp = await client.post(entry.server.url, json=payload, headers=headers)
             resp.raise_for_status()
-            body = resp.json()
+            body = parse_response(resp, call_id)
         except tls_pinning.TLSPinMismatchError as exc:
             raise UpstreamUnavailable(
                 f"Upstream TLS certificate fingerprint does not match the attested "

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -30,6 +30,7 @@ from starlette.routing import Route
 
 from cmcp_runtime.catalog.loader import ApprovedDefinition, CatalogEntry, ServerIdentity
 from cmcp_runtime.mcp.proxy import CMCPProxy
+from cmcp_runtime.mcp.streamable_http import PROTOCOL_VERSION
 
 if TYPE_CHECKING:
     from cmcp_runtime.audit.chain import AuditChain
@@ -310,7 +311,7 @@ class MCPServer:
                 "jsonrpc": "2.0",
                 "id": rpc_id,
                 "result": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": PROTOCOL_VERSION,
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "cmcp-runtime", "version": "0.1.0"},
                 },

--- a/src/cmcp_runtime/mcp/streamable_http.py
+++ b/src/cmcp_runtime/mcp/streamable_http.py
@@ -1,0 +1,138 @@
+"""MCP 2026-07-28 Streamable HTTP request and response helpers."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any
+
+import httpx
+
+PROTOCOL_VERSION = "2026-07-28"
+_META_VERSION = "io.modelcontextprotocol/protocolVersion"
+_META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo"
+_META_CLIENT_CAPABILITIES = "io.modelcontextprotocol/clientCapabilities"
+_HEADER_TOKEN = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
+
+def _header_value(value: str) -> str:
+    """Encode a value using MCP's Base64 sentinel when plain ASCII is unsafe."""
+    safe = (
+        value == value.strip()
+        and all(char == "\t" or 0x20 <= ord(char) <= 0x7E for char in value)
+        and not (value.startswith("=?base64?") and value.endswith("?="))
+    )
+    if safe:
+        return value
+    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
+    return f"=?base64?{encoded}?="
+
+
+def build_request(
+    request_id: str,
+    method: str,
+    params: dict[str, Any],
+    *,
+    name: str | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Build a modern stateless MCP request and its mirrored HTTP headers."""
+    body_params = dict(params)
+    body_params["_meta"] = {
+        _META_VERSION: PROTOCOL_VERSION,
+        _META_CLIENT_INFO: {"name": "cmcp-runtime", "version": "0.4.0"},
+        _META_CLIENT_CAPABILITIES: {},
+    }
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": body_params,
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": PROTOCOL_VERSION,
+        "Mcp-Method": method,
+    }
+    if name is not None:
+        headers["Mcp-Name"] = _header_value(name)
+    return body, headers
+
+
+def parameter_headers(
+    input_schema: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, str]:
+    """Mirror statically reachable ``x-mcp-header`` tool parameters."""
+    headers: dict[str, str] = {}
+    seen: set[str] = set()
+
+    def visit(schema: dict[str, Any], value: Any) -> None:
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            return
+        instance = value if isinstance(value, dict) else {}
+        for property_name, child in properties.items():
+            if not isinstance(child, dict):
+                continue
+            annotation = child.get("x-mcp-header")
+            if annotation is not None:
+                if (
+                    not isinstance(annotation, str)
+                    or not _HEADER_TOKEN.fullmatch(annotation)
+                    or annotation.lower() in seen
+                    or child.get("type") not in ("string", "integer", "boolean")
+                ):
+                    raise ValueError(f"invalid x-mcp-header annotation: {annotation!r}")
+                seen.add(annotation.lower())
+                if property_name in instance and instance[property_name] is not None:
+                    raw = instance[property_name]
+                    expected = child["type"]
+                    if expected == "boolean" and isinstance(raw, bool):
+                        rendered = "true" if raw else "false"
+                    elif expected == "integer" and isinstance(raw, int) and not isinstance(raw, bool):
+                        if abs(raw) > 2**53 - 1:
+                            raise ValueError("x-mcp-header integer exceeds JavaScript safe range")
+                        rendered = str(raw)
+                    elif expected == "string" and isinstance(raw, str):
+                        rendered = raw
+                    else:
+                        raise ValueError(
+                            f"x-mcp-header value for {property_name!r} does not match {expected}"
+                        )
+                    headers[f"Mcp-Param-{annotation}"] = _header_value(rendered)
+            visit(child, instance.get(property_name))
+
+    visit(input_schema, arguments)
+    return headers
+
+
+def parse_response(response: httpx.Response, request_id: str) -> dict[str, Any]:
+    """Parse a JSON or request-scoped SSE response and return the final reply."""
+    media_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if media_type == "application/json":
+        body = response.json()
+        if not isinstance(body, dict):
+            raise ValueError("MCP JSON response is not an object")
+        return body
+    if media_type != "text/event-stream":
+        raise ValueError(f"unsupported MCP response content type: {media_type or 'missing'}")
+
+    data_lines: list[str] = []
+    for line in response.text.splitlines() + [""]:
+        if line == "":
+            if data_lines:
+                event = json.loads("\n".join(data_lines))
+                data_lines.clear()
+                if (
+                    isinstance(event, dict)
+                    and str(event.get("id")) == str(request_id)
+                    and ("result" in event or "error" in event)
+                ):
+                    return event
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            value = line[5:]
+            data_lines.append(value[1:] if value.startswith(" ") else value)
+    raise ValueError("MCP SSE stream ended without a matching final response")

--- a/tests/conformance/test_gateway_conformance.py
+++ b/tests/conformance/test_gateway_conformance.py
@@ -156,6 +156,7 @@ def test_mcp_initialize(client: TestClient) -> None:
     assert body["id"] == 1
     result = body["result"]
     assert "protocolVersion" in result
+    assert result["protocolVersion"] == "2026-07-28"
     assert "capabilities" in result
 
 

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -142,6 +142,20 @@ def test_catalog_defaults_sensitivity_level(catalog_file):
     assert cat.entries["crm.query"].sensitivity_level == "public"
 
 
+def test_streamable_http_transport_loads(catalog_file):
+    entry = dict(ENTRY_1)
+    entry["server"] = dict(entry["server"], transport="streamable-http")
+    cat = load_catalog(catalog_file([entry]))
+    assert cat.entries["crm.query"].server.transport == "streamable-http"
+
+
+def test_unimplemented_websocket_transport_fails_closed(catalog_file):
+    entry = dict(ENTRY_1)
+    entry["server"] = dict(entry["server"], transport="websocket")
+    with pytest.raises(ConfigError, match="schema violation"):
+        load_catalog(catalog_file([entry]))
+
+
 def test_catalog_empty_is_valid(catalog_file):
     cat = load_catalog(catalog_file([]))
     assert len(cat.entries) == 0

--- a/tests/unit/test_streamable_http.py
+++ b/tests/unit/test_streamable_http.py
@@ -1,0 +1,99 @@
+"""MCP 2026-07-28 Streamable HTTP transport contract tests."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from cmcp_runtime.mcp.streamable_http import (
+    build_request,
+    parameter_headers,
+    parse_response,
+)
+
+
+def test_request_mirrors_modern_metadata_into_headers():
+    body, headers = build_request(
+        "c1", "tools/call", {"name": "echo", "arguments": {}}, name="echo"
+    )
+    assert headers == {
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "echo",
+    }
+    assert body["params"]["_meta"][
+        "io.modelcontextprotocol/protocolVersion"
+    ] == headers["MCP-Protocol-Version"]
+
+
+def test_non_ascii_name_uses_base64_sentinel():
+    _, headers = build_request(
+        "c1", "tools/call", {"name": "héllo", "arguments": {}}, name="héllo"
+    )
+    assert headers["Mcp-Name"] == "=?base64?aMOpbGxv?="
+
+
+def test_sse_parser_ignores_notifications_and_returns_final_response():
+    final = {"jsonrpc": "2.0", "id": "c1", "result": {"content": []}}
+    text = (
+        ": keepalive\n\n"
+        'data: {"jsonrpc":"2.0","method":"notifications/progress"}\n\n'
+        f"data: {json.dumps(final)}\n\n"
+    )
+    response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        text=text,
+    )
+    assert parse_response(response, "c1") == final
+
+
+def test_sse_parser_fails_closed_without_final_response():
+    response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        text='data: {"jsonrpc":"2.0","method":"notifications/progress"}\n\n',
+    )
+    with pytest.raises(ValueError, match="without a matching final response"):
+        parse_response(response, "c1")
+
+
+def test_parser_rejects_unadvertised_content_type():
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, text="ok")
+    with pytest.raises(ValueError, match="unsupported MCP response content type"):
+        parse_response(response, "c1")
+
+
+def test_parameter_headers_follow_static_property_paths():
+    schema = {
+        "type": "object",
+        "properties": {
+            "region": {"type": "string", "x-mcp-header": "Region"},
+            "options": {
+                "type": "object",
+                "properties": {
+                    "dry_run": {"type": "boolean", "x-mcp-header": "Dry-Run"}
+                },
+            },
+        },
+    }
+    assert parameter_headers(
+        schema, {"region": "us-west1", "options": {"dry_run": True}}
+    ) == {"Mcp-Param-Region": "us-west1", "Mcp-Param-Dry-Run": "true"}
+
+
+@pytest.mark.parametrize(
+    "annotation, property_type",
+    [("bad header", "string"), ("Region", "number")],
+)
+def test_invalid_parameter_header_annotation_fails_closed(annotation, property_type):
+    schema = {
+        "properties": {
+            "value": {"type": property_type, "x-mcp-header": annotation}
+        }
+    }
+    with pytest.raises(ValueError, match="invalid x-mcp-header"):
+        parameter_headers(schema, {"value": "x"})

--- a/tests/unit/test_upstream_forwarding.py
+++ b/tests/unit/test_upstream_forwarding.py
@@ -28,6 +28,13 @@ class _MockMCPHandler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0))
         request = json.loads(self.rfile.read(length))
         tool = request["params"]["name"]
+        assert self.headers["Accept"] == "application/json, text/event-stream"
+        assert self.headers["MCP-Protocol-Version"] == "2026-07-28"
+        assert self.headers["Mcp-Method"] == "tools/call"
+        assert self.headers["Mcp-Name"] == tool
+        assert request["params"]["_meta"][
+            "io.modelcontextprotocol/protocolVersion"
+        ] == "2026-07-28"
         if tool == "test.fail":
             body = {
                 "jsonrpc": "2.0",
@@ -42,9 +49,19 @@ class _MockMCPHandler(BaseHTTPRequestHandler):
                     "content": [{"type": "text", "text": f"echo:{tool}"}]
                 },
             }
-        payload = json.dumps(body).encode()
+        if tool == "test.sse":
+            notification = json.dumps({
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": {"progress": 1},
+            })
+            payload = f"data: {notification}\n\ndata: {json.dumps(body)}\n\n".encode()
+            content_type = "text/event-stream; charset=utf-8"
+        else:
+            payload = json.dumps(body).encode()
+            content_type = "application/json"
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
         self.wfile.write(payload)
@@ -86,7 +103,7 @@ def _make_proxy(server_url: str):
         approved_by="test",
     )
     catalog = ToolCatalog(
-        entries={"test.echo": entry, "test.fail": entry},
+        entries={"test.echo": entry, "test.fail": entry, "test.sse": entry},
         catalog_hash="sha256:" + "1" * 64,
     )
     config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
@@ -116,6 +133,13 @@ async def test_forward_raises_on_jsonrpc_error(mock_server):
     proxy, entry = _make_proxy(mock_server)
     with pytest.raises(UpstreamToolError, match="tool exploded"):
         await proxy._forward_to_upstream("c1", entry, "test.fail", {})
+
+
+@pytest.mark.asyncio
+async def test_forward_accepts_request_scoped_sse(mock_server):
+    proxy, entry = _make_proxy(mock_server)
+    text = await proxy._forward_to_upstream("c-sse", entry, "test.sse", {})
+    assert text == "echo:test.sse"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #496.

Implements the MCP 2026-07-28 stateless Streamable HTTP request contract for network upstreams: per-request protocol metadata, mirrored headers, JSON and request-scoped SSE responses, and x-mcp-header parameter mirroring. Invalid streams, content types, annotations, and unimplemented WebSocket catalogs fail closed.

The issue comment proposed initialize and Mcp-Session-Id, but those belong to 2025-era compatibility. The 2026-07-28 protocol explicitly removes both; this PR follows the current official contract and documents that decision.

Evidence:
- focused transport, forwarding, catalog, and conformance tests passed
- full suite: 1167 passed, 24 skipped
- Ruff and mypy passed
- Bandit passed on the new transport module
- git diff check passed