### PR TITLE
fix: widen the AIA chain depth cap for TPM attestation keys and log truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The catalog schema conditions its requirements on transport rather than relaxing them, so a network transport still requires `url` and `tls_fingerprint` while stdio requires `spawn`.
 
+### Fixed
+
+- **The AIA chain walk for a TPM attestation key had no margin above the one depth it was measured against (#514).** `TPMProvider._chain_from_leaf` stops walking the certificate chain at `_AIA_MAX_DEPTH`, and that constant was `4`, exactly the length of the one real Azure hierarchy measured so far: leaf, Azure Cloud Virtual TPM CA - 11, Azure Cloud Virtual TPM CA 2025, root. Split out of #453, whose own investigation found a second real hierarchy, `Global Virtual TPM CA - 03`, that reaches the same root in only 3 certificates. Two different depths already exist on real fleet hardware, so a cap sized to match one of them exactly leaves zero room for a future or differently configured hierarchy that needs one more hop: the walk would stop one certificate short of the root, and the resulting chain would ship without it.
+
+  Not a loop logic bug: the walk correctly builds any chain up to the cap, including one where the root arrives on the last allowed certificate. The cap is now `6`, two hops above the deeper of the two known depths rather than matching either exactly, and the walk logs a warning when it stops without reaching a self signed root, so a future truncation is visible in the logs immediately rather than only surfacing later as a chain verification failure that looks identical to a chain that legitimately reaches an untrusted root.
+
 ## [0.4.0] - 2026-08-08
 
 **Anyone running 0.3.0 should upgrade.** On 0.3.0 a forged TPM quote was reported as hardware-attested: the `tpm2` branch of `verify_trace_claim` called only `verify_tpm_measurement`, which takes no signature parameter, so a `TPMS_ATTEST` with the correct magic and matching `qualifying_data` passed with no signature and no certificate chain (#370). The authenticated path existed and was tested; nothing in production called it. This release makes the quote signature and the AK certificate chain the gate on `hardware_attestation`, so evidence that does not chain to a pinned root can no longer report as verified.

--- a/src/cmcp_runtime/tee/tpm.py
+++ b/src/cmcp_runtime/tee/tpm.py
@@ -37,8 +37,17 @@ _PLATFORM_AK_CERT_NV_INDEX = 0x01C101D0
 
 # Walking the certificate AIA extension is what lets a relying party verify offline
 # later: the chain travels with the evidence instead of being fetched at audit time.
+#
+# #514: the two Azure hierarchies measured on real hardware so far are leaf, Azure
+# Cloud Virtual TPM CA - 11, Azure Cloud Virtual TPM CA 2025, root (4 certificates)
+# and leaf, Global Virtual TPM CA - 03, root (3 certificates), see #453. This value
+# is set two hops above the deeper of the two rather than matching either exactly,
+# since matching one of them exactly is what left the walk with no room at all for
+# a future or differently configured hierarchy that needs one more hop. It is a
+# judgment call pending more fleet data, not a value derived from a documented
+# Azure guarantee.
 _AIA_FETCH_TIMEOUT_SECONDS = 5
-_AIA_MAX_DEPTH = 4
+_AIA_MAX_DEPTH = 6
 
 # TPM2_NV_Read is bounded by TPM2_PT_NV_BUFFER_MAX; query it and cap by this.
 _NV_READ_CHUNK_BYTES = 512
@@ -362,6 +371,20 @@ class TPMProvider(TEEProvider):
             if issuer is None:
                 break
             chain.append(issuer)
+
+        # #514: tell "the walk reached a real, self signed root" apart from "the
+        # walk stopped only because the depth cap was hit" in the log, before a
+        # truncated chain turns into a confusing chain verification failure
+        # downstream that looks identical to a chain that legitimately reaches an
+        # untrusted root.
+        if len(chain) >= _AIA_MAX_DEPTH and chain[-1].subject != chain[-1].issuer:
+            logger.warning(
+                "AIA chain walk stopped at the %d certificate depth cap without "
+                "reaching a self signed root; the shipped chain is likely "
+                "truncated. issuer=%r",
+                _AIA_MAX_DEPTH,
+                chain[-1].issuer.rfc4514_string(),
+            )
 
         from cryptography.hazmat.primitives.serialization import Encoding
 

--- a/tests/unit/test_tpm_platform_ak.py
+++ b/tests/unit/test_tpm_platform_ak.py
@@ -8,12 +8,14 @@ the first implementation fail on a 1596-byte certificate.
 from __future__ import annotations
 
 import datetime
+import logging
+from unittest.mock import patch
 
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509.oid import NameOID
+from cryptography.x509.oid import AuthorityInformationAccessOID, NameOID
 
 from cmcp_runtime.tee.tpm import TPMProvider
 
@@ -68,6 +70,76 @@ def _self_signed(cn: str = "unit-test-ak") -> x509.Certificate:
         .not_valid_after(now + datetime.timedelta(days=365))
         .sign(key, hashes.SHA256())
     )
+
+
+def _build_chain(depth: int) -> list[x509.Certificate]:
+    """Build a synthetic chain of `depth` certificates, leaf first, each signed by
+    the next and carrying an AIA extension pointing at the next by URL, terminating
+    in a self signed root (#514)."""
+    keys = [rsa.generate_private_key(public_exponent=65537, key_size=2048) for _ in range(depth)]
+    names = [
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, f"unit-test-{i}")])
+        for i in range(depth)
+    ]
+    now = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    certs: list[x509.Certificate] = []
+    for i in range(depth):
+        is_root = i == depth - 1
+        issuer = names[i] if is_root else names[i + 1]
+        signing_key = keys[i] if is_root else keys[i + 1]
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(names[i])
+            .issuer_name(issuer)
+            .public_key(keys[i].public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=365))
+        )
+        if not is_root:
+            url = f"https://example.test/cert{i + 1}.der"
+            builder = builder.add_extension(
+                x509.AuthorityInformationAccess([
+                    x509.AccessDescription(
+                        AuthorityInformationAccessOID.CA_ISSUERS,
+                        x509.UniformResourceIdentifier(url),
+                    )
+                ]),
+                critical=False,
+            )
+        certs.append(builder.sign(signing_key, hashes.SHA256()))
+    return certs
+
+
+class _FakeAiaResponse:
+    """Minimal urlopen() context manager stand-in serving one certificate's DER."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __enter__(self) -> _FakeAiaResponse:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def _fake_urlopen_for(certs: list[x509.Certificate]):
+    """Serve certs[i] DER bytes for the URL _build_chain() gave cert i-1's AIA."""
+    der_by_url = {
+        f"https://example.test/cert{i + 1}.der": certs[i + 1].public_bytes(
+            serialization.Encoding.DER
+        )
+        for i in range(len(certs) - 1)
+    }
+
+    def _urlopen(url: str, timeout: float | None = None) -> _FakeAiaResponse:
+        return _FakeAiaResponse(der_by_url[url])
+
+    return _urlopen
 
 
 def test_nv_read_chunks_within_the_buffer_limit() -> None:
@@ -146,3 +218,39 @@ def test_certifies_matches_only_the_key_in_the_leaf() -> None:
 @pytest.mark.parametrize("blob", [b"", b"\x30\x82", b"\xff" * 64])
 def test_chain_from_malformed_input_never_raises(blob: bytes) -> None:
     assert TPMProvider._chain_from_leaf(blob) == b""
+
+
+def test_chain_walk_reaches_root_deeper_than_previously_known_azure_depth() -> None:
+    """#514: the two Azure hierarchies measured on real hardware are 4 and 3
+    certificates deep. A chain one hop deeper than the deeper of the two must not
+    be truncated by the widened depth cap."""
+    certs = _build_chain(5)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen_for(certs)):
+        chain = TPMProvider._chain_from_leaf(certs[0].public_bytes(serialization.Encoding.DER))
+
+    loaded = x509.load_pem_x509_certificates(chain)
+    assert len(loaded) == 5
+    assert loaded[-1].subject == loaded[-1].issuer  # reached the real, self signed root
+
+
+def test_chain_walk_past_the_depth_cap_logs_a_truncation_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#514: when a chain needs more hops than the cap allows, the walk stops
+    without reaching the root, and that must be visible in the logs rather than
+    only surfacing later as a chain-verification failure that looks identical to
+    a chain that legitimately reaches an untrusted root."""
+    monkeypatch.setattr("cmcp_runtime.tee.tpm._AIA_MAX_DEPTH", 2)
+    certs = _build_chain(3)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=_fake_urlopen_for(certs)),
+        caplog.at_level(logging.WARNING, logger="cmcp_runtime.tee.tpm"),
+    ):
+        chain = TPMProvider._chain_from_leaf(certs[0].public_bytes(serialization.Encoding.DER))
+
+    loaded = x509.load_pem_x509_certificates(chain)
+    assert len(loaded) == 2
+    assert loaded[-1].subject != loaded[-1].issuer  # truncated, not the real root
+    assert any("depth cap" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Closes #514, split out of #453 at imran-siddique's request after zohebk8s found this while sourcing the Azure CA-03 root.

_AIA_MAX_DEPTH in tee/tpm.py bounds how many certificates TPMProvider._chain_from_leaf will walk via the AIA extension when building the chain shipped alongside a TPM attestation key. It was 4, exactly the length of the one real Azure hierarchy measured so far, leaf, Azure Cloud Virtual TPM CA - 11, Azure Cloud Virtual TPM CA 2025, root. The #453 investigation already found a second real hierarchy, Global Virtual TPM CA - 03, that reaches the same root in only 3 certificates, so two different depths already exist on real fleet hardware today. A cap sized to match one of them exactly left zero room for a future or differently configured hierarchy that needs one more hop, in which case the walk stops one certificate short of the root and the shipped chain silently lacks it, then fails downstream verification with the same error a chain that legitimately reaches an untrusted root would produce.

Not a loop logic bug. The while len(chain) < N walk correctly builds any chain up to N total certificates, including one where the root arrives on the Nth certificate. The bug is purely that N was sized to match one observed case exactly rather than with real margin.

## This is a security critical path

src/cmcp_runtime/tee/ is listed in CONTRIBUTING.md as requiring two maintainer approvals and an explicit security impact note, so flagging that plainly. This PR widens a depth cap and adds a diagnostic log. It does not change what is trusted, how a certificate signature is checked, or the fail closed behavior when a chain cannot be built or does not reach a pinned root.

## Changes

- src/cmcp_runtime/tee/tpm.py: _AIA_MAX_DEPTH raised from 4 to 6, comment records both known real depths and that the margin is a judgment call pending more fleet data. A warning is now logged when the walk stops at the depth cap without reaching a self signed root, distinguishing that case from legitimately reaching an untrusted root, in the logs, before it becomes a confusing chain verification failure.
- tests/unit/test_tpm_platform_ak.py: no existing test walked a multi hop AIA chain at all. Added a synthetic chain builder plus two tests, one proving a 5 certificate chain, one hop deeper than either known real depth, completes under the new cap, one proving a chain that does exceed the cap is detected as truncated and logs the new warning.
- CHANGELOG.md.

## Test plan

- [x] pytest tests/unit/test_tpm_platform_ak.py passes locally, 12 passed
- [x] pytest tests/unit/ passes locally, 1084 passed, 8 skipped, plus one pre-existing failure unrelated to this change (test_release_distribution_smoke.py, fails identically on main with this branch's changes stashed, a local dev venv packaging gap, not a regression)
- [x] ruff check src/ tests/ clean
- [x] mypy src/cmcp_runtime/ src/cmcp_verify/ clean
- [x] bandit -r src/ clean
- [x] manually confirmed the constant is 6 and the two new tests exercise both the successful-deeper-chain case and the truncation-and-log case