### PR TITLE
docs: add Termux/Android setup notes for cMCP install

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,6 +44,16 @@ This installs:
 - `cmcp` - the gateway CLI
 - `cmcp_verify` - the Python library for verifying TRACE Claims (no separate CLI install needed)
 
+### Termux (Android)
+
+`pip install cmcp-runtime` fails to build two dependencies on Termux/ARM out of the box.
+
+**1. cedarpy/maturin cannot detect the Android API level.** Fix: `export ANDROID_API_LEVEL=$(getprop ro.build.version.sdk)` before installing.
+
+**2. pynacl fails to build against libsodium.** Fix: `pkg install libsodium pkg-config` then `export SODIUM_INSTALL=system SODIUM_LIB_DIR=$PREFIX/lib SODIUM_INC_DIR=$PREFIX/include`.
+
+With both fixes set, `pip install cmcp-runtime` completes normally.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
## What
Adds a Termux (Android) subsection to the Install section of `docs/quickstart.md`, documenting two dependency build failures specific to Termux/ARM.

## Why
`pip install cmcp-runtime` fails to build on Termux out of the box - cedarpy/maturin can't detect the Android API level, and pynacl can't build against libsodium. Neither issue is documented, so anyone trying to run cMCP on Android hits the same wall with no guidance. This adds the two fixes that resolve it.

## Security impact
None. Documentation-only change; no code touched, no changes under `src/cmcp_gateway/audit/`, `tee/`, or `policy/`.

## Test plan

- [ ] `pytest` passes — not applicable, docs-only change
- [ ] `ruff check` passes — not applicable, docs-only change
- [ ] `mypy` passes — not applicable, docs-only change
- [x] Manual test performed (describe steps below if applicable)

Installed `cmcp-runtime` fresh on Termux (Android, Python 3.13.13) following the standard quickstart. Hit both failures described in this PR before applying the documented fixes. After applying them, install completed cleanly and the full quickstart flow (write Cedar policy, start runtime, block a PII-tagged tool call with 403/POLICY_DENY, close session, verify signed TRACE claim) ran successfully end to end.

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree to the Developer Certificate of Origin (https://developercertificate.org).
