### PR TITLE
docs: stop asserting AAIF project status the charter says we do not have

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,15 @@ This document describes how cMCP is governed: who holds what role, how decisions
 
 ## Upstream governance body
 
-cMCP is a project of the **Agentic AI Foundation**. The Foundation sets the overall direction for the agentrust-io ecosystem, holds the project's trademarks, and provides a neutral venue for resolving disputes that cannot be resolved within the project itself. Foundation policies supersede this document where they conflict.
+AAIF hosting for cMCP is **proposed, not accepted**. [CHARTER.md](CHARTER.md) is the
+authoritative record: it is a pre-acceptance draft, and the "cMCP" and "cMCP-compatible"
+marks are currently held by OPAQUE Systems, Inc.
+
+On acceptance the Foundation would set overall direction for the agentrust-io ecosystem, hold
+the project's trademarks, and provide a neutral venue for resolving disputes that cannot be
+resolved within the project itself, and Foundation policies would supersede this document
+where they conflict. Until acceptance, this document governs and nothing here should be read
+as a binding foundation commitment.
 
 ---
 
@@ -16,7 +24,7 @@ The project lead is responsible for the technical direction of cMCP, final say o
 
 | Name | Affiliation | GitHub |
 |------|-------------|--------|
-| Imran Siddique | OPAQUE Systems | @imransiddique |
+| Imran Siddique | OPAQUE Systems | @imran-siddique |
 
 The project lead role is subject to Foundation confirmation. Succession is decided by a 2/3 maintainer vote, ratified by the Foundation.
 
@@ -69,10 +77,12 @@ An explicit vote is conducted by opening a GitHub Discussion tagged `vote`. It r
 
 ### Dispute resolution
 
-If a PR or proposal reaches an impasse, any Maintainer may call for a formal vote. If the vote does not resolve the dispute, the project lead makes the final call. If the dispute involves the project lead, the matter is escalated to the Agentic AI Foundation for binding resolution. A 2/3 majority of Maintainers is required to override a project lead decision through Foundation escalation.
+If a PR or proposal reaches an impasse, any Maintainer may call for a formal vote. If the vote does not resolve the dispute, the project lead makes the final call. A 2/3 majority of Maintainers is required to override a project lead decision.
+
+Where the dispute involves the project lead, there is currently no external venue: AAIF hosting is proposed and not accepted, so the Foundation cannot arbitrate for this project yet. Until acceptance such a dispute is resolved by a 2/3 majority of the remaining Maintainers. On acceptance, escalation to the Foundation for binding resolution replaces that fallback.
 
 ---
 
 ## Amendments
 
-Changes to this document require an explicit vote (see above) and ratification by the Agentic AI Foundation.
+Changes to this document require an explicit vote (see above). Ratification by the Agentic AI Foundation becomes an additional requirement only once AAIF hosting is accepted; requiring it today would make this document unamendable, since there is no Foundation relationship to ratify through.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,11 @@
 | Name | GitHub | Affiliation | Role |
 |------|--------|-------------|------|
 | Imran Siddique | @imran-siddique | OPAQUE Systems | Project Lead |
+| Rishabh Poddar | @podcastinator | OPAQUE Systems | Maintainer |
+| Aaron Fulkerson | @AaronRoeF | OPAQUE Systems | Maintainer |
+
+The Project Lead has final decision authority on architecture, conformance
+requirements, and Maintainer appointments.
 
 ## Roles
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 
 | Name | GitHub | Affiliation | Role |
 |------|--------|-------------|------|
-| Imran Siddique | @imransiddique | OPAQUE Systems | Project Lead |
+| Imran Siddique | @imran-siddique | OPAQUE Systems | Project Lead |
 
 ## Roles
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 cMCP - Confidential MCP Gateway
 
-Copyright 2026 Agentic AI Foundation contributors
+Copyright 2026 cMCP contributors
 
 This project is licensed under the MIT License.
 


### PR DESCRIPTION
Same defect as agentrust-io/ca2a#124, found by grepping the siblings after fixing that one. It was templated across both repos.

`GOVERNANCE.md` said cMCP **is** a project of the Agentic AI Foundation and that the Foundation **holds the project's trademarks**. `CHARTER.md` in the same tree says hosting is *"Proposed"*, that the charter *"has not yet been accepted by a host organization"*, and that the marks are *"currently held by OPAQUE Systems, Inc."*

### Two clauses were worse than the header

- **Dispute resolution** escalated to the Foundation for *"binding resolution"*.
- **Amendments** required *"ratification by the Agentic AI Foundation"* for any change.

Neither venue exists yet, so **the amendment clause made this document formally unamendable**. Both now name a fallback that works today and defer to the Foundation only on acceptance.

### Also in here

- `NOTICE` carried the same overclaim. `cmcp-runtime` 0.4.0 is already on PyPI with the old file, so the correction reaches users on the next release.
- `MAINTAINERS.md` and `GOVERNANCE.md` credited **@imransiddique**, a real but different GitHub account. Corrected to **@imran-siddique**.

No behaviour change, docs only.