### PR TITLE
fix(config): make catalog drift policy configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ASCII-only records serialize to the same bytes as before, pinned by test, so nothing that verifies today stops verifying. #517 asks for JCS reuse precisely so a record can cross implementations, and nothing consumes these records at runtime yet, so the encoding is still free to correct.
 
+- **`catalog.drift_policy` was unreachable from configuration (#523).** The parser defined
+  the setting, but strict top-level validation rejected every `catalog:` block before it
+  could be read. The block and its only supported key are now explicitly allowlisted;
+  `fail_closed` remains the default, and misspelled nested keys fail closed.
+
 - **cMCP could not verify a v0.2 Agent Manifest at all (agent-manifest#315, phase 4 of agent-manifest#243).** The pin moved to `agent-manifest>=0.11`, which carries the COSE verifier, and nothing here ever presented a v0.2 manifest to it. It could not have worked: `load_agent_manifest` read JSON and `_verify_with_sdk` passed a dict, and from v0.2 the COSE_Sign1 structure **is** the signature (ADR-0011), so a v0.2 document handed over as a dict has nothing to appraise. The SDK correctly reported a missing signature, and an operator would have read that as a malformed manifest rather than a manifest supplied in the wrong form.
 
   `load_agent_manifest_document()` now returns the decoded document alongside the envelope bytes it arrived in, and the envelope is what reaches `verify_manifest` when there is one. The file is sniffed rather than switched on its extension: a COSE envelope is CBOR and never parses as JSON, so trying JSON first is unambiguous and an operator does not have to name the file correctly for the gateway to read it. A v0.2 payload supplied as bare JSON is now named as such. `load_agent_manifest()` keeps its dict-returning signature for callers that only read identity fields.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,13 @@ agent_manifest:
   trust_anchor_path: ./manifest-public-key.json
   authenticated_subject: spiffe://factory.example/agent/material-movement/dev
 
+catalog:
+  # fail_closed (default): deny calls when an upstream server advertises a
+  # changed or withdrawn approved tool definition.
+  # warn_only: route the call but record the drift in the audit chain and
+  # TRACE Claim so an operator can measure a rollout before enforcing.
+  drift_policy: fail_closed
+
 # Path to the directory containing .cedar policy files and manifest.json.
 # Must not contain '..' components. Relative paths are resolved from the
 # working directory at startup.
@@ -96,6 +103,16 @@ All fields are optional as a group. If `path` is set, `trust_anchor_path` must a
 | `path` | string | none | Path to the signed Agent Manifest JSON document. Path traversal (`..` components) is rejected. |
 | `trust_anchor_path` | string | none | Path to a JSON trust anchor containing the issuer Ed25519 public key, either as `{ "key_id": "...", "public_key_base64url": "..." }` or `{ "keys": [...] }`. |
 | `authenticated_subject` | string | none | SPIFFE URI for the authenticated agent subject. This must equal `manifest.agent_id`. In production this should come from the agent SVID/mTLS identity; the config field is the current runtime input for that subject. |
+
+### catalog
+
+The gateway compares an upstream server's advertised tool definitions with the approved
+catalog once per server per session, on first contact. Drift is always written to the audit
+chain and TRACE Claim; this setting controls whether the session also fails closed.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `drift_policy` | string | `fail_closed` | Action when an approved tool definition changed or was withdrawn. Valid values: `fail_closed` (deny calls in the session) and `warn_only` (route calls while recording the drift). |
 
 ### top-level fields
 

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -137,6 +137,7 @@ class Config:
 _KNOWN_TOP_KEYS = {
     "attestation",
     "agent_manifest",
+    "catalog",
     "kill_switch",
     "sensitivity",
     "policy_bundle_path",
@@ -160,6 +161,7 @@ _FORBIDDEN_CATALOG_MUTATION_KEYS = {
 #: profile name must be a config error rather than silently enforcing nothing,
 #: which is how a deployment ends up believing it is conformant when it is not.
 _KNOWN_CONFORMANCE_PROFILES = {"aarm"}
+_KNOWN_CATALOG_KEYS = {"drift_policy"}
 _KNOWN_KILL_SWITCH_KEYS = {
     "enabled",
     "window_seconds",
@@ -391,6 +393,11 @@ def load_config(path: str) -> Config:
     catalog_raw = raw.get("catalog", {})
     if not isinstance(catalog_raw, dict):
         raise ConfigError("catalog must be a mapping")
+    for key in catalog_raw:
+        if key not in _KNOWN_CATALOG_KEYS:
+            raise ConfigError(
+                f"Unknown catalog key '{key}'. Valid keys: {sorted(_KNOWN_CATALOG_KEYS)}"
+            )
     try:
         drift_policy = DriftPolicy(catalog_raw.get("drift_policy", "fail_closed"))
     except ValueError as err:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from cmcp_runtime.config import Config, EnforcementMode, TEEProvider, load_config
+from cmcp_runtime.config import Config, DriftPolicy, EnforcementMode, TEEProvider, load_config
 from cmcp_runtime.errors import ConfigError
 
 
@@ -101,6 +101,38 @@ def test_catalog_reload_knob_is_reserved_and_requires_restart(config_file):
 def test_unknown_agent_manifest_key_raises(config_file):
     path = config_file("agent_manifest:\n  surprise: value\n")
     with pytest.raises(ConfigError, match="surprise"):
+        load_config(path)
+
+
+# ── #523: configurable upstream catalog drift policy ──────────────────────
+
+
+def test_catalog_drift_policy_loads(config_file):
+    path = config_file("catalog:\n  drift_policy: warn_only\n")
+    cfg = load_config(path)
+    assert cfg.catalog.drift_policy is DriftPolicy.WARN_ONLY
+
+
+def test_catalog_drift_policy_defaults_to_fail_closed(config_file):
+    cfg = load_config(config_file(""))
+    assert cfg.catalog.drift_policy is DriftPolicy.FAIL_CLOSED
+
+
+def test_invalid_catalog_drift_policy_raises(config_file):
+    path = config_file("catalog:\n  drift_policy: ignore\n")
+    with pytest.raises(ConfigError, match="catalog.drift_policy"):
+        load_config(path)
+
+
+def test_catalog_config_must_be_mapping(config_file):
+    path = config_file("catalog: warn_only\n")
+    with pytest.raises(ConfigError, match="catalog must be a mapping"):
+        load_config(path)
+
+
+def test_unknown_catalog_key_raises(config_file):
+    path = config_file("catalog:\n  drift_polciy: warn_only\n")
+    with pytest.raises(ConfigError, match="drift_polciy"):
         load_config(path)
 
 


### PR DESCRIPTION
## What

Allow the existing `catalog.drift_policy` setting through strict configuration validation, reject unknown keys inside the `catalog` block, and document both supported policies.

## Why

This is a narrow follow-up to #523 and #58. The parser already consumed `catalog.drift_policy` and the proxy already enforced it, but `_KNOWN_TOP_KEYS` omitted `catalog`. Every explicit `catalog:` block was therefore rejected before the parser ran; the default `fail_closed` behavior worked only because it required no block.

This reconnects the existing configuration contract without changing drift detection, comparison, or the default policy.

## Security impact

None. This does not touch the TEE boundary, signing path, audit chain, capability tokens, or trust-score inputs. `fail_closed` remains the default, `warn_only` remains an explicit operator choice, and unknown nested keys are rejected so misspellings cannot silently fall back.

## Test plan

- [x] `pytest` passes — 1,179 passed, 6 skipped
- [x] `ruff check` passes
- [x] `mypy` passes — 63 source files
- [x] Manual test performed
- [x] `bandit -r src/ -c pyproject.toml` passes
- [x] `mkdocs build --strict` passes

Manual test: on the parent commit, loading YAML with `catalog.drift_policy: warn_only` raises `ConfigError: Unknown config key 'catalog'`. With this change, it loads as `DriftPolicy.WARN_ONLY`. The suite also covers the omitted default, invalid enum, non-mapping block, and unknown nested key.

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree to the Developer Certificate of Origin (https://developercertificate.org).

## Author name correction

My full name is **Noah Ingwers** (`@noah-ing`). The original commit [`dac89aa`](https://github.com/agentrust-io/cmcp/commit/dac89aa5b6b589338585418b717810d1d0bf1d74) incorrectly used `Noah Ing` in its author, committer, and `Signed-off-by` fields. Those entries refer to me, Noah Ingwers.
