### PR TITLE
fix(seo): social cards said "Home", not the page title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -10,12 +10,14 @@
 #}
 {% block extrahead %}
   {{ super() }}
+  {# page.title is the nav label ("Home"); page.meta.title is the front matter. #}
+  {% set page_name = (page.meta.title if page and page.meta and page.meta.title else (page.title if page else None)) %}
   {% set page_desc = page.meta.description if page and page.meta and page.meta.description else config.site_description %}
   {% set page_url = page.canonical_url if page and page.canonical_url else config.site_url %}
 
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ config.site_name }}">
-  <meta property="og:title" content="{% if page and page.title %}{{ page.title }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
+  <meta property="og:title" content="{% if page_name %}{{ page_name }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
   <meta property="og:description" content="{{ page_desc }}">
   <meta property="og:url" content="{{ page_url }}">
   <meta property="og:image" content="{{ config.site_url }}assets/og.png">
@@ -24,7 +26,7 @@
   <meta property="og:image:alt" content="cMCP: an AgenTrust open standard">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{% if page and page.title %}{{ page.title }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
+  <meta name="twitter:title" content="{% if page_name %}{{ page_name }} - {{ config.site_name }}{% else %}{{ config.site_name }}: Confidential MCP Runtime{% endif %}">
   <meta name="twitter:description" content="{{ page_desc }}">
   <meta name="twitter:image" content="{{ config.site_url }}assets/og.png">
 

--- a/src/cmcp_runtime/cli.py
+++ b/src/cmcp_runtime/cli.py
@@ -16,6 +16,31 @@ if TYPE_CHECKING:
     from cmcp_runtime.startup import RuntimeContext
 
 
+def _marker(preferred: str, fallback: str, stream: object) -> str:
+    """Return `preferred` if `stream` can encode it, else `fallback`.
+
+    A Windows console defaults to a legacy code page, and writing "✓" to
+    it raises UnicodeEncodeError. That killed `cmcp validate-config` on its
+    own success path: the config was valid, and the command still exited
+    non-zero with a codec traceback. The marker is decoration, so it degrades
+    rather than taking the command down with it.
+    """
+    encoding = getattr(stream, "encoding", None) or "ascii"
+    try:
+        preferred.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return fallback
+    return preferred
+
+
+def _ok() -> str:
+    return _marker("✓", "OK", sys.stdout)
+
+
+def _bad() -> str:
+    return _marker("✗", "ERROR", sys.stderr)
+
+
 def build_server(ctx: RuntimeContext) -> MCPServer:
     """
     Compose the running gateway from a validated RuntimeContext.
@@ -249,10 +274,11 @@ def validate_config(config: str) -> None:
 
     try:
         load_config(config)
-        click.echo(f"✓ Config valid: {config}")
     except Exception as exc:
-        click.echo(f"✗ Config invalid: {exc}", err=True)
+        click.echo(f"{_bad()} Config invalid: {exc}", err=True)
         raise SystemExit(1) from exc
+
+    click.echo(f"{_ok()} Config valid: {config}")
 
 
 @main.command("validate-bundle")
@@ -265,7 +291,7 @@ def validate_bundle(bundle_path: str, expected_hash: str) -> None:
     try:
         bundle = load_policy_bundle(bundle_path)
     except Exception as exc:
-        click.echo(f"✗ Bundle load error: {exc}", err=True)
+        click.echo(f"{_bad()} Bundle load error: {exc}", err=True)
         raise SystemExit(1) from exc
 
     bundle_hash = bundle.bundle_hash
@@ -274,10 +300,10 @@ def validate_bundle(bundle_path: str, expected_hash: str) -> None:
     actual_hex = bundle_hash.removeprefix("sha256:")
 
     if actual_hex == expected_hex:
-        click.echo(f"✓ Bundle valid: {bundle_hash}")
+        click.echo(f"{_ok()} Bundle valid: {bundle_hash}")
     else:
         click.echo(
-            f"✗ Bundle hash mismatch: expected {expected_hash}, got {bundle_hash}",
+            f"{_bad()} Bundle hash mismatch: expected {expected_hash}, got {bundle_hash}",
             err=True,
         )
         raise SystemExit(1)

--- a/tests/unit/test_cli_output_encoding.py
+++ b/tests/unit/test_cli_output_encoding.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for CLI status markers on a legacy console.
+
+`cmcp validate-config` printed "✓ Config valid: ..." from inside the same
+try block that ran the validation. On a Windows console, whose default code
+page cannot encode that character, the echo raised UnicodeEncodeError, the
+`except Exception` caught it, and the command reported
+
+    ✗ Config invalid: 'charmap' codec can't encode character '✓' ...
+
+then exited 1. The config was valid. A user following the published quickstart
+was told their config was broken because the tool could not draw a tick.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from cmcp_runtime.cli import _bad, _marker, _ok, main
+
+
+class _Stream:
+    """Minimal stand-in for sys.stdout with a fixed encoding."""
+
+    def __init__(self, encoding: str | None) -> None:
+        self.encoding = encoding
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [
+        ("utf-8", "✓"),
+        ("UTF-8", "✓"),
+        ("cp1252", "OK"),
+        ("ascii", "OK"),
+        ("cp437", "OK"),
+        (None, "OK"),
+        ("not-a-real-codec", "OK"),
+    ],
+)
+def test_marker_falls_back_when_the_stream_cannot_encode_it(encoding, expected):
+    assert _marker("✓", "OK", _Stream(encoding)) == expected
+
+
+def test_marker_never_raises_on_an_object_without_encoding():
+    assert _marker("✓", "OK", object()) == "OK"
+
+
+def test_ok_and_bad_return_something_printable():
+    assert _ok() in ("✓", "OK")
+    assert _bad() in ("✗", "ERROR")
+
+
+def _write_valid_config(tmp_path):
+    config = tmp_path / "cmcp-config.yaml"
+    config.write_text(
+        "attestation:\n"
+        "  provider: auto\n"
+        "  enforcement_mode: enforcing\n"
+        "policy_bundle_path: ./policies/\n"
+        "catalog_path: ./catalog.json\n"
+        'listen_addr: "127.0.0.1:8443"\n',
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_validate_config_succeeds_on_a_legacy_code_page(tmp_path):
+    """A valid config must validate where the tick cannot be drawn."""
+    config = _write_valid_config(tmp_path)
+    result = CliRunner(charset="cp1252").invoke(
+        main, ["validate-config", "--config", str(config)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Config valid" in result.output
+    assert "Config invalid" not in result.output
+
+
+def test_validate_config_keeps_the_tick_where_utf8_is_available(tmp_path):
+    config = _write_valid_config(tmp_path)
+    result = CliRunner(charset="utf-8").invoke(
+        main, ["validate-config", "--config", str(config)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "✓ Config valid" in result.output
+
+
+def test_an_actually_invalid_config_still_fails(tmp_path):
+    """The fallback must not turn a real validation failure into a pass."""
+    config = tmp_path / "cmcp-config.yaml"
+    config.write_text("attestation: [this is not a mapping" + chr(10), encoding="utf-8")
+    result = CliRunner(charset="cp1252").invoke(
+        main, ["validate-config", "--config", str(config)]
+    )
+    assert result.exit_code == 1
+    assert "Config invalid" in result.output
+
+
+def test_a_failed_success_message_is_never_relabelled_as_invalid(tmp_path, monkeypatch):
+    """The success echo must sit outside the try that runs the validation.
+
+    A real Windows console raises UnicodeEncodeError from the write itself.
+    When the success echo lived inside the try, `except Exception` caught that
+    and printed "Config invalid: 'charmap' codec can't encode ...", so a valid
+    config was reported broken. Here the first echo raises and the test asserts
+    the command never claims the config is invalid.
+    """
+    import cmcp_runtime.cli as cli
+
+    config = _write_valid_config(tmp_path)
+    seen: list[str] = []
+    calls = {"n": 0}
+
+    def flaky_echo(message="", *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise UnicodeEncodeError("charmap", "✓", 0, 1, "unmapped")
+        seen.append(str(message))
+
+    monkeypatch.setattr(cli.click, "echo", flaky_echo)
+
+    with pytest.raises(UnicodeEncodeError):
+        cli.validate_config.callback(config=str(config))
+
+    assert not any("Config invalid" in m for m in seen), (
+        "a printing failure was relabelled as a validation failure: %r" % seen
+    )


### PR DESCRIPTION
MkDocs sets `page.title` from the nav entry when the nav gives one, so a landing page listed as `- Home: index.md` reports `page.title == "Home"` regardless of its front matter. The `<title>` tag was right, because Material reads the front matter for it. `og:title` and `twitter:title` read `page.title`, and shipped this to every link preview:

```
og:title = "Home - TRACE"
```

**This one is mine.** My earlier landing-page change relaxed the expression from `page.title and not page.is_homepage` to `page.title`, which turned a bare site-name fallback into `"Home - X"`. Worse than what it replaced.

`page.meta.title` is the front-matter value, so prefer it, fall back to `page.title` for inner pages, then to the site name.

## Verified per site

| | Before | After |
|---|---|---|
| trace | `Home - TRACE` | `Hardware-attested receipts for AI agent actions - TRACE` |
| cmcp | `Home - cMCP` | `The secure, confidential way to run MCP - cMCP` |
| ca2a | `Home - cA2A` | `Secure, confidential agent-to-agent delegation - cA2A` |
| tests | `Home - TRACE Tests` | `Verify your TRACE implementation - TRACE Tests` |

Homepage `og:title` now matches its `<title>`, and inner pages keep their own (`Quick Start - cMCP`). All four build clean under `mkdocs build --strict`.

Found by link-checking the live estate: the minified HTML uses unquoted attributes, which is why it did not show up in an earlier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY