### PR TITLE
fix: ruff UP031 in the CLI encoding test

### DIFF
--- a/tests/unit/test_cli_output_encoding.py
+++ b/tests/unit/test_cli_output_encoding.py
@@ -124,5 +124,5 @@ def test_a_failed_success_message_is_never_relabelled_as_invalid(tmp_path, monke
         cli.validate_config.callback(config=str(config))
 
     assert not any("Config invalid" in m for m in seen), (
-        "a printing failure was relabelled as a validation failure: %r" % seen
+        f"a printing failure was relabelled as a validation failure: {seen!r}"
     )


### PR DESCRIPTION
`ruff check src/ tests/` fails on main. The regression test I added in #540 used percent formatting in an assertion message, and the repo lints for UP031.

Now: `All checks passed!` and the 13 tests still pass.

My fault, and it reached main because I gated the merge on a check-status grep rather than on the lint job itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY