### PR TITLE
fix(mock-upstream): hardened JSON-RPC gate for the mock MCP upstream

### DIFF
--- a/scripts/mock_upstream.py
+++ b/scripts/mock_upstream.py
@@ -15,39 +15,121 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+# Matches MCPServer._max_request_bytes's default in cmcp_runtime/mcp/server.py,
+# so the mock rejects at the same boundary the real gateway does.
+MAX_REQUEST_BYTES = 1_000_000
+
+# How much of an oversized body we are willing to read and discard so the
+# client can finish writing it and read our 413 cleanly, instead of racing
+# an abrupt close (a client mid-write into a closed socket gets a
+# nondeterministic broken pipe, not the JSON-RPC error object this gate
+# promises). Bounded well above MAX_REQUEST_BYTES but still bounded, so an
+# attacker cannot turn this into the unbounded read the size check exists
+# to prevent -- past this ceiling we give up on a clean response and close.
+DRAIN_CEILING_BYTES = 10 * MAX_REQUEST_BYTES
+
+logger = logging.getLogger("mock_upstream")
 
 
 class MockMCPHandler(BaseHTTPRequestHandler):
-    def log_message(self, *_args) -> None:  # silence per-request logging
+    def log_message(self, *_args) -> None:  # silence per-request access logging
         pass
 
-    def do_POST(self) -> None:
-        length = int(self.headers.get("Content-Length", 0))
-        raw = self.rfile.read(length)
-        try:
-            msg = json.loads(raw)
-        except (ValueError, TypeError):
-            msg = {}
-
-        params = msg.get("params", {}) if isinstance(msg, dict) else {}
-        tool_name = params.get("name", "unknown")
-        arguments = params.get("arguments", {})
-        text = f"mock upstream: {tool_name} called with {json.dumps(arguments, sort_keys=True)}"
-
-        response = json.dumps(
-            {
-                "jsonrpc": "2.0",
-                "id": msg.get("id") if isinstance(msg, dict) else None,
-                "result": {"content": [{"type": "text", "text": text}]},
-            }
-        ).encode()
-
-        self.send_response(200)
+    def _send_json(self, payload: dict[str, Any], *, status: int) -> None:
+        response = json.dumps(payload).encode()
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(response)))
         self.end_headers()
         self.wfile.write(response)
+
+    def _reject(
+        self, event: str, code: int, message: str, *, status: int, rpc_id: Any = None
+    ) -> None:
+        # Security visibility (#518): every rejection is logged, separately
+        # from the per-request access log this handler otherwise silences,
+        # so a malformed or oversized request leaves a trace even though
+        # ordinary traffic does not.
+        logger.warning(
+            "rejected request: event=%s code=%s status=%s client=%s",
+            event, code, status, self.client_address[0],
+        )
+        self._send_json(
+            {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": rpc_id},
+            status=status,
+        )
+
+    def do_POST(self) -> None:
+        # Bounded request size: reject before reading the body, same boundary
+        # and error shape as MCPServer._handle_mcp's DOS-001 check.
+        content_length_header = self.headers.get("Content-Length")
+        try:
+            length = int(content_length_header) if content_length_header else 0
+        except ValueError:
+            self._reject("invalid_content_length", -32600, "Invalid Content-Length", status=400)
+            return
+        if length > MAX_REQUEST_BYTES:
+            self.rfile.read(min(length, DRAIN_CEILING_BYTES))
+            if length > DRAIN_CEILING_BYTES:
+                # Past the drain ceiling: do not read further, and do not
+                # reuse a connection whose unread tail could be misparsed as
+                # the start of the next request.
+                self.close_connection = True
+            self._reject("oversized_request", -32600, "Request body too large", status=413)
+            return
+
+        raw = self.rfile.read(length)
+
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            self._reject("parse_error", -32700, "Parse error", status=400)
+            return
+
+        if not isinstance(msg, dict):
+            self._reject("invalid_request", -32600, "Invalid Request", status=400)
+            return
+
+        rpc_id = msg.get("id")
+        method = msg.get("method", "")
+        if not isinstance(method, str) or not method:
+            self._reject("invalid_request", -32600, "Invalid Request", status=400, rpc_id=rpc_id)
+            return
+
+        params = msg.get("params", {})
+        if not isinstance(params, dict):
+            self._reject("invalid_request", -32600, "Invalid Request", status=400, rpc_id=rpc_id)
+            return
+
+        tool_name = params.get("name")
+        if not isinstance(tool_name, str) or not tool_name:
+            self._reject(
+                "invalid_params", -32602, "Invalid params: 'name' must be a non-empty string",
+                status=400, rpc_id=rpc_id,
+            )
+            return
+
+        arguments = params.get("arguments", {})
+        if not isinstance(arguments, dict):
+            self._reject(
+                "invalid_params", -32602, "Invalid params: 'arguments' must be an object",
+                status=400, rpc_id=rpc_id,
+            )
+            return
+
+        text = f"mock upstream: {tool_name} called with {json.dumps(arguments, sort_keys=True)}"
+        self._send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": rpc_id,
+                "result": {"content": [{"type": "text", "text": text}]},
+            },
+            status=200,
+        )
 
 
 def main() -> None:
@@ -56,6 +138,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=9001)
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.WARNING)
     server = HTTPServer((args.host, args.port), MockMCPHandler)
     print(f"mock upstream listening on {args.host}:{args.port}/mcp", flush=True)
     try:

--- a/tests/unit/test_mock_upstream_gate.py
+++ b/tests/unit/test_mock_upstream_gate.py
@@ -1,0 +1,288 @@
+"""Tests for scripts/mock_upstream.py's JSON-RPC request gate (#518).
+
+Spins up the real MockMCPHandler in-process against a random local port and
+issues raw HTTP requests, so these exercise the actual handler class rather
+than a reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import json
+import socket
+import sys
+import threading
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+from mock_upstream import MockMCPHandler  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def upstream():
+    server = HTTPServer(("127.0.0.1", 0), MockMCPHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server.server_port
+    server.shutdown()
+
+
+def _post(port: int, body: bytes, *, headers: dict[str, str] | None = None):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    hdrs = {"Content-Type": "application/json"}
+    if headers:
+        hdrs.update(headers)
+    conn.request("POST", "/mcp", body=body, headers=hdrs)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    return resp.status, json.loads(raw)
+
+
+VALID_REQUEST = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "tools/call",
+        "params": {"name": "echo", "arguments": {"message": "hi"}},
+    }
+).encode()
+
+
+# ---------------------------------------------------------------------------
+# Existing valid-request behavior must be unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_valid_request_returns_200_with_expected_shape(upstream):
+    status, body = _post(upstream, VALID_REQUEST)
+    assert status == 200
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == "req-1"
+    text = body["result"]["content"][0]["text"]
+    assert text == 'mock upstream: echo called with {"message": "hi"}'
+
+
+def test_valid_request_without_arguments_defaults_to_empty_dict(upstream):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "echo"}}
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 200
+    assert body["result"]["content"][0]["text"] == "mock upstream: echo called with {}"
+
+
+# ---------------------------------------------------------------------------
+# -32700 Parse error: malformed JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_returns_parse_error(upstream):
+    status, body = _post(upstream, b"{not valid json")
+    assert status == 400
+    assert body["jsonrpc"] == "2.0"
+    assert body["error"]["code"] == -32700
+    assert body["id"] is None
+
+
+def test_empty_body_returns_parse_error(upstream):
+    status, body = _post(upstream, b"")
+    assert status == 400
+    assert body["error"]["code"] == -32700
+
+
+# ---------------------------------------------------------------------------
+# -32600 Invalid Request: structurally wrong
+# ---------------------------------------------------------------------------
+
+
+def test_non_object_json_returns_invalid_request(upstream):
+    status, body = _post(upstream, b"[1, 2, 3]")
+    assert status == 400
+    assert body["error"]["code"] == -32600
+    assert body["id"] is None
+
+
+def test_missing_method_returns_invalid_request(upstream):
+    req = json.dumps({"jsonrpc": "2.0", "id": 3, "params": {"name": "echo"}}).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32600
+    assert body["id"] == 3
+
+
+def test_non_string_method_returns_invalid_request(upstream):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 4, "method": 7, "params": {"name": "echo"}}
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32600
+    assert body["id"] == 4
+
+
+def test_non_object_params_returns_invalid_request(upstream):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": "nope"}
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32600
+    assert body["id"] == 5
+
+
+# ---------------------------------------------------------------------------
+# -32602 Invalid params
+# ---------------------------------------------------------------------------
+
+
+def test_missing_tool_name_returns_invalid_params(upstream):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {}}
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+    assert body["id"] == 6
+
+
+def test_non_string_tool_name_returns_invalid_params(upstream):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {"name": 42}}
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+    assert body["id"] == 7
+
+
+def test_non_object_arguments_returns_invalid_params(upstream):
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": "nope"},
+        }
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+    assert body["id"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Bounded request size
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_request_rejected_before_parsing(upstream):
+    huge_args = "x" * 2_000_000
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"message": huge_args}},
+        }
+    ).encode()
+    status, resp = _post(upstream, body)
+    assert status == 413
+    assert resp["error"]["code"] == -32600
+    assert resp["id"] is None
+
+
+def test_far_oversized_request_beyond_the_drain_ceiling_still_gets_a_clean_response(upstream):
+    # Above DRAIN_CEILING_BYTES the server stops draining and closes instead,
+    # so this is allowed to surface as a connection-level failure on the
+    # client side rather than a parsed response -- covered separately so the
+    # two size regimes (bounded-drain vs. give-up-and-close) are both tested.
+    huge_args = "x" * 15_000_000
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"message": huge_args}},
+        }
+    ).encode()
+    with socket.create_connection(("127.0.0.1", upstream), timeout=5) as sock:
+        header = (
+            f"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+            f"Content-Type: application/json\r\nContent-Length: {len(body)}\r\n\r\n"
+        ).encode()
+        sock.sendall(header)
+        # Acceptable above the drain ceiling: the header alone already
+        # triggers rejection, so a broken pipe while writing the body is not
+        # a defect.
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            sock.sendall(body)
+        raw_response = sock.recv(65536)
+    assert b"413" in raw_response.split(b"\r\n", 1)[0]
+
+
+def test_request_at_the_limit_is_accepted(upstream):
+    # Build a request whose total serialized size sits just under the cap.
+    filler_len = 1_000_000 - 200
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"message": "x" * filler_len}},
+        }
+    ).encode()
+    assert len(body) < 1_000_000
+    status, resp = _post(upstream, body)
+    assert status == 200
+    assert resp["id"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Security visibility: rejections are logged (#518)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_is_logged(upstream, caplog):
+    with caplog.at_level("WARNING", logger="mock_upstream"):
+        _post(upstream, b"{not valid json")
+    assert any("event=parse_error" in r.message for r in caplog.records)
+
+
+def test_invalid_request_is_logged(upstream, caplog):
+    with caplog.at_level("WARNING", logger="mock_upstream"):
+        _post(upstream, b"[1, 2, 3]")
+    assert any("event=invalid_request" in r.message for r in caplog.records)
+
+
+def test_invalid_params_is_logged(upstream, caplog):
+    req = json.dumps(
+        {"jsonrpc": "2.0", "id": 11, "method": "tools/call", "params": {}}
+    ).encode()
+    with caplog.at_level("WARNING", logger="mock_upstream"):
+        _post(upstream, req)
+    assert any("event=invalid_params" in r.message for r in caplog.records)
+
+
+def test_oversized_request_is_logged(upstream, caplog):
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"message": "x" * 2_000_000}},
+        }
+    ).encode()
+    with caplog.at_level("WARNING", logger="mock_upstream"):
+        _post(upstream, body)
+    assert any("event=oversized_request" in r.message for r in caplog.records)
+
+
+def test_valid_request_is_not_logged(upstream, caplog):
+    with caplog.at_level("WARNING", logger="mock_upstream"):
+        _post(upstream, VALID_REQUEST)
+    assert caplog.records == []


### PR DESCRIPTION
Addresses #518

Adds a bounded JSON-RPC validation gate to the mock MCP upstream:

- rejects malformed JSON with -32700
- rejects structurally invalid requests with -32600
- rejects invalid tool names/arguments with -32602
- bounds request size before parsing
- logs rejected requests
- preserves existing valid-request behavior

The unmodified handler also crashed on non-object `params`; this is now covered by a regression test.

This intentionally does not close all of #518: strict jsonrpc/id validation, nested argument limits, non-standard JSON values such as NaN, and tool allowlisting remain follow-up scope.

## Verification

- 19 focused tests added
- unit suite: 1200 passed, 6 skipped, 6 pre-existing TPM-environment failures reproduced on unmodified `main`
- ruff clean
- mypy clean on the actual `src/cmcp_runtime/` package
- bandit: 0 findings

All required checks are clean relative to baseline; the six unit-test failures are pre-existing TPM environment failures reproduced identically on unmodified main.
