### PR TITLE
docs: document project sponsorship roles

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,6 +2,10 @@
 
 Organizations using cMCP in production or evaluation are listed here.
 
+Project funding and in-kind support are recognized separately in
+[SPONSORS.md](SPONSORS.md). Sponsorship does not imply adoption, governance
+authority, or ownership of the project.
+
 To add yours, open a PR adding a line with your organization, the use case, and the month you started. Anything you are not able to say publicly, leave out; a one-line entry is worth more than a case study you have to get approved.
 
 If you are running cMCP but cannot be named, we would still like to hear where it bends: open a [Discussion](https://github.com/orgs/agentrust-io/discussions) or contact the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-cMCP is a self-hosted gateway that you deploy and operate. agentrust-io and OPAQUE run no service on your behalf and receive no data from your deployment: cMCP sends no telemetry, analytics, or usage data to us.
+cMCP is a self-hosted gateway that you deploy and operate. The cMCP project runs no service on your behalf and receives no data from your deployment: cMCP sends no telemetry, analytics, or usage data to the project.
 
 What cMCP processes: as an MCP gateway, cMCP handles the MCP requests and responses that pass through it in order to enforce policy and produce attestation. This traffic is processed inside the trusted execution environment (TEE) you run and is governed by your own configuration and your privacy commitments to your users. cMCP is designed so that a privileged operator cannot silently exfiltrate this data.
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,20 @@
+# Sponsors
+
+cMCP is an open-source AgenTrust project governed through its published
+project processes. Sponsors provide funding, engineering time, infrastructure,
+or other in-kind support. Sponsorship does not confer project ownership,
+governance authority, or control over technical decisions.
+
+## Current sponsors
+
+### OPAQUE Systems
+
+Founding engineering and infrastructure sponsor, and contributor to the
+project's confidential-computing integrations.
+
+## Recognition policy
+
+Sponsor recognition records support for the project. Adopters are listed
+separately in [ADOPTERS.md](ADOPTERS.md), maintainers in
+[MAINTAINERS.md](MAINTAINERS.md), and governance roles in
+[GOVERNANCE.md](GOVERNANCE.md).

--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -1,0 +1,10 @@
+# Sponsors
+
+cMCP is an open-source AgenTrust project. Sponsors support the project without
+receiving project ownership or governance authority.
+
+OPAQUE Systems is recognized as a founding engineering and infrastructure
+sponsor and as a contributor to the project's confidential-computing
+integrations.
+
+See the repository's [sponsor policy and recognition page](https://github.com/agentrust-io/cmcp/blob/main/SPONSORS.md) for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,7 @@ nav:
       - Hardware Validation: testing/hardware-validation.md
   - Project:
       - Limitations: limitations.md
+      - Sponsors: sponsors.md
       - Changelog: https://github.com/agentrust-io/cmcp/blob/main/CHANGELOG.md
       - Contributing: https://github.com/agentrust-io/cmcp/blob/main/CONTRIBUTING.md
       - Governance: https://github.com/agentrust-io/cmcp/blob/main/GOVERNANCE.md


### PR DESCRIPTION
## Summary

- add a dedicated sponsor policy and recognition page
- separate sponsor recognition from adoption and project governance
- use project-level language in the self-hosted privacy notice
- add sponsor information to the documentation site

## Validation

- `git diff --check`