### PR TITLE
docs: update project contact email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hardware-attested MCP runtime, TEE-enforced policy and TRACE Clai
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
-    { name = "AgenTrust Contributors", email = "oss@agentrust-io.com" },
+    { name = "AgenTrust Contributors", email = "imransiddique@live.com" },
 ]
 keywords = ["mcp", "tee", "attestation", "security", "ai-agents", "cedar"]
 classifiers = [


### PR DESCRIPTION
## Summary

- replace a non-operational project email with the current contact address
- leave example identities and protocol data unchanged

## Validation

- git diff --check
- verified the retired operational address is absent