### PR TITLE
fix(startup): _VALID_PROVIDERS was missing azure-cvm-sev-snp

### DIFF
--- a/src/cmcp_runtime/startup.py
+++ b/src/cmcp_runtime/startup.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 # audit/trace_claim.py - kept as a local constant to avoid a circular import.
 _VALID_PROVIDERS: frozenset[str] = frozenset({
     "sev-snp",
+    "azure-cvm-sev-snp",
     "tdx",
     "opaque",
     "tpm",

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -476,3 +476,20 @@ def test_an_unknown_profile_is_a_config_error(tmp_path, monkeypatch):
     monkeypatch.setenv("CMCP_DEV_MODE", "1")
     with pytest.raises(SystemExit):
         run_startup(str(config_path))
+
+
+def test_valid_providers_matches_the_map_it_says_it_mirrors():
+    """The comment above ``_VALID_PROVIDERS`` says it mirrors the keys of
+    ``_PROVIDER_MAP``. It did not: ``azure-cvm-sev-snp`` was in the map and not in
+    the set, so ``_validate_attestation_report`` raised
+    ``ATTESTATION_PROVIDER_INVALID`` on every Azure confidential-VM report and the
+    gateway exited. Found by @zohebk8s while wiring #552's report_data binding,
+    which applies to that provider and could not be reached through this path.
+
+    Comparing the two sets rather than asserting one membership, so the next
+    provider added to either side cannot drift the same way.
+    """
+    from cmcp_runtime.audit.trace_claim import _PROVIDER_MAP
+    from cmcp_runtime.startup import _VALID_PROVIDERS
+
+    assert _VALID_PROVIDERS == frozenset(_PROVIDER_MAP)

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -492,4 +492,5 @@ def test_valid_providers_matches_the_map_it_says_it_mirrors():
     from cmcp_runtime.audit.trace_claim import _PROVIDER_MAP
     from cmcp_runtime.startup import _VALID_PROVIDERS
 
-    assert _VALID_PROVIDERS == frozenset(_PROVIDER_MAP)
+    mapped = frozenset(_PROVIDER_MAP)
+    assert mapped == _VALID_PROVIDERS


### PR DESCRIPTION
Follow-up to #563, from a defect @zohebk8s found and flagged while wiring #552's `report_data` measurement binding.

## The defect

`startup.py:55` says:

> Mirrors the keys of `_PROVIDER_MAP` in `audit/trace_claim.py`

It did not.

| | contents |
|---|---|
| `_VALID_PROVIDERS` (`startup.py:57`) | `sev-snp`, `tdx`, `opaque`, `tpm`, `software-only` |
| `_PROVIDER_MAP` (`audit/trace_claim.py:25`) | the same five plus `azure-cvm-sev-snp` |

So `_validate_attestation_report` raised `ATTESTATION_PROVIDER_INVALID` on every Azure confidential-VM report and the gateway exited at startup. #563 applies the measurement binding to `azure-cvm-sev-snp`, which meant it added behaviour for a provider this path could not select.

## The guard

The test compares the two sets rather than asserting that one name is present. Asserting membership fixes today's instance and leaves the class open; comparing the sets means the next provider added to either side cannot drift the same way, which is what the comment already promised.

Proved it fails for the right reason by reverting only the one-line addition and keeping the test:

```
E     Extra items in the right set:
E     'azure-cvm-sev-snp'
FAILED tests/unit/test_startup.py::test_valid_providers_matches_the_map_it_says_it_mirrors
```

With the entry restored: `tests/unit/test_startup.py` and `tests/unit/test_trace_claim.py`, 55 passed.

## Not covered

Whether an Azure CVM gateway then completes startup end to end on real hardware. This removes a gate that rejected it before anything else ran; it is not a claim that the rest of the path is exercised.