### PR TITLE
fix: enforce a per-string length cap on tool arguments (#562)

### DIFF
--- a/scripts/mock_upstream.py
+++ b/scripts/mock_upstream.py
@@ -43,6 +43,26 @@ DRAIN_CEILING_BYTES = 10 * MAX_REQUEST_BYTES
 _MAX_ARG_DEPTH = 20
 _MAX_ARG_KEYS = 256
 
+# #562: docs/spec/proxy-security.md's Fuzzing Definition of Done specs
+# MAX_STRING_LENGTH at 1MB per string field, separate from the depth/key
+# caps above. A single oversized string can sit inside an otherwise
+# shallow, low-key-count payload and slip past both of those unbounded,
+# up to whatever the whole-body byte cap happens to be.
+#
+# Not set to the spec's literal 1MB: that would equal MAX_REQUEST_BYTES
+# itself, and a 1MB string plus any JSON structure around it already
+# exceeds the whole-body cap, so the check could never fire before
+# DOS-001's size rejection already had. Set to half of MAX_REQUEST_BYTES
+# instead, so a single string cannot consume the whole request budget and
+# the cap is actually reachable. Worth revisiting to the spec's literal
+# value if MAX_REQUEST_BYTES itself is ever raised toward the spec's
+# stated 10MB (see #562).
+#
+# Checked as UTF-8 byte length, not character count, since a codepoint
+# count understates the actual memory and processing cost of multi-byte
+# text.
+_MAX_ARG_STRING_LENGTH = MAX_REQUEST_BYTES // 2
+
 logger = logging.getLogger("mock_upstream")
 
 
@@ -56,23 +76,41 @@ def _valid_rpc_id(value: Any) -> bool:
     return value is None or (isinstance(value, (str, int, float)) and not isinstance(value, bool))
 
 
+def _over_string_cap(text: str) -> bool:
+    return len(text.encode("utf-8")) > _MAX_ARG_STRING_LENGTH
+
+
+def _object_shape_violation(value: dict[str, Any], depth: int) -> str | None:
+    if len(value) > _MAX_ARG_KEYS:
+        return f"object has more than {_MAX_ARG_KEYS} keys"
+    for key, child in value.items():
+        # Keys carry the same cost as values and are not covered by the key
+        # *count* cap above, so a single huge key would otherwise slip
+        # through every check here.
+        if isinstance(key, str) and _over_string_cap(key):
+            return f"object key over the length cap of {_MAX_ARG_STRING_LENGTH} bytes"
+        violation = _arg_shape_violation(child, depth=depth + 1)
+        if violation is not None:
+            return violation
+    return None
+
+
 def _arg_shape_violation(value: Any, *, depth: int = 0) -> str | None:
-    """Return a message describing the first depth/key-count violation found
-    under `value`, or None if it fits within `_MAX_ARG_DEPTH` / `_MAX_ARG_KEYS`."""
+    """Return a message describing the first depth/key-count/string-length
+    violation found under `value`, or None if it fits within `_MAX_ARG_DEPTH` /
+    `_MAX_ARG_KEYS` / `_MAX_ARG_STRING_LENGTH`."""
     if depth > _MAX_ARG_DEPTH:
         return f"arguments nested past the depth cap of {_MAX_ARG_DEPTH}"
     if isinstance(value, dict):
-        if len(value) > _MAX_ARG_KEYS:
-            return f"object has more than {_MAX_ARG_KEYS} keys"
-        for child in value.values():
-            violation = _arg_shape_violation(child, depth=depth + 1)
-            if violation is not None:
-                return violation
-    elif isinstance(value, list):
+        return _object_shape_violation(value, depth)
+    if isinstance(value, list):
         for child in value:
             violation = _arg_shape_violation(child, depth=depth + 1)
             if violation is not None:
                 return violation
+        return None
+    if isinstance(value, str) and _over_string_cap(value):
+        return f"string value over the length cap of {_MAX_ARG_STRING_LENGTH} bytes"
     return None
 
 

--- a/src/cmcp_runtime/mcp/server.py
+++ b/src/cmcp_runtime/mcp/server.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 # Endpoints exempt from bearer-token auth (Kubernetes liveness / readiness probes)
 _AUTH_EXEMPT_PATHS = {"/health", "/readyz"}
 
+# DOS-001: default ceiling on a single request body. Overridable per
+# deployment via MCPServer(max_request_bytes=...). Named here rather than
+# left inline on the constructor so the argument-shape caps below can be
+# derived from it instead of restating the number.
+_DEFAULT_MAX_REQUEST_BYTES = 1_000_000
+
 # #518: DOS-001's byte cap bounds total size, not shape. A payload well under
 # the limit can still push toward Python's recursion limit through deep
 # nesting, or cost real time to iterate through a flat object with thousands
@@ -50,6 +56,29 @@ _AUTH_EXEMPT_PATHS = {"/health", "/readyz"}
 # unified per qubeena07's review on #518.
 _MAX_ARG_DEPTH = 20
 _MAX_ARG_KEYS = 256
+
+# #562: docs/spec/proxy-security.md's Fuzzing Definition of Done specs
+# MAX_STRING_LENGTH at 1MB per string field, separate from the depth/key
+# caps above. A single oversized string can sit inside an otherwise
+# shallow, low-key-count payload and slip past both of those unbounded,
+# up to whatever the whole-body byte cap happens to be.
+#
+# Not set to the spec's literal 1MB: that equals the whole-body default
+# below, and a 1MB string plus any JSON structure around it already
+# exceeds that cap, so the check could never fire before DOS-001's size
+# rejection already had. Derived from the default instead, so a single
+# string cannot consume the whole request budget, the cap is actually
+# reachable, and raising the default carries this along with it rather
+# than silently leaving it behind. This is scoped against the *default*
+# max_request_bytes; a deployment that configures a smaller value simply
+# has the whole-body cap bind first, which is a safe direction to fail
+# in, not a gap. Worth revisiting to the spec's literal value if the
+# default is ever raised toward the spec's stated 10MB (see #562).
+#
+# Checked as UTF-8 byte length, not character count, since a codepoint
+# count understates the actual memory and processing cost of multi-byte
+# text.
+_MAX_ARG_STRING_LENGTH = _DEFAULT_MAX_REQUEST_BYTES // 2
 
 
 def _reject_nan_and_infinity(text: str) -> float:
@@ -62,23 +91,41 @@ def _valid_rpc_id(value: Any) -> bool:
     return value is None or (isinstance(value, (str, int, float)) and not isinstance(value, bool))
 
 
+def _over_string_cap(text: str) -> bool:
+    return len(text.encode("utf-8")) > _MAX_ARG_STRING_LENGTH
+
+
+def _object_shape_violation(value: dict[str, Any], depth: int) -> str | None:
+    if len(value) > _MAX_ARG_KEYS:
+        return f"object has more than {_MAX_ARG_KEYS} keys"
+    for key, child in value.items():
+        # Keys carry the same cost as values and are not covered by the key
+        # *count* cap above, so a single huge key would otherwise slip
+        # through every check here.
+        if isinstance(key, str) and _over_string_cap(key):
+            return f"object key over the length cap of {_MAX_ARG_STRING_LENGTH} bytes"
+        violation = _arg_shape_violation(child, depth=depth + 1)
+        if violation is not None:
+            return violation
+    return None
+
+
 def _arg_shape_violation(value: Any, *, depth: int = 0) -> str | None:
-    """Return a message describing the first depth/key-count violation found
-    under `value`, or None if it fits within `_MAX_ARG_DEPTH` / `_MAX_ARG_KEYS`."""
+    """Return a message describing the first depth/key-count/string-length
+    violation found under `value`, or None if it fits within `_MAX_ARG_DEPTH` /
+    `_MAX_ARG_KEYS` / `_MAX_ARG_STRING_LENGTH`."""
     if depth > _MAX_ARG_DEPTH:
         return f"arguments nested past the depth cap of {_MAX_ARG_DEPTH}"
     if isinstance(value, dict):
-        if len(value) > _MAX_ARG_KEYS:
-            return f"object has more than {_MAX_ARG_KEYS} keys"
-        for child in value.values():
-            violation = _arg_shape_violation(child, depth=depth + 1)
-            if violation is not None:
-                return violation
-    elif isinstance(value, list):
+        return _object_shape_violation(value, depth)
+    if isinstance(value, list):
         for child in value:
             violation = _arg_shape_violation(child, depth=depth + 1)
             if violation is not None:
                 return violation
+        return None
+    if isinstance(value, str) and _over_string_cap(value):
+        return f"string value over the length cap of {_MAX_ARG_STRING_LENGTH} bytes"
     return None
 
 
@@ -255,7 +302,7 @@ class MCPServer:
         audit_chain: AuditChain | None = None,
         bearer_token: str | None = None,
         session: SessionState | None = None,
-        max_request_bytes: int = 1_000_000,
+        max_request_bytes: int = _DEFAULT_MAX_REQUEST_BYTES,
     ) -> None:
         self._proxy = proxy
         self._session_manager = session_manager
@@ -506,7 +553,8 @@ class MCPServer:
         tool_name: str = params.get("name", "").lower()
         arguments: dict[str, Any] = params.get("arguments", {})
 
-        # #518: depth/key-count cap, matching scripts/mock_upstream.py.
+        # #518/#562: depth, key-count and string-length caps, matching
+        # scripts/mock_upstream.py.
         violation = _arg_shape_violation(arguments)
         if violation is not None:
             return JSONResponse(

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -672,6 +672,27 @@ def test_depth_cap_violation_inside_a_list_is_caught():
     assert resp.json()["error"]["code"] == -32602
 
 
+def test_well_formed_list_in_arguments_is_accepted():
+    """The list walk must fall through cleanly when nothing inside it violates a
+    cap. Without this the only list coverage is the rejection path, which would
+    still pass if the walk rejected every list it saw."""
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "t",
+                "arguments": {"items": [1, "ok", {"nested": ["fine"]}, None]},
+            },
+            "id": 1,
+        },
+    )
+    assert resp.status_code != 400
+
+
 def test_arguments_within_key_cap_is_allowed():
     server = _make_server()
     client = TestClient(server.app, raise_server_exceptions=False)

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from starlette.testclient import TestClient
 
-from cmcp_runtime.mcp.server import _MAX_ARG_DEPTH, _MAX_ARG_KEYS, MCPServer
+from cmcp_runtime.mcp.server import (
+    _MAX_ARG_DEPTH,
+    _MAX_ARG_KEYS,
+    _MAX_ARG_STRING_LENGTH,
+    MCPServer,
+)
 
 
 def _make_server(bearer_token: str | None = None) -> MCPServer:
@@ -694,6 +700,91 @@ def test_arguments_exceeding_key_cap_returns_invalid_params():
             "params": {"name": "t", "arguments": arguments},
             "id": 1,
         },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32602
+
+
+# ── #562: argument string-length cap, matching scripts/mock_upstream.py ─────
+
+def test_string_within_length_cap_is_allowed():
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "t", "arguments": {"text": "a" * 1000}},
+            "id": 1,
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_string_exceeding_length_cap_returns_invalid_params():
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "t", "arguments": {"text": "a" * (_MAX_ARG_STRING_LENGTH + 1)}},
+            "id": 1,
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32602
+
+
+def test_oversized_object_key_returns_invalid_params():
+    """A huge key is as expensive as a huge value and is not bounded by the
+    key *count* cap, so it must be rejected on its own."""
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+    key = "a" * (_MAX_ARG_STRING_LENGTH + 1)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "t", "arguments": {key: 1}},
+            "id": 1,
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32602
+
+
+def test_multibyte_string_length_measured_in_bytes_not_characters():
+    """A 4-byte-per-char string well under the byte cap in character count
+    but over it in UTF-8 bytes must still be rejected."""
+    # U+1F600 (😀) is 4 bytes in UTF-8, 1 codepoint in Python's len(). Choose
+    # a character count that clears the string cap in bytes while staying
+    # well under the server's default max_request_bytes once JSON-encoded.
+    char_count = (_MAX_ARG_STRING_LENGTH // 4) + 1
+    oversized_by_bytes = "\U0001F600" * char_count
+    assert len(oversized_by_bytes.encode("utf-8")) > _MAX_ARG_STRING_LENGTH
+    server = _make_server()
+    client = TestClient(server.app, raise_server_exceptions=False)
+    # Built and encoded by hand with ensure_ascii=False, rather than passed
+    # via the json= kwarg: both json.dumps' default and httpx's json=
+    # encoder escape each emoji to a 12-byte \uXXXX\uXXXX surrogate pair,
+    # inflating the wire size far past the string's actual UTF-8 length and
+    # tripping max_request_bytes instead of the check this test targets.
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "t", "arguments": {"text": oversized_by_bytes}},
+            "id": 1,
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+    assert len(body) < 1_000_000
+    resp = client.post(
+        "/mcp", content=body, headers={"Content-Type": "application/json"}
     )
     assert resp.status_code == 400
     assert resp.json()["error"]["code"] == -32602

--- a/tests/unit/test_mock_upstream_gate.py
+++ b/tests/unit/test_mock_upstream_gate.py
@@ -20,7 +20,11 @@ from typing import Any
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
-from mock_upstream import MockMCPHandler  # noqa: E402
+from mock_upstream import (  # noqa: E402
+    _MAX_ARG_STRING_LENGTH,
+    MAX_REQUEST_BYTES,
+    MockMCPHandler,
+)
 
 
 @pytest.fixture(scope="module")
@@ -227,17 +231,23 @@ def test_far_oversized_request_beyond_the_drain_ceiling_still_gets_a_clean_respo
 
 
 def test_request_at_the_limit_is_accepted(upstream):
-    # Build a request whose total serialized size sits just under the cap.
-    filler_len = 1_000_000 - 200
+    # Build a request whose total serialized size sits just under the whole
+    # body cap. Split across two string fields, each under the separate
+    # per-string length cap (#562), so this test stays targeted at the
+    # DOS-001 whole-body boundary rather than also tripping the string cap.
+    field_len = _MAX_ARG_STRING_LENGTH - 100
     body = json.dumps(
         {
             "jsonrpc": "2.0",
             "id": 10,
             "method": "tools/call",
-            "params": {"name": "echo", "arguments": {"message": "x" * filler_len}},
+            "params": {
+                "name": "echo",
+                "arguments": {"a": "x" * field_len, "b": "x" * field_len},
+            },
         }
     ).encode()
-    assert len(body) < 1_000_000
+    assert len(body) < MAX_REQUEST_BYTES
     status, resp = _post(upstream, body)
     assert status == 200
     assert resp["id"] == 10
@@ -415,6 +425,109 @@ def test_arguments_within_key_count_cap_are_accepted(upstream):
     ).encode()
     status, body = _post(upstream, req)
     assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# Argument string-length cap (#562, docs/spec/proxy-security.md MAX_STRING_LENGTH)
+# ---------------------------------------------------------------------------
+
+
+def test_string_within_length_cap_is_accepted(upstream):
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 34,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"text": "a" * 1000}},
+        }
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 200
+
+
+def test_string_past_length_cap_returns_invalid_params(upstream):
+    # Past the string cap but comfortably under MAX_REQUEST_BYTES, so this
+    # exercises the string-length check itself, not the whole-body size gate.
+    assert _MAX_ARG_STRING_LENGTH + 1 < MAX_REQUEST_BYTES
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 35,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"text": "a" * (_MAX_ARG_STRING_LENGTH + 1)}},
+        }
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+    assert body["id"] == 35
+
+
+def test_oversized_object_key_returns_invalid_params(upstream):
+    """A huge key is as expensive as a huge value and is not bounded by the
+    key *count* cap, so it must be rejected on its own."""
+    key = "a" * (_MAX_ARG_STRING_LENGTH + 1)
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 38,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {key: 1}},
+        }
+    ).encode()
+    # Reachable: over the string cap but still under the whole-body cap, so
+    # this exercises the key check rather than DOS-001's size rejection.
+    assert len(req) < MAX_REQUEST_BYTES
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+    assert body["id"] == 38
+
+
+def test_oversized_string_nested_inside_arguments_is_caught(upstream):
+    """The cap applies at any depth, not only to top-level string values."""
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 36,
+            "method": "tools/call",
+            "params": {
+                "name": "echo",
+                "arguments": {"child": {"text": "a" * (_MAX_ARG_STRING_LENGTH + 1)}},
+            },
+        }
+    ).encode()
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
+
+
+def test_multibyte_string_length_measured_in_bytes_not_characters(upstream):
+    """A 4-byte-per-char string well under the byte cap in character count
+    but over it in UTF-8 bytes must still be rejected."""
+    # U+1F600 (😀) is 4 bytes in UTF-8, 1 codepoint in Python's len(). Choose
+    # a character count that clears the string cap in bytes while staying
+    # well under MAX_REQUEST_BYTES once JSON-encoded.
+    char_count = (_MAX_ARG_STRING_LENGTH // 4) + 1
+    oversized_by_bytes = "\U0001F600" * char_count
+    assert len(oversized_by_bytes.encode("utf-8")) > _MAX_ARG_STRING_LENGTH
+    # ensure_ascii=False: the default True would escape each emoji to a
+    # 12-byte \uXXXX\uXXXX surrogate pair, inflating the wire size far past
+    # the string's actual UTF-8 length and tripping MAX_REQUEST_BYTES
+    # instead of the check this test targets.
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 37,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"text": oversized_by_bytes}},
+        },
+        ensure_ascii=False,
+    ).encode()
+    assert len(req) < MAX_REQUEST_BYTES
+    status, body = _post(upstream, req)
+    assert status == 400
+    assert body["error"]["code"] == -32602
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mock_upstream_gate.py
+++ b/tests/unit/test_mock_upstream_gate.py
@@ -484,6 +484,24 @@ def test_oversized_object_key_returns_invalid_params(upstream):
     assert body["id"] == 38
 
 
+def test_well_formed_list_in_arguments_is_accepted(upstream):
+    """The list walk must fall through cleanly when nothing inside it violates a
+    cap, mirroring the same case in tests/unit/test_mcp_server_auth.py."""
+    req = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": {
+                "name": "echo",
+                "arguments": {"items": [1, "ok", {"nested": ["fine"]}, None]},
+            },
+        }
+    ).encode()
+    status, _ = _post(upstream, req)
+    assert status == 200
+
+
 def test_oversized_string_nested_inside_arguments_is_caught(upstream):
     """The cap applies at any depth, not only to top-level string values."""
     req = json.dumps(


### PR DESCRIPTION
Closes #562.

`docs/spec/proxy-security.md`'s Fuzzing Definition of Done specs `MAX_STRING_LENGTH = 1 * 1024 * 1024  # 1MB per string field`. It is not implemented anywhere in `src/` or `scripts/`. The depth and key-count caps that landed in #556 and #561 bound how deep and how wide a payload is, not how large any one piece of it is, so a single oversized string sitting inside an otherwise shallow, low-key-count `arguments` object passes both of them unbounded, up to whatever the whole-body byte cap happens to be.

This extends the existing `_arg_shape_violation` walk in both files with a UTF-8 byte length check.

## Why the cap is not the spec's literal 1MB

This is the part I would look at first if I were reviewing it.

The spec's `MAX_STRING_LENGTH` is 1MB. `MAX_REQUEST_BYTES` is also 1MB in both files today. A 1MB string plus the JSON structure around it already exceeds the whole-body cap, so a check at the literal spec value could never fire before DOS-001's size rejection already had. Implemented at the spec's number, this would have been dead code that reads like a control.

So the cap is half the whole-body limit instead, and it is derived from a named constant rather than a restated literal:

```python
_DEFAULT_MAX_REQUEST_BYTES = 1_000_000
...
_MAX_ARG_STRING_LENGTH = _DEFAULT_MAX_REQUEST_BYTES // 2
```

Hoisting the constructor default into `_DEFAULT_MAX_REQUEST_BYTES` is what makes that derivation possible without stating `1_000_000` twice. Raising the default now carries the string cap along with it instead of silently leaving it behind at a stale absolute number.

Verified reachable rather than assumed: an over-cap string is 500,101 bytes on the wire against a 1,000,000 byte body cap, and an over-cap key is 500,099. Both land inside the window where the string check is the thing that rejects them.

This is scoped against the *default* `max_request_bytes`. A deployment that configures something smaller just has the whole-body cap bind first, which is a safe direction to fail in rather than a gap.

## Object keys, not only values

`_MAX_ARG_KEYS` bounds how many keys an object has, not how large each one is. A single huge key would otherwise pass every check in this function, so keys are measured against the same cap. `_object_shape_violation` was extracted to hold that without pushing `_arg_shape_violation` past the complexity limit.

## Byte length, not character count

Measured as UTF-8 bytes. A codepoint count understates the real memory and processing cost of multi-byte text, and it is the byte length that the whole-body cap is already denominated in, so the two caps now speak the same unit. There is a test for a string that is under the cap by characters and over it by bytes.

## What I am deliberately not doing here

**`MAX_REQUEST_BYTES`, 10MB in the spec versus 1MB in both implementations.** Flagged on #562 rather than resolved. It is not obvious whether 1MB was a deliberate tightening or spec drift, and picking a number is a maintainer call, not one to make inside a change scoped to a different constant. This PR works around the mismatch rather than resolving it.

**`MAX_PARSE_TIME_MS = 100`.** Also unenforced anywhere, also left open on #562. A real wall-clock bound on `json.loads` needs either a signal-based timeout, which does not work on the Windows CI legs this repo runs, or an executor or subprocess. That is a design decision rather than a missing check.

**`params.name` is not shape-checked.** It is a string field, so the spec's `MAX_STRING_LENGTH` arguably covers it, but it sits outside the `arguments` walk this PR extends and is bounded by the whole-body cap today. Naming it rather than widening the scope of a change that already touches two files.

**`server.py` still does not require `arguments` to be an object,** while the mock does. That gap was raised on #561 and left alone deliberately. One behaviour note for the record: a bare oversized string passed as `arguments` now gets rejected by the string cap on the gateway side, where before it fell through the shape walk untouched. Stricter, in the safe direction, but it is a change on a path that was previously discussed.

## On the duplication

Worth stating plainly, since it was noted on #561 that the caps are kept in sync by comment reference rather than by shared code. This change makes that worse, not better: it is now three constants and three functions duplicated across `scripts/mock_upstream.py` and `src/cmcp_runtime/mcp/server.py`.

The reason is that `scripts/mock_upstream.py` imports stdlib only. Giving it a shared module to import from `cmcp_runtime` would cost it the standalone property that lets it run as demo scaffolding from `docker-compose.yml` and `docs/quickstart.md` without the package installed. I did not think that trade was mine to make unilaterally, so I kept the duplication and the comment-reference sync. If the preference is a shared module and the mock taking a dependency on the package, that is a small follow-up and I am happy to do it.

The two copies are byte-identical, which is at least checkable.

## Verification

```
cap parity        : server 500,000 == mock 500,000
reachable         : over-cap string = 500,101 bytes on the wire vs the 1,000,000 body cap
                    over-cap key    = 500,099 bytes
helpers identical : diff across both files is empty

over-cap string value            -> string value over the length cap of 500000 bytes
over-cap object key              -> object key over the length cap of 500000 bytes
over-cap string in list          -> string value over the length cap of 500000 bytes
over-cap bare string arguments   -> string value over the length cap of 500000 bytes
at-cap string                    -> None          (boundary is >, not >=)
multibyte over cap by bytes only -> string value over the length cap of 500000 bytes
```

- `tests/unit/test_mock_upstream_gate.py` and `tests/unit/test_mcp_server_auth.py`: 90 passed, 9 of them new. Both suites drive the real handler over a socket or the real ASGI app rather than reimplementing the rules.
- Full `tests/unit`: 1338 passed. The 6 `test_startup.py` failures I see locally are `FileNotFoundError: 'tpm2_pcrread'`, reproduce identically on a clean `origin/main` with this diff stashed, and are a missing tpm2-tools binary on my machine rather than anything from this change.
- `ruff check` on all four touched files is clean apart from one pre-existing `T201 print` at `scripts/mock_upstream.py:241`, confirmed pre-existing on main the same way. Left alone as unrelated.

Based on `origin/main` at a2893da, after #556 and #561 landed, so the diff here is only this change.
