### PR TITLE
docs: make proxy-security.md's MAX_STRING_LENGTH derivable (#562)

### DIFF
--- a/docs/spec/proxy-security.md
+++ b/docs/spec/proxy-security.md
@@ -38,8 +38,24 @@ These constants are hard-coded in the proxy implementation. They are not configu
 MAX_REQUEST_BYTES = 10 * 1024 * 1024  # 10MB
 MAX_JSON_NESTING_DEPTH = 64
 MAX_PARSE_TIME_MS = 100
-MAX_STRING_LENGTH = 1 * 1024 * 1024   # 1MB per string field
+MAX_STRING_LENGTH = MAX_REQUEST_BYTES // 2   # per string field, see invariant below
 ```
+
+### MAX_STRING_LENGTH is a ratio, not an absolute
+
+`MAX_STRING_LENGTH` must stay meaningfully below `MAX_REQUEST_BYTES`, and it is written above as a derivation rather than a literal so that it cannot drift out of that relationship.
+
+The invariant matters because violating it produces a check that reads like a control and can never fire. A single string at or above the whole-body cap makes a request the body-size check already rejects, so the per-string check is unreachable on every input that survives long enough to reach it. That is worse than an absent check: an absent control is visible as missing, while a present one passes review, passes an audit read of the source, and counts toward this Definition of Done.
+
+An implementation MUST derive the per-string cap from whatever whole-body cap it enforces. It MUST NOT restate the value as a literal, since a later change to the body cap then silently recreates the unreachable condition at a new ratio.
+
+### Open: MAX_REQUEST_BYTES disagrees with the implementation
+
+This document states 10MB. Both implementations enforce 1MB: `scripts/mock_upstream.py` and `MCPServer.__init__` in `src/cmcp_runtime/mcp/server.py`.
+
+At the implemented 1MB, the per-string cap this document originally stated as a literal 1MB was exactly the whole-body cap, which is how the unreachable case above was found. Deriving the cap removes the dead-code hazard at either value, but the disagreement itself is still open: nothing records whether 1MB was a deliberate tightening or drift from this spec.
+
+Tracked on #562. Implementers should follow the enforced body cap and the ratio above until that is settled, rather than raising a body cap to match this document.
 
 ## Malformed Input Handling
 

--- a/docs/spec/proxy-security.md
+++ b/docs/spec/proxy-security.md
@@ -55,7 +55,7 @@ This document states 10MB. Both implementations enforce 1MB: `scripts/mock_upstr
 
 At the implemented 1MB, the per-string cap this document originally stated as a literal 1MB was exactly the whole-body cap, which is how the unreachable case above was found. Deriving the cap removes the dead-code hazard at either value, but the disagreement itself is still open: nothing records whether 1MB was a deliberate tightening or drift from this spec.
 
-Tracked on #562. Implementers should follow the enforced body cap and the ratio above until that is settled, rather than raising a body cap to match this document.
+Tracked on #573. Implementers should follow the enforced body cap and the ratio above until that is settled, rather than raising a body cap to match this document.
 
 ## Malformed Input Handling
 


### PR DESCRIPTION
Follow-up to the #570 review, where you said:

> That leaves the spec itself stating a number that cannot be enforced as written. Not your problem in this PR, and worth fixing separately so the next person implementing from that document does not reach the same conclusion the hard way.

This is that fix. Docs only, no source touched.

## What was wrong

`MAX_STRING_LENGTH = 1 * 1024 * 1024` is a literal, and it is the same number as the whole-body cap both implementations enforce. A string at that size is already a request the body-size check rejects, so a per-string check written at the spec's literal value is unreachable on every input that gets far enough to hit it.

Someone implementing from this document faithfully ends up with dead code that reads like a control. That is the failure mode you described better than I did: a missing check is visible as missing, a present one that cannot fire passes review, passes an audit read of the source, and counts toward this Definition of Done.

## What changed

The cap is stated as a derivation rather than a literal:

```python
MAX_STRING_LENGTH = MAX_REQUEST_BYTES // 2   # per string field, see invariant below
```

Plus the invariant written down, so the relationship survives someone changing the body cap later. The wording requires deriving from whatever body cap the implementation actually enforces, rather than mandating exactly half, since the ratio is a judgment call and the derivation is the part that matters.

That matches what shipped in #570 (`_MAX_ARG_STRING_LENGTH = _DEFAULT_MAX_REQUEST_BYTES // 2`), so the document and the implementation now agree on shape even while they disagree on the body cap.

## What I did not change

The 10MB in this document versus 1MB in `scripts/mock_upstream.py` and `MCPServer.__init__`. I have flagged that twice now without picking a side, and it is still not mine to pick. #562 was closed as completed when #570 merged, so that question had no live tracker. Filed #573 for it specifically, and the document points there, along with a note telling implementers to follow the enforced cap meanwhile rather than raising a body cap to match the doc, since that would be the more dangerous way to resolve the mismatch unilaterally.

Deriving the string cap removes the dead-code hazard at either value, so this does not block that decision either way.

I also left the DoD checklist and the Malformed Input Handling contract alone.

## Verification

`git diff --stat` is one file, +17 -1. No source changes, so the suite is unaffected. Line endings preserved as CRLF to keep the diff to the lines that actually changed.
