### PR TITLE
fix(proxy): preserve terminal outcome across failures

### DIFF
--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -13,11 +13,13 @@ Network topology:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 
 import httpx
@@ -49,14 +51,16 @@ from cmcp_runtime.session.state import SessionState, _max_sensitivity
 
 logger = logging.getLogger(__name__)
 
-_EXTERNAL_EVIDENCE_FIELDS: frozenset[str] = frozenset({
-    "issuer",
-    "issuer_key_id",
-    "signature",
-    "evidence_hash",
-    "evidence_type",
-    "linked_call_id",
-})
+_EXTERNAL_EVIDENCE_FIELDS: frozenset[str] = frozenset(
+    {
+        "issuer",
+        "issuer_key_id",
+        "signature",
+        "evidence_hash",
+        "evidence_type",
+        "linked_call_id",
+    }
+)
 
 
 @dataclass
@@ -74,6 +78,45 @@ class CallResult:
     # Annotations from the forbid policies that matched (deny or advisory).
     # Sourced from the hash-pinned policy bundle, safe to reflect to callers.
     advice: dict[str, str] | None = None
+
+
+class _EffectBoundaryState(StrEnum):
+    """Monotonic evidence states for one upstream tool invocation."""
+
+    PRE_TRANSPORT = "pre_transport"
+    TRANSPORT_MAY_HAVE_STARTED = "transport_may_have_started"
+    EXACT_RESPONSE_AVAILABLE = "exact_response_available"
+    TERMINAL_DURABLE = "terminal_durable"
+
+
+@dataclass
+class _CallFinalizationState:
+    """Per-invocation facts needed for honest terminal finalization."""
+
+    failure_stage: str = "call_entry"
+    effect_boundary_state: _EffectBoundaryState = _EffectBoundaryState.PRE_TRANSPORT
+    request_payload_hash: str | None = None
+    response_payload_hash: str | None = None
+    server_identity: str | None = None
+    external_execution_evidence: dict[str, str] | None = None
+    terminal_entry_id: str | None = None
+
+    @property
+    def terminal_disposition(self) -> str:
+        return (
+            "not_attempted"
+            if self.effect_boundary_state is _EffectBoundaryState.PRE_TRANSPORT
+            else "outcome_unknown"
+        )
+
+    @property
+    def effect_boundary_label(self) -> str:
+        return {
+            _EffectBoundaryState.PRE_TRANSPORT: "not_reached",
+            _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED: "transport_may_have_started",
+            _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE: "exact_response_available",
+            _EffectBoundaryState.TERMINAL_DURABLE: "terminal_durable",
+        }[self.effect_boundary_state]
 
 
 def _server_execution_key(entry: CatalogEntry) -> tuple[str, ...]:
@@ -146,14 +189,10 @@ def _extract_external_execution_evidence(response_text: str) -> dict[str, str] |
     if receipt is None:
         return None
     if not isinstance(receipt, dict):
-        logger.warning(
-            "EXTERNAL_EVIDENCE_IGNORED: external_execution_evidence is not an object"
-        )
+        logger.warning("EXTERNAL_EVIDENCE_IGNORED: external_execution_evidence is not an object")
         return None
     if set(receipt) != _EXTERNAL_EVIDENCE_FIELDS:
-        logger.warning(
-            "EXTERNAL_EVIDENCE_IGNORED: external_execution_evidence fields mismatch"
-        )
+        logger.warning("EXTERNAL_EVIDENCE_IGNORED: external_execution_evidence fields mismatch")
         return None
     if not all(isinstance(receipt[field], str) for field in _EXTERNAL_EVIDENCE_FIELDS):
         logger.warning(
@@ -196,9 +235,12 @@ class CMCPProxy:
         self._audit = audit_chain
         self._config = config
         self._enforcement = config.attestation.enforcement_mode
-        self._call_log: CallLog = call_log if call_log is not None else CallLog(session_id=session.session_id)
+        self._call_log: CallLog = (
+            call_log if call_log is not None else CallLog(session_id=session.session_id)
+        )
         self._session_call_log: SessionCallLog = (
-            session_call_log if session_call_log is not None
+            session_call_log
+            if session_call_log is not None
             else SessionCallLog(session_id=session.session_id)
         )
         self._attestation_generated_at = attestation_generated_at
@@ -298,8 +340,7 @@ class CMCPProxy:
             key = "unpinned"
         elif not tls_pinning.FINGERPRINT_PATTERN.match(fingerprint):
             raise UpstreamUnavailable(
-                f"Catalog tls_fingerprint for {server_url} is malformed - "
-                "refusing to connect",
+                f"Catalog tls_fingerprint for {server_url} is malformed - refusing to connect",
                 detail=f"tls_fingerprint={fingerprint[:64]!r}",
             )
         else:
@@ -355,9 +396,7 @@ class CMCPProxy:
             return await (await self._stdio_for(entry)).list_tools()
         try:
             client = self._client_for_upstream(entry)
-            payload, headers = build_request(
-                "provenance-tools-list", "tools/list", {}
-            )
+            payload, headers = build_request("provenance-tools-list", "tools/list", {})
             resp = await client.post(
                 entry.server.url,
                 json=payload,
@@ -433,9 +472,7 @@ class CMCPProxy:
                     current_definition=offered,
                 )
                 if result.available and result.threats:
-                    classification = ";".join(
-                        t.get("threat_type", "?") for t in result.threats
-                    )
+                    classification = ";".join(t.get("threat_type", "?") for t in result.threats)
             logger.error(
                 "UPSTREAM_CATALOG_DRIFT tool=%s server=%s kind=%s policy=%s",
                 tool_name,
@@ -462,9 +499,7 @@ class CMCPProxy:
         result = self._provenance.get(key)
         if result is None:
             advertised = (
-                await self._advertised_tools(entry)
-                if entry.server.provenance_record_path
-                else None
+                await self._advertised_tools(entry) if entry.server.provenance_record_path else None
             )
             result = check_server_provenance(
                 entry.server.provenance_record_path,
@@ -474,7 +509,9 @@ class CMCPProxy:
             self._provenance[key] = result
             logger.info(
                 "provenance: server=%s outcome=%s kind=%s",
-                key, result.outcome.value, result.kind or "-",
+                key,
+                result.outcome.value,
+                result.kind or "-",
             )
         return result
 
@@ -484,6 +521,8 @@ class CMCPProxy:
         entry: CatalogEntry,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        finalization: _CallFinalizationState | None = None,
     ) -> str:
         """
         Forward the tool call to the attested upstream MCP server (JSON-RPC 2.0
@@ -507,6 +546,9 @@ class CMCPProxy:
 
         if entry.server.is_stdio:
             server = await self._stdio_for(entry)
+            if finalization is not None:
+                finalization.failure_stage = "stdio_server_call"
+                finalization.effect_boundary_state = _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED
             return await server.call(call_id, tool_name, arguments)
 
         client = self._client_for_upstream(entry)
@@ -516,14 +558,20 @@ class CMCPProxy:
             {"name": tool_name, "arguments": arguments},
             name=tool_name,
         )
+        headers.update(parameter_headers(entry.approved_definition.input_schema, arguments))
+        if finalization is not None:
+            finalization.failure_stage = "http_transport"
+            finalization.effect_boundary_state = _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED
         try:
-            headers.update(
-                parameter_headers(entry.approved_definition.input_schema, arguments)
-            )
             resp = await client.post(entry.server.url, json=payload, headers=headers)
+            if finalization is not None:
+                finalization.effect_boundary_state = _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE
             resp.raise_for_status()
             body = parse_response(resp, call_id)
         except tls_pinning.TLSPinMismatchError as exc:
+            if finalization is not None:
+                finalization.failure_stage = "tls_pin_verification_pre_send"
+                finalization.effect_boundary_state = _EffectBoundaryState.PRE_TRANSPORT
             raise UpstreamUnavailable(
                 f"Upstream TLS certificate fingerprint does not match the attested "
                 f"catalog pin: {entry.server.url} - connection rejected before the "
@@ -553,9 +601,7 @@ class CMCPProxy:
         result = body.get("result", {})
         content = result.get("content", []) if isinstance(result, dict) else []
         texts = [
-            c.get("text", "")
-            for c in content
-            if isinstance(c, dict) and c.get("type") == "text"
+            c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text"
         ]
         if texts:
             return "\n".join(texts)
@@ -698,6 +744,68 @@ class CMCPProxy:
             )
             self._session.suspicious_sequences += 1
 
+    def _append_call_terminal(
+        self,
+        finalization: _CallFinalizationState,
+        entry_type: str,
+        **fields: Any,
+    ) -> None:
+        """Persist one terminal for this invocation, independent of call_id reuse."""
+        if finalization.terminal_entry_id is not None:
+            raise RuntimeError("terminal audit entry already persisted for this invocation")
+        entry = self._audit.append(entry_type, **fields)  # type: ignore[arg-type]
+        finalization.terminal_entry_id = entry.entry_id
+        finalization.effect_boundary_state = _EffectBoundaryState.TERMINAL_DURABLE
+
+    def _finalize_unexpected_call_failure(
+        self,
+        finalization: _CallFinalizationState,
+        exc: BaseException,
+        *,
+        call_id: str,
+        tool_name: str,
+        workflow_id: str | None,
+    ) -> None:
+        """Best-effort durable fault without laundering an uncertain outcome."""
+        if finalization.terminal_entry_id is not None:
+            return
+        pointer_state = (
+            "bound"
+            if finalization.external_execution_evidence is not None
+            else "unavailable_or_unbound"
+        )
+        try:
+            self._append_call_terminal(
+                finalization,
+                "fault",
+                call_id=call_id,
+                tool_name=tool_name,
+                server_identity=finalization.server_identity,
+                policy_decision="fault",
+                policy_rule_matched=f"unexpected:{type(exc).__name__}",
+                request_payload_hash=finalization.request_payload_hash,
+                response_payload_hash=finalization.response_payload_hash,
+                session_sensitivity_before=self._session.max_sensitivity,
+                session_sensitivity_after=self._session.max_sensitivity,
+                detail={
+                    "exception_type": type(exc).__name__,
+                    "failure_stage": finalization.failure_stage,
+                    "effect_boundary": finalization.effect_boundary_label,
+                    "effect_boundary_state": finalization.effect_boundary_state.value,
+                    "terminal_disposition": finalization.terminal_disposition,
+                    "external_execution_evidence_state": pointer_state,
+                },
+                workflow_id=workflow_id,
+                external_execution_evidence=(finalization.external_execution_evidence),
+            )
+        except Exception as persistence_exc:
+            exc.add_note(
+                "terminal audit persistence failed with "
+                f"{type(persistence_exc).__name__} during "
+                f"{finalization.failure_stage}"
+            )
+            raise exc from persistence_exc
+
     async def call_tool(
         self,
         call_id: str,
@@ -705,6 +813,39 @@ class CMCPProxy:
         arguments: dict[str, Any],
         workflow_id: str | None = None,
         declared_data_class: str | None = None,
+    ) -> CallResult:
+        """Run one call and guarantee one terminal on failure or cancellation."""
+        finalization = _CallFinalizationState()
+        try:
+            return await self._call_tool_impl(
+                call_id,
+                tool_name,
+                arguments,
+                workflow_id,
+                declared_data_class,
+                _finalization=finalization,
+            )
+        except BaseException as exc:
+            if not isinstance(exc, (Exception, asyncio.CancelledError)):
+                raise
+            self._finalize_unexpected_call_failure(
+                finalization,
+                exc,
+                call_id=call_id,
+                tool_name=tool_name,
+                workflow_id=workflow_id,
+            )
+            raise
+
+    async def _call_tool_impl(
+        self,
+        call_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        workflow_id: str | None = None,
+        declared_data_class: str | None = None,
+        *,
+        _finalization: _CallFinalizationState,
     ) -> CallResult:
         """
         Execute one MCP tool call through the full enforcement pipeline.
@@ -736,6 +877,7 @@ class CMCPProxy:
         would_have_denied = False
 
         # Step 0: health check (attestation staleness, catalog drift)
+        _finalization.failure_stage = "health_check"
         unhealthy_reason = self._check_health()
         if unhealthy_reason is not None:
             return CallResult(
@@ -749,14 +891,18 @@ class CMCPProxy:
                 audit_entry_hash=self._audit.chain_tip,
             )
 
+        _finalization.failure_stage = "request_serialization"
         _payload_bytes = json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode()
         request_payload_hash = f"sha256:{hashlib.sha256(_payload_bytes).hexdigest()}"
+        _finalization.request_payload_hash = request_payload_hash
 
         # Step 1: catalog lookup
+        _finalization.failure_stage = "catalog_lookup"
         entry = self._catalog.lookup(tool_name)
         if entry is None:
             deny_reason = f"Tool '{tool_name}' not in attested catalog"
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -791,11 +937,14 @@ class CMCPProxy:
                 audit_entry_hash=self._audit.chain_tip,
             )
 
+        _finalization.server_identity = entry.server.url
+
         # Step 1a (#521): does this server still offer what we approved? First
         # contact with each server only, so the cost is one tools/list per server
         # per session. Placed after the catalog lookup because it needs the entry
         # to know which server to ask, and before the policy decision because a
         # server that has been swapped underneath us should not reach Cedar at all.
+        _finalization.failure_stage = "upstream_drift_check"
         if await self._check_upstream_drift(entry):
             elapsed_ms = (time.perf_counter() - t0) * 1000
             self._record_call(
@@ -852,6 +1001,7 @@ class CMCPProxy:
             )
 
         # Step 2: Cedar policy evaluation
+        _finalization.failure_stage = "policy_evaluation"
         cedar_context = self._build_cedar_context(
             tool_name, arguments, workflow_id, effective_data_class
         )
@@ -870,7 +1020,8 @@ class CMCPProxy:
             # from "needs an approver", which the caller also learns from
             # `advice` below.
             denied_as = audit_value(exc.aarm_decision)
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -910,32 +1061,27 @@ class CMCPProxy:
             # policy). Write a fault audit entry so the incident is traceable, then
             # re-raise so server.py can return a generic 500.
             logger.error("CEDAR_FAULT: tool=%s error=%s", tool_name, exc, exc_info=True)
-            self._audit.append(
-                "fault",
+            self._finalize_unexpected_call_failure(
+                _finalization,
+                exc,
                 call_id=call_id,
                 tool_name=tool_name,
-                server_identity=entry.server.url,
-                policy_decision="fault",
-                policy_rule_matched=f"cedar_exception:{type(exc).__name__}",
-                request_payload_hash=request_payload_hash,
-                session_sensitivity_before=sensitivity_before,
-                session_sensitivity_after=self._session.max_sensitivity,
-                detail={"exception_type": type(exc).__name__},
+                workflow_id=workflow_id,
             )
             raise
 
         # Step 3a: AGT MCPGateway pre-call interception - per-agent rate
         # limiting, parameter sanitization, allow/deny. Fail-closed inside AGT.
+        _finalization.failure_stage = "ingress_gateway"
         agt_allowed, agt_reason = self._mcp_gateway.intercept_tool_call(
             agent_id=self._session.session_id,
             tool_name=tool_name,
             params=arguments,
         )
         if not agt_allowed:
-            logger.warning(
-                "AGT MCPGateway rejected call: tool=%s reason=%s", tool_name, agt_reason
-            )
-            self._audit.append(
+            logger.warning("AGT MCPGateway rejected call: tool=%s reason=%s", tool_name, agt_reason)
+            self._append_call_terminal(
+                _finalization,
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -971,13 +1117,20 @@ class CMCPProxy:
             )
 
         # Step 3b: forward to the attested upstream MCP server.
+        _finalization.failure_stage = "upstream_invocation"
         try:
             response_text = await self._forward_to_upstream(
-                call_id, entry, tool_name, arguments
+                call_id,
+                entry,
+                tool_name,
+                arguments,
+                finalization=_finalization,
             )
+            _finalization.effect_boundary_state = _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE
         except (UpstreamUnavailable, UpstreamToolError) as exc:
             logger.warning("Upstream call failed: tool=%s error=%s", tool_name, exc)
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "fault",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -987,7 +1140,14 @@ class CMCPProxy:
                 request_payload_hash=request_payload_hash,
                 session_sensitivity_before=sensitivity_before,
                 session_sensitivity_after=self._session.max_sensitivity,
-                detail={"error_code": exc.code},
+                detail={
+                    "error_code": exc.code,
+                    "failure_stage": _finalization.failure_stage,
+                    "effect_boundary": _finalization.effect_boundary_label,
+                    "effect_boundary_state": _finalization.effect_boundary_state.value,
+                    "terminal_disposition": _finalization.terminal_disposition,
+                    "external_execution_evidence_state": "unavailable_or_unbound",
+                },
             )
             elapsed_ms = (time.perf_counter() - t0) * 1000
             self._record_call(
@@ -1013,8 +1173,10 @@ class CMCPProxy:
             )
 
         # Step 3c: response size guard (DOS-002) before scanning.
+        _finalization.failure_stage = "response_size_check"
         if len(response_text.encode()) > self._config.max_response_size_bytes:
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -1051,6 +1213,7 @@ class CMCPProxy:
             )
 
         # Step 3d: AGT response interception - injection / credential / PII scan.
+        _finalization.failure_stage = "response_scan"
         scan = self._mcp_gateway.intercept_tool_response(
             agent_id=self._session.session_id,
             tool_name=tool_name,
@@ -1072,7 +1235,8 @@ class CMCPProxy:
             threat_categories = ",".join(
                 sorted({str(t.get("category", "unknown")) for t in scan.threats})
             )
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "tool_call",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -1127,6 +1291,7 @@ class CMCPProxy:
             else None
         )
         injection_threshold = None
+        _finalization.failure_stage = "session_update"
         async with self._session.mutation_lock:
             self._session.update_from_inspection(
                 call_id=call_id,
@@ -1137,7 +1302,9 @@ class CMCPProxy:
 
         # Step 5: egress Cedar policy check
         response_bytes: bytes = agt_result.encode()
+        _finalization.response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
 
+        _finalization.failure_stage = "egress_policy"
         try:
             egress_decision = self._policy.authorize_egress(
                 tool_name, response_bytes, self._session, workflow_id=workflow_id
@@ -1146,7 +1313,8 @@ class CMCPProxy:
             egress_advice = egress_decision.advice
         except PolicyDeny as exc:
             egress_deny_reason = str(exc)
-            self._audit.append(
+            self._append_call_terminal(
+                _finalization,
                 "egress_denied",
                 call_id=call_id,
                 tool_name=tool_name,
@@ -1174,12 +1342,13 @@ class CMCPProxy:
         advisory_advice = {**ingress_advice, **egress_advice}
 
         # Step 6: audit chain write
+        _finalization.failure_stage = "terminal_persistence"
         policy_decision: Any = "advisory_deny" if would_have_denied else "allow"
         latency_us = int((time.perf_counter() - t0) * 1_000_000)
         # #293: bind the outcome into the audit entry. Hash exactly the bytes the
         # egress check saw (post-scan, possibly sanitized) so a verifier can match
         # the audited response against what the caller actually received.
-        response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
+        response_payload_hash = _finalization.response_payload_hash
         # Evidence class: what a verifier can conclude about where this response
         # came from. tls-pinned when a network upstream has a real cert pin;
         # spawn-measured when the gateway digested a stdio server's entrypoint
@@ -1187,6 +1356,7 @@ class CMCPProxy:
         # are deliberately not collapsed: one identifies an endpoint, the other
         # identifies code.
         from cmcp_runtime.mcp import tls_pinning as _tls_mod
+
         if entry is not None and entry.server.is_stdio:
             spawned = self._stdio_servers.get(_server_execution_key(entry))
             # A stdio response with no spawned server on record is not something
@@ -1206,19 +1376,27 @@ class CMCPProxy:
                 and _fp != _tls_mod.PLACEHOLDER_FINGERPRINT
                 else "hash-only"
             )
+        _finalization.failure_stage = "external_evidence_extraction"
         external_execution_evidence = _extract_external_execution_evidence(agt_result)
+        _finalization.external_execution_evidence = external_execution_evidence
         # INJECT-003: include injection scanner and pattern in audit detail when detected
         injection_detail: dict[str, str | int | float] | None = (
             {
                 "injection_scanner": str(injection_scanner or "unknown")[:128],
                 "matched_pattern": str(injection_pattern or "unknown")[:256],
                 # INJECT-007: include threshold so the decision is replayable under config changes
-                **({"injection_threshold": float(injection_threshold)} if isinstance(injection_threshold, int | float) else {}),
+                **(
+                    {"injection_threshold": float(injection_threshold)}
+                    if isinstance(injection_threshold, int | float)
+                    else {}
+                ),
             }
             if injection_detected
             else None
         )
-        self._audit.append(
+        _finalization.failure_stage = "terminal_persistence"
+        self._append_call_terminal(
+            _finalization,
             "tool_call",
             call_id=call_id,
             tool_name=tool_name,
@@ -1238,6 +1416,7 @@ class CMCPProxy:
         )
 
         # Step 6: call log record + suspicious-sequence check
+        _finalization.failure_stage = "post_terminal_bookkeeping"
         elapsed_ms = (time.perf_counter() - t0) * 1000
         self._record_call(
             tool_name=tool_name,

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -85,7 +85,7 @@ class _EffectBoundaryState(StrEnum):
 
     PRE_TRANSPORT = "pre_transport"
     TRANSPORT_MAY_HAVE_STARTED = "transport_may_have_started"
-    EXACT_RESPONSE_AVAILABLE = "exact_response_available"
+    TRANSPORT_RESPONSE_RECEIVED = "transport_response_received"
     TERMINAL_DURABLE = "terminal_durable"
 
 
@@ -114,7 +114,7 @@ class _CallFinalizationState:
         return {
             _EffectBoundaryState.PRE_TRANSPORT: "not_reached",
             _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED: "transport_may_have_started",
-            _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE: "exact_response_available",
+            _EffectBoundaryState.TRANSPORT_RESPONSE_RECEIVED: "transport_response_received",
             _EffectBoundaryState.TERMINAL_DURABLE: "terminal_durable",
         }[self.effect_boundary_state]
 
@@ -565,7 +565,9 @@ class CMCPProxy:
         try:
             resp = await client.post(entry.server.url, json=payload, headers=headers)
             if finalization is not None:
-                finalization.effect_boundary_state = _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE
+                finalization.effect_boundary_state = (
+                    _EffectBoundaryState.TRANSPORT_RESPONSE_RECEIVED
+                )
             resp.raise_for_status()
             body = parse_response(resp, call_id)
         except tls_pinning.TLSPinMismatchError as exc:
@@ -798,7 +800,7 @@ class CMCPProxy:
                 workflow_id=workflow_id,
                 external_execution_evidence=(finalization.external_execution_evidence),
             )
-        except Exception as persistence_exc:
+        except (Exception, asyncio.CancelledError) as persistence_exc:
             exc.add_note(
                 "terminal audit persistence failed with "
                 f"{type(persistence_exc).__name__} during "
@@ -1126,7 +1128,7 @@ class CMCPProxy:
                 arguments,
                 finalization=_finalization,
             )
-            _finalization.effect_boundary_state = _EffectBoundaryState.EXACT_RESPONSE_AVAILABLE
+            _finalization.effect_boundary_state = _EffectBoundaryState.TRANSPORT_RESPONSE_RECEIVED
         except (UpstreamUnavailable, UpstreamToolError) as exc:
             logger.warning("Upstream call failed: tool=%s error=%s", tool_name, exc)
             self._append_call_terminal(

--- a/src/cmcp_runtime/mcp/proxy.py
+++ b/src/cmcp_runtime/mcp/proxy.py
@@ -1277,6 +1277,15 @@ class CMCPProxy:
         # Scanner may have sanitized the content (ResponsePolicy.SANITIZE).
         agt_result: str = scan.content if scan.content is not None else response_text
 
+        # Bind post-scan facts before any cancellable or fallible session/egress
+        # processing. The hash is bound first so an evidence-parser failure still
+        # preserves the exact response bytes that were available.
+        _finalization.failure_stage = "response_binding"
+        response_bytes: bytes = agt_result.encode()
+        _finalization.response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
+        _finalization.failure_stage = "external_evidence_extraction"
+        _finalization.external_execution_evidence = _extract_external_execution_evidence(agt_result)
+
         # Step 4: session update from response sensitivity
         # AUTH-002: lock protects against race with concurrent session reset requests.
         # Sensitivity comes from the attested catalog entry's declared level, raised
@@ -1303,9 +1312,6 @@ class CMCPProxy:
             )
 
         # Step 5: egress Cedar policy check
-        response_bytes: bytes = agt_result.encode()
-        _finalization.response_payload_hash = f"sha256:{hashlib.sha256(response_bytes).hexdigest()}"
-
         _finalization.failure_stage = "egress_policy"
         try:
             egress_decision = self._policy.authorize_egress(
@@ -1378,9 +1384,6 @@ class CMCPProxy:
                 and _fp != _tls_mod.PLACEHOLDER_FINGERPRINT
                 else "hash-only"
             )
-        _finalization.failure_stage = "external_evidence_extraction"
-        external_execution_evidence = _extract_external_execution_evidence(agt_result)
-        _finalization.external_execution_evidence = external_execution_evidence
         # INJECT-003: include injection scanner and pattern in audit detail when detected
         injection_detail: dict[str, str | int | float] | None = (
             {
@@ -1413,7 +1416,7 @@ class CMCPProxy:
             session_sensitivity_after=self._session.max_sensitivity,
             workflow_id=workflow_id,
             detail=injection_detail,
-            external_execution_evidence=external_execution_evidence,
+            external_execution_evidence=_finalization.external_execution_evidence,
             effective_data_class=effective_data_class,
         )
 

--- a/tests/unit/test_issue_571_finalization.py
+++ b/tests/unit/test_issue_571_finalization.py
@@ -126,6 +126,43 @@ def _provenance(*, meets_requirement: bool) -> MagicMock:
     return result
 
 
+def _external_receipt(call_id: str) -> dict[str, str]:
+    return {
+        "issuer": "spiffe://factory.example/controller/cell-7",
+        "issuer_key_id": "a" * 64,
+        "signature": "sig",
+        "evidence_hash": "sha256:" + "b" * 64,
+        "evidence_type": "controller-execution-receipt/v1",
+        "linked_call_id": call_id,
+    }
+
+
+def _response_with_receipt(call_id: str) -> tuple[str, dict[str, str]]:
+    receipt = _external_receipt(call_id)
+    return json.dumps({"external_execution_evidence": receipt}), receipt
+
+
+class _BlockingMutationLock:
+    """Deterministically expose cancellation while entering a mutation lock."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __aenter__(self) -> _BlockingMutationLock:
+        self.entered.set()
+        await self.release.wait()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> None:
+        return None
+
+
 @pytest.mark.parametrize("backend", ["memory", "sqlite"])
 @pytest.mark.parametrize(
     ("side", "expected", "stage"),
@@ -620,3 +657,153 @@ async def test_commit_then_raise_is_bounded_not_exactly_once(
     assert sqlite_terminals[0]["sequence_number"] == sqlite_terminals[1]["sequence_number"]
     assert sqlite_terminals[0]["entry_id"] != sqlite_terminals[1]["entry_id"]
     store.close()
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+@pytest.mark.asyncio
+async def test_post_scan_bindings_survive_cancellation_waiting_for_mutation_lock(
+    backend: str, tmp_path: Path
+) -> None:
+    database = tmp_path / f"post-scan-lock-{backend}.sqlite3"
+    store = SqliteAuditStore(database) if backend == "sqlite" else None
+    chain = AuditChain("issue-571", store=store)
+    proxy = _make_proxy(chain)
+    response, receipt = _response_with_receipt("post-scan-lock")
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+    blocking_lock = _BlockingMutationLock()
+    proxy._session.mutation_lock = blocking_lock  # type: ignore[assignment]
+
+    task = asyncio.create_task(proxy.call_tool("post-scan-lock", "test.echo", {}))
+    await asyncio.wait_for(blocking_lock.entered.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    terminals = _terminals(chain)
+    assert len(terminals) == 1
+    terminal = terminals[0]
+    assert terminal.entry_type == "fault"
+    assert terminal.detail["failure_stage"] == "session_update"
+    assert terminal.detail["terminal_disposition"] == "outcome_unknown"
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence == receipt
+    assert terminal.detail["external_execution_evidence_state"] == "bound"
+    if store is not None:
+        assert _sqlite_payloads(database) == [asdict(entry) for entry in chain.entries]
+        store.close()
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+@pytest.mark.asyncio
+async def test_post_scan_bindings_survive_session_update_exception(
+    backend: str, tmp_path: Path
+) -> None:
+    database = tmp_path / f"post-scan-update-{backend}.sqlite3"
+    store = SqliteAuditStore(database) if backend == "sqlite" else None
+    chain = AuditChain("issue-571", store=store)
+    proxy = _make_proxy(chain)
+    response, receipt = _response_with_receipt("post-scan-update")
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+    proxy._session.update_from_inspection = MagicMock(
+        side_effect=RuntimeError("session-update-fault")
+    )
+
+    with pytest.raises(RuntimeError, match="session-update-fault"):
+        await proxy.call_tool("post-scan-update", "test.echo", {})
+
+    terminals = _terminals(chain)
+    assert len(terminals) == 1
+    terminal = terminals[0]
+    assert terminal.detail["failure_stage"] == "session_update"
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence == receipt
+    assert terminal.detail["external_execution_evidence_state"] == "bound"
+    if store is not None:
+        assert _sqlite_payloads(database) == [asdict(entry) for entry in chain.entries]
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_post_scan_bindings_survive_unexpected_egress_exception() -> None:
+    chain = AuditChain("issue-571")
+    evaluator = _evaluator()
+    evaluator.authorize_egress.side_effect = RuntimeError("egress-fault")
+    proxy = _make_proxy(chain, evaluator)
+    response, receipt = _response_with_receipt("post-scan-egress")
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+
+    with pytest.raises(RuntimeError, match="egress-fault"):
+        await proxy.call_tool("post-scan-egress", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["failure_stage"] == "egress_policy"
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence == receipt
+    assert terminal.detail["external_execution_evidence_state"] == "bound"
+
+
+@pytest.mark.asyncio
+async def test_absent_evidence_remains_unavailable_after_session_failure() -> None:
+    response = '{"result":"no-receipt"}'
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+    proxy._session.update_from_inspection = MagicMock(side_effect=RuntimeError("session"))
+
+    with pytest.raises(RuntimeError, match="session"):
+        await proxy.call_tool("absent-receipt", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence is None
+    assert terminal.detail["external_execution_evidence_state"] == "unavailable_or_unbound"
+
+
+@pytest.mark.asyncio
+async def test_sanitized_post_scan_content_owns_hash_and_evidence() -> None:
+    raw_response = '{"raw":"must-not-be-bound"}'
+    sanitized_response, receipt = _response_with_receipt("sanitized-response")
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value=raw_response)
+    proxy._mcp_gateway.intercept_tool_response.return_value.content = sanitized_response
+    proxy._session.update_from_inspection = MagicMock(side_effect=RuntimeError("session"))
+
+    with pytest.raises(RuntimeError, match="session"):
+        await proxy.call_tool("sanitized-response", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(sanitized_response.encode()).hexdigest()
+    )
+    assert terminal.response_payload_hash != (
+        "sha256:" + hashlib.sha256(raw_response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence == receipt
+
+
+@pytest.mark.asyncio
+async def test_post_scan_binding_success_control_is_unchanged() -> None:
+    response, receipt = _response_with_receipt("binding-success")
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+
+    result = await proxy.call_tool("binding-success", "test.echo", {})
+
+    assert result.allowed is True
+    assert result.response == response
+    terminal = _terminals(chain)[0]
+    assert terminal.entry_type == "tool_call"
+    assert terminal.response_payload_hash == (
+        "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    )
+    assert terminal.external_execution_evidence == receipt

--- a/tests/unit/test_issue_571_finalization.py
+++ b/tests/unit/test_issue_571_finalization.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from cmcp_runtime.audit.chain import AuditChain
@@ -229,6 +230,93 @@ async def test_cancellation_after_terminal_persistence_does_not_duplicate() -> N
 
     assert caught.value.__cause__ is None
     assert not getattr(caught.value, "__notes__", [])
+    terminals = _terminals(chain)
+    assert len(terminals) == 1
+    assert terminals[0].entry_type == "tool_call"
+
+
+@pytest.mark.asyncio
+async def test_http_status_failure_records_transport_response_received() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    request = httpx.Request("POST", "https://local.invalid/mcp")
+    response = httpx.Response(503, request=request, content=b'{"error":"unavailable"}')
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    proxy._client_for_upstream = MagicMock(return_value=client)
+
+    result = await proxy.call_tool("status-fault", "test.echo", {})
+
+    assert result.allowed is False
+    terminal = _terminals(chain)[0]
+    assert terminal.response_payload_hash is None
+    assert terminal.detail["effect_boundary"] == "transport_response_received"
+    assert terminal.detail["effect_boundary_state"] == "transport_response_received"
+    assert terminal.detail["terminal_disposition"] == "outcome_unknown"
+
+
+@pytest.mark.asyncio
+async def test_parse_failure_records_transport_response_received() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    request = httpx.Request("POST", "https://local.invalid/mcp")
+    response = httpx.Response(200, request=request, content=b'{"jsonrpc":"2.0"}')
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    proxy._client_for_upstream = MagicMock(return_value=client)
+
+    with (
+        patch("cmcp_runtime.mcp.proxy.parse_response", side_effect=RecursionError("parse")),
+        pytest.raises(RecursionError, match="parse"),
+    ):
+        await proxy.call_tool("parse-fault", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.response_payload_hash is None
+    assert terminal.detail["effect_boundary"] == "transport_response_received"
+    assert terminal.detail["effect_boundary_state"] == "transport_response_received"
+    assert terminal.detail["terminal_disposition"] == "outcome_unknown"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_from_fault_persistence_preserves_original() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    original_append = chain.append
+
+    def cancel_fault(entry_type: str, **fields: Any):
+        if entry_type == "fault":
+            raise asyncio.CancelledError("audit-cancelled")
+        return original_append(entry_type, **fields)
+
+    chain.append = cancel_fault  # type: ignore[method-assign]
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy._extract_external_execution_evidence",
+            side_effect=RecursionError("late-parser-fault"),
+        ),
+        pytest.raises(RecursionError, match="late-parser-fault") as caught,
+    ):
+        await proxy.call_tool("cancelled-persistence", "test.echo", {})
+
+    assert isinstance(caught.value.__cause__, asyncio.CancelledError)
+    assert any("terminal audit persistence failed" in note for note in caught.value.__notes__)
+    assert _terminals(chain) == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_after_terminal_persistence_does_not_duplicate() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    proxy._record_call = MagicMock(side_effect=RuntimeError("post-terminal"))
+
+    with pytest.raises(RuntimeError, match="post-terminal"):
+        await proxy.call_tool("runtime-after-terminal", "test.echo", {})
+
     terminals = _terminals(chain)
     assert len(terminals) == 1
     assert terminals[0].entry_type == "tool_call"

--- a/tests/unit/test_issue_571_finalization.py
+++ b/tests/unit/test_issue_571_finalization.py
@@ -1,0 +1,534 @@
+"""Regression gates for issue #571 terminal finalization semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.audit.store import SqliteAuditStore
+from cmcp_runtime.catalog.loader import (
+    ApprovedDefinition,
+    CatalogEntry,
+    ServerIdentity,
+    ToolCatalog,
+)
+from cmcp_runtime.config import AttestationConfig, Config, EnforcementMode
+from cmcp_runtime.errors import UpstreamUnavailable
+from cmcp_runtime.mcp import tls_pinning
+from cmcp_runtime.mcp.proxy import _EffectBoundaryState
+from cmcp_runtime.policy.evaluator import PolicyDecision, PolicyEvaluator
+from cmcp_runtime.session.state import SessionState
+
+TERMINAL_TYPES = {"tool_call", "fault", "egress_denied"}
+
+
+def _decision() -> PolicyDecision:
+    return PolicyDecision(
+        allowed=True,
+        enforcement_mode=EnforcementMode.ENFORCING,
+        rule_matched=None,
+        advice={},
+        evaluation_ms=0.1,
+        would_have_denied=False,
+    )
+
+
+def _evaluator(exception: BaseException | None = None) -> PolicyEvaluator:
+    evaluator = MagicMock(spec=PolicyEvaluator)
+    if exception is None:
+        evaluator.evaluate.return_value = _decision()
+    else:
+        evaluator.evaluate.side_effect = exception
+    evaluator.authorize_egress.return_value = _decision()
+    evaluator.bundle_hash = "sha256:" + "0" * 64
+    evaluator.enforcement_mode = EnforcementMode.ENFORCING
+    return evaluator
+
+
+def _make_proxy(chain: AuditChain, evaluator: PolicyEvaluator | None = None):
+    from cmcp_runtime.mcp.proxy import CMCPProxy
+
+    entry = CatalogEntry(
+        tool_name="test.echo",
+        server=ServerIdentity(
+            display_name="Local",
+            url="https://local.invalid/mcp",
+            tls_fingerprint="SHA256:" + "A" * 43 + "=",
+            spiffe_id=None,
+            transport="http-sse",
+            rotation_mode="key-pinned",
+        ),
+        approved_definition=ApprovedDefinition(
+            description="echo", input_schema={}, output_schema=None
+        ),
+        definition_hash="sha256:" + "0" * 64,
+        compliance_domain="public",
+        requires_baa=False,
+        sensitivity_level="public",
+        added_at="2026-08-25T00:00:00Z",
+        approved_by="issue-571-finalization",
+    )
+    catalog = ToolCatalog(entries={"test.echo": entry}, catalog_hash="sha256:" + "1" * 64)
+    config = Config(attestation=AttestationConfig(enforcement_mode=EnforcementMode.ENFORCING))
+    with (
+        patch("cmcp_runtime.mcp.proxy.MCPGateway") as gateway,
+        patch("cmcp_runtime.mcp.proxy.MCPResponseScanner"),
+    ):
+        scan = MagicMock()
+        scan.allowed = True
+        scan.threats = []
+        scan.content = None
+        gateway.return_value.intercept_tool_call.return_value = (True, None)
+        gateway.return_value.intercept_tool_response.return_value = scan
+        proxy = CMCPProxy(
+            catalog,
+            evaluator or _evaluator(),
+            SessionState(session_id="issue-571"),
+            chain,
+            config,
+        )
+    proxy._check_upstream_drift = AsyncMock(return_value=False)
+    return proxy
+
+
+def _terminals(chain: AuditChain) -> list[Any]:
+    return [entry for entry in chain.entries[1:] if entry.entry_type in TERMINAL_TYPES]
+
+
+def _sqlite_payloads(path: Path) -> list[dict[str, Any]]:
+    connection = sqlite3.connect(path)
+    try:
+        return [
+            json.loads(row[0])
+            for row in connection.execute(
+                "SELECT payload FROM audit_entries ORDER BY sequence_number"
+            ).fetchall()
+        ]
+    finally:
+        connection.close()
+
+
+def _provenance(*, meets_requirement: bool) -> MagicMock:
+    result = MagicMock()
+    result.meets.return_value = meets_requirement
+    result.outcome.value = "verified" if meets_requirement else "missing"
+    result.detail = "private-r6-test"
+    return result
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+@pytest.mark.parametrize(
+    ("side", "expected", "stage"),
+    [
+        ("pre", "not_attempted", "policy_evaluation"),
+        ("post", "outcome_unknown", "upstream_invocation"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_same_exception_two_sided_boundary_and_storage_parity(
+    backend: str, side: str, expected: str, stage: str, tmp_path: Path
+) -> None:
+    database = tmp_path / f"{backend}-{side}.sqlite3"
+    store = SqliteAuditStore(database) if backend == "sqlite" else None
+    chain = AuditChain("issue-571", store=store)
+    failure = RecursionError("same-exception")
+    proxy = _make_proxy(chain, _evaluator(failure if side == "pre" else None))
+
+    async def fail_after_boundary(*_args: Any, **kwargs: Any) -> str:
+        finalization = kwargs["finalization"]
+        finalization.effect_boundary_state = _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED
+        raise failure
+
+    proxy._forward_to_upstream = AsyncMock(
+        side_effect=fail_after_boundary if side == "post" else None,
+        return_value="{}",
+    )
+
+    with pytest.raises(RecursionError, match="same-exception"):
+        await proxy.call_tool("same-call", "test.echo", {})
+
+    terminals = _terminals(chain)
+    assert len(terminals) == 1
+    terminal = terminals[0]
+    assert terminal.entry_type == "fault"
+    assert terminal.detail["terminal_disposition"] == expected
+    assert terminal.detail["failure_stage"] == stage
+    assert terminal.detail["effect_boundary"] == (
+        "not_reached" if side == "pre" else "transport_may_have_started"
+    )
+    assert terminal.detail["effect_boundary_state"] == (
+        "pre_transport" if side == "pre" else "transport_may_have_started"
+    )
+    assert terminal.response_payload_hash is None
+    assert proxy._forward_to_upstream.await_count == (0 if side == "pre" else 1)
+    assert chain.verify_chain()
+    if store is not None:
+        assert _sqlite_payloads(database) == [asdict(entry) for entry in chain.entries]
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_upstream_is_not_attempted() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_upstream_drift = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await proxy.call_tool("cancel-pre", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["failure_stage"] == "upstream_drift_check"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_awaiting_upstream_is_outcome_unknown() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    started = asyncio.Event()
+
+    async def blocked_forward(*_args: Any, **kwargs: Any) -> str:
+        kwargs[
+            "finalization"
+        ].effect_boundary_state = _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED
+        started.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    proxy._forward_to_upstream = blocked_forward
+    task = asyncio.create_task(proxy.call_tool("cancel-await", "test.echo", {}))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "outcome_unknown"
+    assert terminal.detail["failure_stage"] == "upstream_invocation"
+    assert terminal.detail["effect_boundary"] == "transport_may_have_started"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_terminal_persistence_does_not_duplicate() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    proxy._record_call = MagicMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await proxy.call_tool("cancel-after-terminal", "test.echo", {})
+
+    assert caught.value.__cause__ is None
+    assert not getattr(caught.value, "__notes__", [])
+    terminals = _terminals(chain)
+    assert len(terminals) == 1
+    assert terminals[0].entry_type == "tool_call"
+
+
+@pytest.mark.asyncio
+async def test_fault_persistence_preserves_original_exception_as_primary() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    original_append = chain.append
+
+    def fail_fault(entry_type: str, **fields: Any):
+        if entry_type == "fault":
+            raise OSError("audit-store-unavailable")
+        return original_append(entry_type, **fields)
+
+    chain.append = fail_fault  # type: ignore[method-assign]
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy._extract_external_execution_evidence",
+            side_effect=RecursionError("hostile-response-parse"),
+        ),
+        pytest.raises(RecursionError, match="hostile-response-parse") as caught,
+    ):
+        await proxy.call_tool("persist-fault", "test.echo", {})
+
+    assert isinstance(caught.value.__cause__, OSError)
+    assert "audit-store-unavailable" in str(caught.value.__cause__)
+    assert any("terminal audit persistence failed" in note for note in caught.value.__notes__)
+    assert _terminals(chain) == []
+
+
+@pytest.mark.parametrize("system_exit", [KeyboardInterrupt(), SystemExit(23)])
+@pytest.mark.asyncio
+async def test_system_exceptions_during_fault_persistence_remain_primary(
+    system_exit: BaseException,
+) -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    original_append = chain.append
+
+    def interrupt_fault(entry_type: str, **fields: Any):
+        if entry_type == "fault":
+            raise system_exit
+        return original_append(entry_type, **fields)
+
+    chain.append = interrupt_fault  # type: ignore[method-assign]
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy._extract_external_execution_evidence",
+            side_effect=RecursionError("late-parser-fault"),
+        ),
+        pytest.raises(type(system_exit)) as caught,
+    ):
+        await proxy.call_tool("system-exit", "test.echo", {})
+
+    assert caught.value is system_exit
+    assert caught.value.__cause__ is None
+    assert _terminals(chain) == []
+
+
+@pytest.mark.asyncio
+async def test_exact_response_hash_is_kept_for_late_processing_fault() -> None:
+    response = '{"controller":"accepted"}'
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value=response)
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy._extract_external_execution_evidence",
+            side_effect=RecursionError("late-parser-fault"),
+        ),
+        pytest.raises(RecursionError),
+    ):
+        await proxy.call_tool("late-fault", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    expected = "sha256:" + hashlib.sha256(response.encode()).hexdigest()
+    assert terminal.response_payload_hash == expected
+    assert terminal.detail["failure_stage"] == "external_evidence_extraction"
+
+
+@pytest.mark.asyncio
+async def test_bound_pointer_survives_later_terminal_persistence_fault() -> None:
+    receipt = {
+        "issuer": "spiffe://factory.example/controller/cell-7",
+        "issuer_key_id": "a" * 64,
+        "signature": "sig",
+        "evidence_hash": "sha256:" + "b" * 64,
+        "evidence_type": "controller-execution-receipt/v1",
+        "linked_call_id": "pointer-call",
+    }
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(
+        return_value=json.dumps({"external_execution_evidence": receipt})
+    )
+    original_append = chain.append
+    failed_once = False
+
+    def fail_first_success(entry_type: str, **fields: Any):
+        nonlocal failed_once
+        if entry_type == "tool_call" and not failed_once:
+            failed_once = True
+            raise RuntimeError("first-terminal-persistence-fault")
+        return original_append(entry_type, **fields)
+
+    chain.append = fail_first_success  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="first-terminal-persistence-fault"):
+        await proxy.call_tool("pointer-call", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.entry_type == "fault"
+    assert terminal.external_execution_evidence == receipt
+    assert terminal.detail["external_execution_evidence_state"] == "bound"
+    assert terminal.detail["terminal_disposition"] == "outcome_unknown"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_local_call_ids_are_isolated_per_concurrent_invocation() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+
+    async def fail_after_yield(*_args: Any, **kwargs: Any) -> str:
+        kwargs[
+            "finalization"
+        ].effect_boundary_state = _EffectBoundaryState.TRANSPORT_MAY_HAVE_STARTED
+        await asyncio.sleep(0)
+        raise RecursionError("concurrent-fault")
+
+    proxy._forward_to_upstream = fail_after_yield
+    results = await asyncio.gather(
+        proxy.call_tool("duplicate", "test.echo", {}),
+        proxy.call_tool("duplicate", "test.echo", {}),
+        return_exceptions=True,
+    )
+
+    assert all(isinstance(result, RecursionError) for result in results)
+    terminals = _terminals(chain)
+    assert len(terminals) == 2
+    assert {entry.call_id for entry in terminals} == {"duplicate"}
+    assert all(entry.detail["terminal_disposition"] == "outcome_unknown" for entry in terminals)
+    assert len({entry.entry_id for entry in terminals}) == 2
+    assert chain.verify_chain()
+
+
+@pytest.mark.asyncio
+async def test_provenance_refusal_is_proven_pre_transport() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=False))
+    proxy._client_for_upstream = MagicMock()
+
+    result = await proxy.call_tool("provenance-refused", "test.echo", {})
+
+    assert result.allowed is False
+    proxy._client_for_upstream.assert_not_called()
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["effect_boundary"] == "not_reached"
+
+
+@pytest.mark.asyncio
+async def test_malformed_pin_is_proven_pre_transport() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    proxy._client_for_upstream = MagicMock(side_effect=UpstreamUnavailable("malformed pin"))
+
+    result = await proxy.call_tool("malformed-pin", "test.echo", {})
+
+    assert result.allowed is False
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["effect_boundary_state"] == "pre_transport"
+
+
+@pytest.mark.asyncio
+async def test_tls_pin_mismatch_resets_to_proven_pre_send() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    client = MagicMock()
+    client.post = AsyncMock(
+        side_effect=tls_pinning.TLSPinMismatchError(
+            expected="SHA256:" + "A" * 43 + "=",
+            actual="SHA256:" + "B" * 43 + "=",
+        )
+    )
+    proxy._client_for_upstream = MagicMock(return_value=client)
+
+    result = await proxy.call_tool("tls-mismatch", "test.echo", {})
+
+    assert result.allowed is False
+    assert client.post.await_count == 1
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["failure_stage"] == "tls_pin_verification_pre_send"
+    assert terminal.detail["effect_boundary"] == "not_reached"
+
+
+@pytest.mark.asyncio
+async def test_request_construction_failure_is_pre_transport() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    client = MagicMock()
+    client.post = AsyncMock()
+    proxy._client_for_upstream = MagicMock(return_value=client)
+
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy.build_request",
+            side_effect=RuntimeError("request-construction"),
+        ),
+        pytest.raises(RuntimeError, match="request-construction"),
+    ):
+        await proxy.call_tool("request-fault", "test.echo", {})
+
+    assert client.post.await_count == 0
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["effect_boundary_state"] == "pre_transport"
+
+
+@pytest.mark.asyncio
+async def test_stdio_spawn_or_measurement_failure_is_pre_transport() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    entry = proxy._catalog.lookup("test.echo")
+    assert entry is not None
+    entry.server.transport = "stdio"
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    proxy._stdio_for = AsyncMock(side_effect=OSError("stdio-pre-call"))
+
+    with pytest.raises(OSError, match="stdio-pre-call"):
+        await proxy.call_tool("stdio-pre", "test.echo", {})
+
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["effect_boundary"] == "not_reached"
+
+
+@pytest.mark.asyncio
+async def test_header_construction_failure_is_pre_transport() -> None:
+    chain = AuditChain("issue-571")
+    proxy = _make_proxy(chain)
+    proxy._check_provenance = AsyncMock(return_value=_provenance(meets_requirement=True))
+    client = MagicMock()
+    client.post = AsyncMock()
+    proxy._client_for_upstream = MagicMock(return_value=client)
+
+    with (
+        patch(
+            "cmcp_runtime.mcp.proxy.parameter_headers",
+            side_effect=RuntimeError("header-construction"),
+        ),
+        pytest.raises(RuntimeError, match="header-construction"),
+    ):
+        await proxy.call_tool("header-fault", "test.echo", {})
+
+    assert client.post.await_count == 0
+    terminal = _terminals(chain)[0]
+    assert terminal.detail["terminal_disposition"] == "not_attempted"
+    assert terminal.detail["effect_boundary"] == "not_reached"
+
+
+@pytest.mark.asyncio
+async def test_commit_then_raise_is_bounded_not_exactly_once(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "commit-then-raise.sqlite3"
+    store = SqliteAuditStore(database)
+    chain = AuditChain("issue-571", store=store)
+    proxy = _make_proxy(chain)
+    proxy._forward_to_upstream = AsyncMock(return_value="{}")
+    original_store_append = store.append
+    raised = False
+
+    def commit_then_raise(entry: Any) -> None:
+        nonlocal raised
+        original_store_append(entry)
+        if entry.entry_type == "tool_call" and not raised:
+            raised = True
+            raise RuntimeError("commit-acknowledgement-lost")
+
+    store.append = commit_then_raise  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="commit-acknowledgement-lost"):
+        await proxy.call_tool("commit-then-raise", "test.echo", {})
+
+    memory_terminals = _terminals(chain)
+    sqlite_terminals = [
+        entry for entry in _sqlite_payloads(database) if entry["entry_type"] in TERMINAL_TYPES
+    ]
+    assert len(memory_terminals) == 1
+    assert memory_terminals[0].entry_type == "fault"
+    assert len(sqlite_terminals) == 2
+    assert [entry["entry_type"] for entry in sqlite_terminals] == ["tool_call", "fault"]
+    assert sqlite_terminals[0]["sequence_number"] == sqlite_terminals[1]["sequence_number"]
+    assert sqlite_terminals[0]["entry_id"] != sqlite_terminals[1]["entry_id"]
+    store.close()


### PR DESCRIPTION
## What

Guarantee one terminal audit record for each **propagating exceptional failure or
cancellation** crossing `call_tool`, while carrying an explicit effect-boundary
disposition: `not_attempted` before transport and `outcome_unknown` once an upstream
effect can no longer be excluded. Preserve the existing post-scan response hash and any
detached external-evidence pointer when later processing or persistence fails.

## Why

The existing path could let an upstream tool execute and then lose every audit record
when fallible response processing raised. A retry consumer must not confuse “possibly
committed” with “never attempted.”

Closes #571.

## Security impact

This hardens audit-chain completeness around upstream side effects. The state transition
is made immediately before `client.post` / `server.call`; proven pre-send failures remain
`not_attempted`. A returned HTTP response is labelled
`transport_response_received`—not `exact_response_available`—because status/parsing can
still fail before the existing processed `response_payload_hash` is established.
`KeyboardInterrupt` and `SystemExit` are not masked. A synchronous
`asyncio.CancelledError` raised by fault-terminal persistence is treated as a persistence
failure so the original causal exception remains primary. No schema, raw-transport hash,
retry, or #565 correlation change is included.

The write path does not claim `confirmed_occurred` or `confirmed_absent`; it stores a
pointer to external execution evidence, not an independently verified physical outcome.
A store that commits and then raises before acknowledgement can still produce two SQLite
terminals at one sequence while memory observes one; this bounded lost-ack ambiguity is
documented and is not presented as global exactly-once.

## Test plan

- [x] `pytest` passes — 1,481 passed, 16 skipped, 0 failed
- [x] Focused issue #571 matrix — 32/32 passed across memory/SQLite,
  cancellation at mutation-lock entry, session-update failure, unexpected egress failure,
  pre-send and system exceptions, concurrency, post-scan response hash, detached pointer,
  commit-then-raise, HTTP status/parse failure, persistence cancellation and post-terminal
  exception cases
- [x] Seven new failing regression instances reproduce the P1/P2 windows on the prior
  public head; the normal-success control passes there; all eight pass after the fix
- [x] A separate project-controlled local red-team matrix passes 12/12; eight causal
  ordering/binding mutants are killed and one benign UTF-8 equivalent survives
- [x] `ruff check src/ tests/` passes; the two modified files pass `ruff format --check`
- [x] `mypy src` passes (64 source files)
- [x] `bandit -r src/ -c pyproject.toml` passes
- [x] Real Draft-07 validation remains outside this follow-up; no schema change is
  included

## Validation status and limitations

These are project-controlled local executions, not independent validation. The existing
repository-wide formatting/debt outside the two modified files is not changed. Normal
health-check and drift-denial return paths predate this PR and remain outside its
propagating exception/cancellation finalizer; the drift detector may record a drift
observation, but this PR does not claim a per-call terminal for those normal denials. The
existing caught egress `PolicyDeny` terminal is also unchanged; this follow-up does not
alter its response-hash/evidence fields. Retry correlation remains owned by #565. The
commit-then-raise lost-ack case bounds, rather than proves, exactly-once behavior.

## AI assistance

OpenAI Codex/ChatGPT assisted with analysis, implementation, adversarial tests, and
drafting. The human submitter reviewed the scope, evidence, and claims and accepts
responsibility for the contribution.

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree
  to the Developer Certificate of Origin.
