### PR TITLE
fix(ci): pin sbom.yml actions to SHA and scope permissions to the job

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,22 +9,21 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: spdx-json
           output-file: sbom.spdx.json
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json


### PR DESCRIPTION
## What

This PR scopes permission of sbom.yml to the job and also updates the actions to SHA.

Part of the CI hardening pass in agentrust-io/.github#30.

## Why

`sbom.yml` ran `anchore/sbom-action@v0` (a floating tag) in a job that also holds `id-token: write`. A floating tag means whoever controls that tag controls what runs in a job that can mint an OIDC token and write to the repo and this is the single worst case flagged in the audit. Pinned it, along with `actions/checkout` and `actions/upload-artifact`, to exact commit SHAs with version comments.

Also moved `permissions: { contents: write, id-token: write }` from the workflow level down to the `sbom` job specifically, so a future job added to this file doesn't inherit them by default.

## Security impact

None

## Test plan

- [ ] `pytest` passes
- [ ] `ruff check` passes
- [ ] `mypy` passes
- [x] Manual test performed (describe steps below if applicable)

<!-- Manual test steps (delete if not applicable): -->

It is CI-config change:
- Parsed the file with `yaml.safe_load()` to confirm valid YAML syntax
- Confirmed each pinned SHA resolves to the exact version tag named in its comment, via `git ls-remote --tags` (e.g. `anchore/sbom-action`'s SHA matches its `v0.24.0` tag)
- Diffed against the original to confirm no step, input, or job logic changed and only the action version references and where the `permissions` block sits

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree to the
      Developer Certificate of Origin (https://developercertificate.org).
