### PR TITLE
docs(threat-model): A1 grouped TPM sealing with TEE memory encryption

### DIFF
--- a/docs/spec/threat-model.md
+++ b/docs/spec/threat-model.md
@@ -19,7 +19,14 @@ Status: Draft v0.1 | Covers: Phase 1 cMCP Runtime
 **A1: Rogue operator / privileged insider**
 - Has root access to the host VM
 - Can read/write host memory, modify files, access environment variables
-- Cannot read TEE-encrypted memory (SEV-SNP, TDX) or TPM-sealed secrets
+- On a memory-encrypting TEE (SEV-SNP, TDX): cannot read or modify guest memory while the
+  gateway runs, so policy evaluation and audit construction are outside this adversary's reach.
+- On the `tpm` tier: cannot unseal TPM-sealed secrets outside a matching measured boot, and
+  cannot alter the measured components without the attestation reporting it. This is a
+  boot-time and at-rest guarantee only. **A TPM does not encrypt the memory of a running
+  process**, so on bare-metal TPM an operator with root can read or modify the gateway's
+  memory while it runs, including flipping a Cedar decision, without the TPM detecting it.
+  The `tpm` tier defends against a tampered boot, not against a live privileged insider.
 - Goal: bypass policy, forge audit entries, or exfiltrate data
 
 **A2: Supply chain attacker**


### PR DESCRIPTION
Closes #581, reported by @kingztech2019.

## The claim that was wrong

`docs/spec/threat-model.md:22`, adversary A1:

> - Cannot read TEE-encrypted memory (SEV-SNP, TDX) or TPM-sealed secrets

Two lines above, the same entry grants A1 root on the host. So this bullet is the load-bearing one: it says what root cannot reach.

It groups two different guarantees:

- **SEV-SNP and TDX** encrypt guest memory while the VM runs. Root on the host genuinely cannot read or modify what the gateway is doing, for the whole time it runs.
- **TPM sealing** binds a secret to PCR values at unseal time. That is a boot-time and at-rest guarantee. It says nothing about a running process's memory.

On bare-metal TPM, an operator with root can reach into the running gateway and flip a Cedar DENY to an ALLOW, and the TPM will not detect it, because detecting that is not what a TPM does. The threat model said otherwise.

## What changed

A1's third bullet is split so each tier states its own guarantee, and the `tpm` tier's boundary is explicit: it defends against a tampered boot, not against a live privileged insider.

No change to the SEV-SNP or TDX position, which was accurate.

## Scope

This is distinct from two things already recorded elsewhere:

- **#453**, the missing AK certificate chain to a pinnable root. That is about whether a TPM attestation can be verified at all; this is about what a verified one proves.
- **The Azure vTPM-behind-SEV-SNP case**, documented separately in `LIMITATIONS.md`. There the vTPM sits on top of a memory-encrypting TEE, so the SEV-SNP line applies. This change is about bare-metal TPM, and @kingztech2019 scoped it that way in the report.

## Why it is worth a change rather than a note

A threat model is the document a deployer reads to decide which tier they need. Someone choosing the `tpm` tier because A1 "cannot read TPM-sealed secrets" would have concluded that a rogue operator cannot subvert their policy decisions, and that conclusion does not hold. Overstating a hardware guarantee in the document whose job is to bound it is the failure mode this project exists to avoid.
