### PR TITLE
fix(cmcp-verify): cross-check enforcement_mode in TRACE claim re-verification

### DIFF
--- a/src/cmcp_runtime/audit/trace_claim.py
+++ b/src/cmcp_runtime/audit/trace_claim.py
@@ -111,6 +111,7 @@ class AgentIdentityInfo:
     # subject_source is a non-live-authenticated source (config, manifest-dev) - see
     # AgentIdentityOut for the full contract.
     agent_key_thumbprint: str | None = None
+    enforcement_mode: str | None = None
 
 
 # ── Pydantic output models ─────────────────────────────────────────────────────
@@ -177,6 +178,7 @@ class AgentIdentityOut(BaseModel):
     tool_catalog_hash: str
     intent_hash: Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")] | None = None
     agent_key_thumbprint: Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")] | None = None
+    enforcement_mode: str | None = None
 
 
 class ToolTranscriptEntry(BaseModel):
@@ -508,6 +510,7 @@ def generate_trace_claim(
                 tool_catalog_hash=agent_identity.tool_catalog_hash,
                 intent_hash=agent_identity.intent_hash,
                 agent_key_thumbprint=agent_identity.agent_key_thumbprint,
+                enforcement_mode=agent_identity.enforcement_mode,
             )
             if agent_identity is not None
             else None

--- a/src/cmcp_runtime/session/manager.py
+++ b/src/cmcp_runtime/session/manager.py
@@ -394,6 +394,7 @@ class SessionManager:
                 # AARM R2. None when the bound manifest declares no intent,
                 # which is the common case and not a failure.
                 intent_hash=binding.intent_hash,
+                enforcement_mode=binding.enforcement_mode,
             )
 
         # AUDIT-005: increment the module-level counter to get a monotonic sequence number.

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -25,6 +25,7 @@ from pydantic import ValidationError
 
 from cmcp_runtime.agent_manifest import verify_agent_manifest_binding
 from cmcp_runtime.audit.trace_claim import RuntimeClaim
+from cmcp_runtime.config import EnforcementMode
 from cmcp_runtime.errors import ConfigError
 
 logger = logging.getLogger(__name__)
@@ -909,6 +910,12 @@ def verify_trace_claim(
             details["agent_manifest"] = "no trusted Agent Manifest issuer keys provided"
         else:
             try:
+                enforcement_mode_raw = agent_identity.get("enforcement_mode")
+                claimed_enforcement_mode = (
+                    EnforcementMode(enforcement_mode_raw)
+                    if enforcement_mode_raw is not None
+                    else None
+                )
                 binding = verify_agent_manifest_binding(
                     agent_manifest,
                     trusted_agent_manifest_keys,
@@ -916,6 +923,7 @@ def verify_trace_claim(
                     authenticated_subject_source=agent_identity.get("subject_source"),
                     policy_bundle_hash=claimed_policy,
                     tool_catalog_hash=claimed_catalog,
+                    enforcement_mode=claimed_enforcement_mode,
                     allow_dev_subject_from_manifest=(
                         agent_identity.get("subject_source") == "manifest-dev"
                     ),
@@ -930,6 +938,7 @@ def verify_trace_claim(
                     "policy_bundle_hash": binding.policy_bundle_hash,
                     "tool_catalog_hash": binding.tool_catalog_hash,
                     "intent_hash": binding.intent_hash,
+                    "enforcement_mode": binding.enforcement_mode,
                 }
                 mismatched = [
                     key
@@ -944,7 +953,7 @@ def verify_trace_claim(
                     )
                 else:
                     verified.append("agent_manifest.binding")
-            except ConfigError as exc:
+            except (ConfigError, ValueError) as exc:
                 unverified.append("agent_manifest.binding")
                 failure = failure or VerificationError.AGENT_MANIFEST_MISMATCH
                 details["agent_manifest"] = str(exc)

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -28,6 +28,7 @@ from cmcp_runtime.audit.trace_claim import (
     _to_dict,
     generate_trace_claim,
 )
+from cmcp_runtime.config import EnforcementMode
 from cmcp_verify.verify import (
     ApprovedHashes,
     VerificationError,
@@ -147,7 +148,7 @@ def _b64url(data: bytes) -> str:
 
 
 def _signed_manifest(
-    priv: Ed25519PrivateKey, key_id: str, *, intent: dict | None = None
+    priv: Ed25519PrivateKey, key_id: str, *, intent: dict | None = None, enforcement_mode: str | None = None
 ) -> dict:
     manifest = {
         "@context": "https://agentmanifest.agentrust-io.com/v0.1/context.json",
@@ -160,7 +161,11 @@ def _signed_manifest(
         "issuer": "spiffe://factory.example/signing-authority/development",
         "crypto_profile": "standard",
         "artifacts": {
-            "policy_bundle": {"hash": POLICY_HASH, "policy_language": "cedar"},
+            "policy_bundle": (
+                {"hash": POLICY_HASH, "policy_language": "cedar", "enforcement_mode": enforcement_mode}
+                if enforcement_mode is not None
+                else {"hash": POLICY_HASH, "policy_language": "cedar"}
+            ),
             "tool_manifest": {"catalog_hash": CATALOG_HASH, "tools": []},
         },
         "delegation_chain": [],
@@ -344,6 +349,106 @@ def test_agent_manifest_binding_intent_hash_mismatch_fails():
     assert "agent_manifest.binding" in result.unverified_fields
     assert result.failure_reason == VerificationError.AGENT_MANIFEST_MISMATCH
 
+
+# -- enforcement_mode cross-check (cmcp#576 follow-up) --------------------------
+
+
+def test_agent_manifest_binding_enforcement_mode_reaches_the_claim():
+    """A manifest that declares enforcement_mode binds cleanly when the claim's
+    agent_identity carries the same value the runtime attested at claim time.
+    """
+    priv, pub, key_id = _manifest_keypair()
+    manifest = _signed_manifest(priv, key_id, enforcement_mode="enforce")
+
+    real_binding = verify_agent_manifest_binding(
+        manifest,
+        {key_id: pub},
+        authenticated_subject=AGENT_ID,
+        authenticated_subject_source="config",
+        policy_bundle_hash=POLICY_HASH,
+        tool_catalog_hash=CATALOG_HASH,
+        enforcement_mode=EnforcementMode.ENFORCING,
+    )
+    assert real_binding.enforcement_mode == EnforcementMode.ENFORCING
+
+    identity = _agent_identity()
+    identity.issuer_key_id = key_id
+    identity.enforcement_mode = "enforcing"
+    claim_dict, _ = _make_signed_claim(agent_identity=identity)
+
+    result = verify_trace_claim(
+        claim_dict,
+        _approved(),
+        agent_manifest=manifest,
+        trusted_agent_manifest_keys={key_id: pub},
+    )
+    assert "agent_manifest.binding" in result.verified_fields
+
+
+def test_agent_manifest_binding_enforcement_mode_mismatch_fails():
+    """The claim asserts a different enforcement mode than the one a fresh
+    re-verification of the manifest actually attests -- as if the gateway's
+    mode changed (or was misrecorded) between claim creation and now.
+    """
+    priv, pub, key_id = _manifest_keypair()
+    manifest = _signed_manifest(priv, key_id, enforcement_mode="enforce")
+
+    identity = _agent_identity()
+    identity.issuer_key_id = key_id
+    identity.enforcement_mode = "advisory"  # claim says advisory
+    claim_dict, _ = _make_signed_claim(agent_identity=identity)
+
+    result = verify_trace_claim(
+        claim_dict,
+        _approved(),
+        agent_manifest=manifest,
+        trusted_agent_manifest_keys={key_id: pub},
+    )
+    assert "agent_manifest.binding" in result.unverified_fields
+    assert result.failure_reason == VerificationError.AGENT_MANIFEST_MISMATCH
+
+
+def test_agent_manifest_binding_without_enforcement_mode_still_works():
+    """A manifest that doesn't declare enforcement_mode at all -- the common
+    case before this field existed -- must bind and verify exactly as before.
+    Absence is not failure (same principle as intent_hash's module docstring).
+    """
+    priv, pub, key_id = _manifest_keypair()
+    manifest = _signed_manifest(priv, key_id)  # no enforcement_mode
+
+    identity = _agent_identity()
+    identity.issuer_key_id = key_id
+    claim_dict, _ = _make_signed_claim(agent_identity=identity)
+
+    result = verify_trace_claim(
+        claim_dict,
+        _approved(),
+        agent_manifest=manifest,
+        trusted_agent_manifest_keys={key_id: pub},
+    )
+    assert "agent_manifest.binding" in result.verified_fields
+
+
+def test_agent_manifest_binding_garbled_enforcement_mode_fails_closed():
+    """A claim whose gateway.agent_identity.enforcement_mode is not one of the
+    three valid values must fail closed, not raise an unhandled ValueError.
+    """
+    priv, pub, key_id = _manifest_keypair()
+    manifest = _signed_manifest(priv, key_id, enforcement_mode="enforce")
+
+    identity = _agent_identity()
+    identity.issuer_key_id = key_id
+    identity.enforcement_mode = "not-a-real-mode"
+    claim_dict, _ = _make_signed_claim(agent_identity=identity)
+
+    result = verify_trace_claim(
+        claim_dict,
+        _approved(),
+        agent_manifest=manifest,
+        trusted_agent_manifest_keys={key_id: pub},
+    )
+    assert "agent_manifest.binding" in result.unverified_fields
+    assert result.failure_reason == VerificationError.AGENT_MANIFEST_MISMATCH
 
 # -- agent_key_thumbprint subject binding (#425) -------------------------------
 


### PR DESCRIPTION
## What

Extends the enforcement_mode cross-check from #584 (startup-time binding) to claim-time re-verification: `verify_trace_claim`'s optional Agent Manifest binding check now also cross-checks the enforcement mode recorded at claim-creation time against a fresh re-verification of the manifest.

## Why

Found while verifying #584 would go fully green: `verify_trace_claim` (src/cmcp_verify/verify.py) calls `verify_agent_manifest_binding` too, but never passed `enforcement_mode`. It's wrapped in try/except so it doesn't crash, and no current test exercises a manifest that declares enforcement_mode` through this specific path, so #584 stays green either way but once agent-manifest ships the enforcement_mode check, any manifest built to spec (enforcement_mode is REQUIRED per 6.2) would start silently reporting `agent_manifest.binding: unverified` here, with nothing actually wrong. This closes that gap before it can surface: `AgentIdentityInfo`/`AgentIdentityOut` now carry the enforcement mode
recorded at claim-creation time, and `verify_trace_claim` cross-checks it the same way it already does for `intent_hash`, `policy_bundle_hash`, etc.

## Security impact

Yes. Same class of change as #584/#576, applied to the claim re-verification path instead of the startup path. Before this change, a claim's recorded enforcement mode was never checked against anything an attacker who could modify a claim or a bug that mis-recorded it) could assert any enforcement mode with no cross-check catching it. After this change, the claimed mode must match what a fresh, cryptographic re-verification of the manifest actually attests, or the binding is reported unverified. Also hardens against a garbled/invalid claimed value (`ValueError` from an unrecognized `enforcement_mode` string) now fails closed via the same except path as every other binding failure, instead of raising unhandled.

## Test plan

- [x] `pytest` passes
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Manual test performed (describe steps below if applicable)

<!-- Manual test steps (delete if not applicable): -->

## DCO sign-off

- [ ] I certify that I wrote or have the right to submit this contribution, and I agree to the
      Developer Certificate of Origin (https://developercertificate.org).
