### PR TITLE
fix(verify): classify malformed audit-bundle shapes

### DIFF
--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -539,6 +539,15 @@ def _external_evidence_failure(entry_index: int, reason: str) -> str:
     return f"entry {entry_index}: {_EXTERNAL_EVIDENCE_ERROR}: {reason}"
 
 
+def _audit_bundle_shape_failure(path: str, entry_count: int = 0) -> AuditBundleResult:
+    """Classify malformed external structure without interpreting its contents."""
+    return AuditBundleResult(
+        verified=False,
+        entry_count=entry_count,
+        failures=[f"{path} has invalid object or array shape"],
+    )
+
+
 def verify_audit_bundle(
     bundle_json: dict[str, Any],
     claim_json: dict[str, Any] | None = None,
@@ -560,8 +569,39 @@ def verify_audit_bundle(
        signature). This is opt-in: receipt-less entries and callers that do not
        supply keys are unaffected, so existing evidence keeps verifying.
     """
-    failures: list[str] = []
+    if not isinstance(bundle_json, dict):
+        return _audit_bundle_shape_failure("bundle")
+
     entries = bundle_json.get("entries", [])
+    if not isinstance(entries, list):
+        return _audit_bundle_shape_failure("bundle.entries")
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            return _audit_bundle_shape_failure(f"bundle.entries[{i}]", len(entries))
+
+    if claim_json is not None:
+        if not isinstance(claim_json, dict):
+            return _audit_bundle_shape_failure("claim", len(entries))
+        for path in (
+            ("gateway",),
+            ("gateway", "audit_chain"),
+            ("gateway", "call_summary"),
+            ("trace",),
+            ("trace", "tool_transcript"),
+            ("trace", "cnf"),
+            ("trace", "cnf", "jwk"),
+        ):
+            obj: Any = claim_json
+            for depth, name in enumerate(path):
+                if name not in obj:
+                    break
+                obj = obj[name]
+                if not isinstance(obj, dict):
+                    return _audit_bundle_shape_failure(
+                        "claim." + ".".join(path[: depth + 1]), len(entries)
+                    )
+
+    failures: list[str] = []
     if not entries:
         return AuditBundleResult(verified=False, entry_count=0, failures=["bundle has no entries"])
 

--- a/tests/unit/test_verify_audit_bundle_malformed_shapes.py
+++ b/tests/unit/test_verify_audit_bundle_malformed_shapes.py
@@ -42,7 +42,10 @@ def _one_entry_bundle() -> dict:
     ],
 )
 def test_malformed_entries_return_failed_result(entries) -> None:
-    result = verify_audit_bundle({"entries": entries})
+    try:
+        result = verify_audit_bundle({"entries": entries})
+    except (AttributeError, TypeError) as exc:
+        pytest.xfail(f"known #593 malformed-bundle escape: {type(exc).__name__}: {exc}")
 
     assert isinstance(result, AuditBundleResult)
     assert not result.verified
@@ -61,7 +64,10 @@ def test_malformed_entries_return_failed_result(entries) -> None:
     ],
 )
 def test_malformed_claim_binding_shapes_return_failed_result(claim: dict) -> None:
-    result = verify_audit_bundle(_one_entry_bundle(), claim)
+    try:
+        result = verify_audit_bundle(_one_entry_bundle(), claim)
+    except (AttributeError, TypeError) as exc:
+        pytest.xfail(f"known #593 malformed-claim escape: {type(exc).__name__}: {exc}")
 
     assert isinstance(result, AuditBundleResult)
     assert not result.verified

--- a/tests/unit/test_verify_audit_bundle_malformed_shapes.py
+++ b/tests/unit/test_verify_audit_bundle_malformed_shapes.py
@@ -1,0 +1,78 @@
+"""Malformed audit-bundle boundary vectors for issue #593."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from cmcp_verify.verify import AuditBundleResult, verify_audit_bundle
+
+
+def _one_entry_bundle() -> dict:
+    body = {
+        "entry_type": "session",
+        "call_id": "call-1",
+        "prev_entry_hash": "genesis",
+    }
+    entry_hash = hashlib.sha256(
+        json.dumps(
+            body,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+    ).hexdigest()
+    return {"entries": [{**body, "entry_hash": entry_hash}]}
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        "bad",
+        1,
+        True,
+        {"unexpected": "object"},
+        ["bad"],
+        [1],
+        [True],
+        [[]],
+        [None],
+    ],
+)
+def test_malformed_entries_return_failed_result(entries) -> None:
+    result = verify_audit_bundle({"entries": entries})
+
+    assert isinstance(result, AuditBundleResult)
+    assert not result.verified
+    assert result.failures
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        {"gateway": "bad"},
+        {"gateway": {"audit_chain": "bad"}},
+        {"trace": "bad"},
+        {"trace": {"tool_transcript": "bad"}},
+        {"trace": {"cnf": "bad"}},
+        {"trace": {"cnf": {"jwk": "bad"}}},
+    ],
+)
+def test_malformed_claim_binding_shapes_return_failed_result(claim: dict) -> None:
+    result = verify_audit_bundle(_one_entry_bundle(), claim)
+
+    assert isinstance(result, AuditBundleResult)
+    assert not result.verified
+    assert result.failures
+
+
+def test_missing_entries_preserves_existing_failure() -> None:
+    result = verify_audit_bundle({})
+
+    assert result == AuditBundleResult(
+        verified=False,
+        entry_count=0,
+        failures=["bundle has no entries"],
+    )

--- a/tests/unit/test_verify_audit_bundle_malformed_shapes.py
+++ b/tests/unit/test_verify_audit_bundle_malformed_shapes.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+from typing import Any
 
 import pytest
 
 from cmcp_verify.verify import AuditBundleResult, verify_audit_bundle
 
 
-def _one_entry_bundle() -> dict:
+def _one_entry_bundle() -> dict[str, Any]:
     body = {
         "entry_type": "session",
         "call_id": "call-1",
@@ -28,50 +29,71 @@ def _one_entry_bundle() -> dict:
 
 
 @pytest.mark.parametrize(
-    "entries",
+    ("entries", "failure_path"),
     [
-        "bad",
-        1,
-        True,
-        {"unexpected": "object"},
-        ["bad"],
-        [1],
-        [True],
-        [[]],
-        [None],
+        ("bad", "bundle.entries"),
+        (1, "bundle.entries"),
+        (True, "bundle.entries"),
+        ({"unexpected": "object"}, "bundle.entries"),
+        (["bad"], "bundle.entries[0]"),
+        ([1], "bundle.entries[0]"),
+        ([True], "bundle.entries[0]"),
+        ([[]], "bundle.entries[0]"),
+        ([None], "bundle.entries[0]"),
     ],
 )
-def test_malformed_entries_return_failed_result(entries) -> None:
-    try:
-        result = verify_audit_bundle({"entries": entries})
-    except (AttributeError, TypeError) as exc:
-        pytest.xfail(f"known #593 malformed-bundle escape: {type(exc).__name__}: {exc}")
+def test_malformed_entries_return_failed_result(entries: Any, failure_path: str) -> None:
+    result = verify_audit_bundle({"entries": entries})
 
-    assert isinstance(result, AuditBundleResult)
-    assert not result.verified
-    assert result.failures
+    assert result == AuditBundleResult(
+        verified=False,
+        entry_count=len(entries) if isinstance(entries, list) else 0,
+        failures=[f"{failure_path} has invalid object or array shape"],
+    )
 
 
 @pytest.mark.parametrize(
-    "claim",
+    ("claim", "failure_path"),
     [
-        {"gateway": "bad"},
-        {"gateway": {"audit_chain": "bad"}},
-        {"trace": "bad"},
-        {"trace": {"tool_transcript": "bad"}},
-        {"trace": {"cnf": "bad"}},
-        {"trace": {"cnf": {"jwk": "bad"}}},
+        ({"gateway": "bad"}, "claim.gateway"),
+        ({"gateway": {"audit_chain": "bad"}}, "claim.gateway.audit_chain"),
+        ({"gateway": {"call_summary": "bad"}}, "claim.gateway.call_summary"),
+        ({"trace": "bad"}, "claim.trace"),
+        ({"trace": {"tool_transcript": "bad"}}, "claim.trace.tool_transcript"),
+        ({"trace": {"cnf": "bad"}}, "claim.trace.cnf"),
+        ({"trace": {"cnf": {"jwk": "bad"}}}, "claim.trace.cnf.jwk"),
     ],
 )
-def test_malformed_claim_binding_shapes_return_failed_result(claim: dict) -> None:
-    try:
-        result = verify_audit_bundle(_one_entry_bundle(), claim)
-    except (AttributeError, TypeError) as exc:
-        pytest.xfail(f"known #593 malformed-claim escape: {type(exc).__name__}: {exc}")
+def test_malformed_claim_binding_shapes_return_failed_result(
+    claim: dict[str, Any], failure_path: str
+) -> None:
+    result = verify_audit_bundle(_one_entry_bundle(), claim)
 
-    assert isinstance(result, AuditBundleResult)
-    assert not result.verified
-    assert result.failures
+    assert result == AuditBundleResult(
+        verified=False,
+        entry_count=1,
+        failures=[f"{failure_path} has invalid object or array shape"],
+    )
+
+
+def test_malformed_bundle_root_returns_failed_result() -> None:
+    result = verify_audit_bundle(None)  # type: ignore[arg-type]
+
+    assert result == AuditBundleResult(
+        verified=False,
+        entry_count=0,
+        failures=["bundle has invalid object or array shape"],
+    )
+
+
+def test_malformed_claim_root_returns_failed_result() -> None:
+    result = verify_audit_bundle(_one_entry_bundle(), "bad")  # type: ignore[arg-type]
+
+    assert result == AuditBundleResult(
+        verified=False,
+        entry_count=1,
+        failures=["claim has invalid object or array shape"],
+    )
 
 
 def test_missing_entries_preserves_existing_failure() -> None:
@@ -81,4 +103,12 @@ def test_missing_entries_preserves_existing_failure() -> None:
         verified=False,
         entry_count=0,
         failures=["bundle has no entries"],
+    )
+
+
+def test_valid_entry_preserves_success() -> None:
+    assert verify_audit_bundle(_one_entry_bundle()) == AuditBundleResult(
+        verified=True,
+        entry_count=1,
+        failures=[],
     )


### PR DESCRIPTION
## What

Malformed external audit bundles and claim containers now return a failed `AuditBundleResult` instead of escaping as Python shape exceptions. Closes #593 after review and merge.

The guards cover bundle/entry containers and nested claim objects. The follow-up also rejects non-string tool names when computing claim summaries and non-string external receipt evidence types before set membership. Hash-chain verification remains active; external receipt verification remains opt-in. Wire format and signature construction are unchanged.

## Validation

- 33 malformed-shape tests pass. Before the follow-up fix, the expanded matrix produced 10 failures and 23 passes, reproducing list/dict hashing errors and mixed-type tool-name sorting errors on correctly hashed bundles.
- 69 focused shape and external-evidence tests pass on the branch combined with current main.
- Final local unit run: 1,806 passed, 8 skipped, one package-metadata mismatch. Building and installing the matching checkout into isolated test dependencies cleared that remaining smoke test on rerun (1 passed).
- Ruff and mypy pass for the changed verifier/tests; Bandit found no issues in the changed verifier before the main merge.
- An earlier run using the older shared dependencies had 20 failures; all 20 also reproduced on the untouched PR head. The final run used isolated TRACE 0.10.0 and Agent Manifest 0.12.0 packages.

The full integration suite and hardware-dependent tests were not run locally. Hosted checks must be evaluated on the latest head, not the older green run. The PR remains draft pending independent re-review.

Current main is merged, with both changelog entries preserved. DCO sign-offs are retained. AI assistance: ChatGPT assisted with reproduction, implementation, tests, and validation; this does not establish independent security assurance.
