### PR TITLE
fix(opaque): fail closed on incomplete managed appraisal

### DIFF
--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -50,11 +50,12 @@ def verify_opaque_measurement(
     header. The header value is never logged -- _redact_auth_headers() strips it
     before any debug output (HW-008).
     """
-    result = OpaqueVerificationResult(verified=True)
+    # Fail closed by default. Positive verification credit is granted only after
+    # the managed verifier explicitly confirms both required success predicates.
+    result = OpaqueVerificationResult(verified=False)
 
     endpoint = opaque_endpoint or os.environ.get(_OPAQUE_ENDPOINT_ENV)
     if not endpoint:
-        result.verified = False
         result.failure_reason = "opaque_endpoint_not_configured"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["hint"] = (
@@ -64,7 +65,6 @@ def verify_opaque_measurement(
 
     if raw_evidence is None:
         # Fail closed: an attestation claim with no evidence cannot verify.
-        result.verified = False
         result.failure_reason = "no_raw_evidence"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["opaque_endpoint"] = endpoint
@@ -101,12 +101,21 @@ def verify_opaque_measurement(
         with urllib.request.urlopen(req, timeout=_OPAQUE_TIMEOUT_SECONDS) as resp:  # nosec B310 - req is a Request object with explicit HTTPS endpoint
             body = json.loads(resp.read().decode())
 
-        if body.get("verified") is True:
+        if not isinstance(body, dict):
+            result.failure_reason = "opaque_invalid_response"
+            result.unverified_fields.append("opaque_managed_attestation")
+            result.details["opaque_response_type"] = type(body).__name__
+        elif body.get("verified") is True and body.get("measurement_matched") is True:
+            result.verified = True
             result.verified_fields.append("opaque_managed_attestation")
             result.details["opaque_endpoint"] = endpoint
         else:
-            result.verified = False
-            result.failure_reason = body.get("failure_reason", "opaque_verification_failed")
+            failure_reason = body.get("failure_reason")
+            result.failure_reason = (
+                failure_reason
+                if isinstance(failure_reason, str) and failure_reason
+                else "opaque_verification_failed"
+            )
             result.unverified_fields.append("opaque_managed_attestation")
             result.details["opaque_response"] = str(body.get("details", ""))
 
@@ -119,6 +128,7 @@ def verify_opaque_measurement(
             type(exc).__name__,
             _redact_auth_headers(request_headers),
         )
+        result.failure_reason = "opaque_verification_error"
         result.unverified_fields.append("opaque_managed_attestation")
         result.details["opaque_endpoint"] = endpoint
         result.details["opaque_error"] = type(exc).__name__

--- a/tests/unit/test_opaque_fail_closed_594.py
+++ b/tests/unit/test_opaque_fail_closed_594.py
@@ -1,0 +1,143 @@
+"""Regression matrix for Opaque managed-attestation fail-closed semantics (#594)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cmcp_verify.opaque import OpaqueVerificationResult, verify_opaque_measurement
+from cmcp_verify.verify import VerificationError, verify_trace_claim
+from tests.unit.test_verify import _approved, _make_signed_claim
+
+_MEASUREMENT = "sha384:" + "a" * 96
+_ENDPOINT = "https://attest.example.com/v1/verify"
+_EVIDENCE = bytes(64)
+
+
+def _response_bytes(payload: bytes) -> MagicMock:
+    response = MagicMock()
+    response.__enter__ = lambda s: s
+    response.__exit__ = MagicMock(return_value=False)
+    response.read.return_value = payload
+    return response
+
+
+def _response_json(payload: object) -> MagicMock:
+    return _response_bytes(json.dumps(payload).encode())
+
+
+def _verify_payload(payload: object) -> OpaqueVerificationResult:
+    with patch("cmcp_verify.opaque.urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _response_json(payload)
+        return verify_opaque_measurement(
+            _MEASUREMENT,
+            _EVIDENCE,
+            opaque_endpoint=_ENDPOINT,
+        )
+
+
+def test_opaque_requires_both_affirmative_success_predicates() -> None:
+    result = _verify_payload({"verified": True, "measurement_matched": True})
+
+    assert result.verified is True
+    assert result.failure_reason is None
+    assert "opaque_managed_attestation" in result.verified_fields
+    assert "opaque_managed_attestation" not in result.unverified_fields
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"verified": True, "measurement_matched": False},
+        {"verified": True},
+        {"measurement_matched": True},
+        {"verified": False, "measurement_matched": True},
+        {"verified": "true", "measurement_matched": True},
+        {"verified": 1, "measurement_matched": True},
+        {"verified": None, "measurement_matched": True},
+        {"verified": True, "measurement_matched": "true"},
+        {"verified": True, "measurement_matched": 1},
+        {"verified": True, "measurement_matched": None},
+    ],
+)
+def test_opaque_refuses_missing_false_or_non_boolean_success_members(payload: object) -> None:
+    result = _verify_payload(payload)
+
+    assert result.verified is False
+    assert result.failure_reason is not None
+    assert "opaque_managed_attestation" in result.unverified_fields
+    assert "opaque_managed_attestation" not in result.verified_fields
+
+
+def test_opaque_preserves_endpoint_failure_reason() -> None:
+    result = _verify_payload(
+        {
+            "verified": False,
+            "measurement_matched": False,
+            "failure_reason": "measurement_unknown",
+        }
+    )
+
+    assert result.verified is False
+    assert result.failure_reason == "measurement_unknown"
+
+
+def test_opaque_requires_parsed_response_to_be_an_object() -> None:
+    result = _verify_payload([])
+
+    assert result.verified is False
+    assert result.failure_reason == "opaque_invalid_response"
+    assert result.details.get("opaque_response_type") == "list"
+    assert "opaque_managed_attestation" in result.unverified_fields
+
+
+def test_opaque_parse_failure_is_unverified_and_observable() -> None:
+    with patch("cmcp_verify.opaque.urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _response_bytes(b"not-json")
+        result = verify_opaque_measurement(
+            _MEASUREMENT,
+            _EVIDENCE,
+            opaque_endpoint=_ENDPOINT,
+        )
+
+    assert result.verified is False
+    assert result.failure_reason == "opaque_verification_error"
+    assert result.details.get("opaque_error") == "JSONDecodeError"
+    assert "opaque_managed_attestation" in result.unverified_fields
+
+
+def test_opaque_transport_failure_is_unverified_and_redacted_to_error_type() -> None:
+    with patch(
+        "cmcp_verify.opaque.urllib.request.urlopen",
+        side_effect=OSError("secret-bearing transport detail"),
+    ):
+        result = verify_opaque_measurement(
+            _MEASUREMENT,
+            _EVIDENCE,
+            opaque_endpoint=_ENDPOINT,
+        )
+
+    assert result.verified is False
+    assert result.failure_reason == "opaque_verification_error"
+    assert result.details.get("opaque_error") == "OSError"
+    assert "secret-bearing transport detail" not in str(result.details)
+
+
+def test_failed_opaque_appraisal_cannot_credit_hardware_attestation(monkeypatch) -> None:
+    claim, _ = _make_signed_claim(provider="opaque")
+    failed = OpaqueVerificationResult(
+        verified=False,
+        unverified_fields=["opaque_managed_attestation"],
+        failure_reason="opaque_verification_failed",
+    )
+    monkeypatch.setattr(
+        "cmcp_verify.opaque.verify_opaque_measurement",
+        lambda *args, **kwargs: failed,
+    )
+
+    result = verify_trace_claim(claim, _approved())
+
+    assert "hardware_attestation" not in result.verified_fields
+    assert "hardware_attestation" in result.unverified_fields
+    assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED

--- a/tests/unit/test_tdx_opaque_verify.py
+++ b/tests/unit/test_tdx_opaque_verify.py
@@ -242,7 +242,7 @@ def test_opaque_endpoint_returns_verified(monkeypatch):
         mock_resp = MagicMock()
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.read.return_value = b'{"verified": true}'
+        mock_resp.read.return_value = b'{"verified": true, "measurement_matched": true}'
         mock_open.return_value = mock_resp
 
         result = verify_opaque_measurement(
@@ -284,6 +284,7 @@ def test_opaque_network_error(monkeypatch):
             opaque_endpoint="https://attest.example.com/v1/verify",
         )
 
-    assert result.verified
+    assert result.verified is False
+    assert result.failure_reason == "opaque_verification_error"
     assert "opaque_managed_attestation" in result.unverified_fields
     assert result.details.get("opaque_error") == "OSError"


### PR DESCRIPTION
Closes #594.

## What

`verify_opaque_measurement()` previously started from `verified=True`, so transport/parse exceptions could return a contradictory positive result. It also treated `{"verified": true}` as sufficient even though the managed appraisal response carries a separate `measurement_matched` predicate.

This patch follows the accepted scope from #594:

- initialize `OpaqueVerificationResult` fail-closed;
- grant positive verification only when the parsed response is an object and both `verified is True` and `measurement_matched is True`;
- reject missing, false, and non-boolean success members;
- keep endpoint-supplied failure reasons when valid;
- keep transport/parse failures unverified with an observable generic failure reason and error-type-only detail;
- refuse parsed non-object JSON explicitly rather than relying on an incidental attribute error.

## Regression coverage

The regression matrix covers:

- `verified=true` + `measurement_matched=true` -> success;
- false or missing `measurement_matched` -> refusal;
- missing `verified` -> refusal;
- `verified=false` -> refusal with endpoint failure reason preserved;
- truthy non-boolean values (`1`, `"true"`) for either predicate -> refusal;
- `null` predicates -> refusal;
- parsed non-object JSON -> refusal;
- malformed JSON -> refusal with parse error type observable;
- transport failure -> refusal with error type observable and exception text not surfaced;
- enclosing `verify_trace_claim()` regression proving a failed Opaque appraisal cannot add `hardware_attestation` to `verified_fields`.

The pre-existing tests that asserted the old fail-open behavior are corrected to the new contract.

## Scope

This intentionally does **not** change the separate stale evidence-plumbing path (`trace.runtime.raw_evidence` versus the shared evidence helper). No wire-format or policy decision is introduced here.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, and diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.