### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-02
+
+**Anyone running 0.4.0 should upgrade.** On 0.4.0 `verify_gateway_measurement()` could return
+`verified=True` for a correctly signed TPM2_NV_Certify pair that does not refer to cMCP's configured
+`TPM_NT_EXTEND` object or its complete 32-byte range (GHSA-943q-hvhp-mrx2). The verifier compared the
+two signed TPM Names only with each other and never against trusted verifier policy, so an accepted AK
+could certify attacker-arranged values from an ordinary NV object and receive an authorization-grade
+verdict. No signature forgery was required. Reported and fixed by
+[Noah Ingwers](https://github.com/noah-ing).
+
+The appraisal API is intentionally breaking: callers that omit the full `GatewayNvAppraisalPolicy` now
+fail closed.
+
 ### Changed
 
 - TPM NV-certify wire parsing now delegates to Agent Manifest 0.11.2 instead of
@@ -365,7 +378,9 @@ Five changes below the headline TPM fix, each one a case where cMCP reported mor
 - `cmcp-verify` standalone verifier for validating TRACE Claims offline
 - Audit chain with Ed25519 signing for tamper-evident log integrity
 
-[Unreleased]: https://github.com/agentrust-io/cmcp/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/agentrust-io/cmcp/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/agentrust-io/cmcp/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/agentrust-io/cmcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/agentrust-io/cmcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/agentrust-io/cmcp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/agentrust-io/cmcp/releases/tag/v0.1.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,3 +38,11 @@ If you are unsure whether an issue is in scope, report it anyway and we will tri
 ## Credit
 
 Reporters of confirmed, in-scope vulnerabilities will be acknowledged by name (or handle, if preferred) in the release notes of the fix. We will not publish details of the report without your consent. If you prefer to remain anonymous, say so in your advisory submission and we will honor that.
+
+### Acknowledgements
+
+Our thanks to the researchers who have reported confirmed vulnerabilities in cMCP:
+
+- [Noah Ingwers](https://github.com/noah-ing) for GHSA-943q-hvhp-mrx2, gateway NV appraisal accepting
+  signed evidence for an unapproved NV object and range, reported with a genuine swtpm reproduction
+  corpus and a complete fix (fixed in 0.4.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cmcp-runtime"
-version = "0.4.0"
+version = "0.4.1"
 description = "Hardware-attested MCP runtime, TEE-enforced policy and TRACE Claim generation"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/cmcp_runtime/__init__.py
+++ b/src/cmcp_runtime/__init__.py
@@ -1,3 +1,3 @@
 """cMCP Runtime: hardware-attested MCP runtime."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/cmcp_runtime/mcp/streamable_http.py
+++ b/src/cmcp_runtime/mcp/streamable_http.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import httpx
 
+from cmcp_runtime import __version__
+
 PROTOCOL_VERSION = "2026-07-28"
 _META_VERSION = "io.modelcontextprotocol/protocolVersion"
 _META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo"
@@ -40,7 +42,7 @@ def build_request(
     body_params = dict(params)
     body_params["_meta"] = {
         _META_VERSION: PROTOCOL_VERSION,
-        _META_CLIENT_INFO: {"name": "cmcp-runtime", "version": "0.4.0"},
+        _META_CLIENT_INFO: {"name": "cmcp-runtime", "version": __version__},
         _META_CLIENT_CAPABILITIES: {},
     }
     body = {


### PR DESCRIPTION
Release prep for 0.4.1, whose headline is the GHSA-943q-hvhp-mrx2 fix merged in #602.

- `pyproject.toml` to 0.4.1, which the release workflow checks against the `v0.4.1` tag
- Cuts the accumulated `[Unreleased]` section as `[0.4.1] - 2026-09-02` with an upgrade lead, matching the shape of the 0.4.0 entry
- Adds a researcher acknowledgements list to SECURITY.md. The Credit section promised acknowledgement by name and there was nowhere it was actually recorded. First entry is @noah-ing.
- Repairs the changelog link refs. `[Unreleased]` still compared from `v0.3.0` and `[0.4.0]` had no entry at all.

Advisory publication follows the release, not this PR.