### PR TITLE
fix(verify): read platform evidence from the cmcp envelope on every branch

### DIFF
--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -1180,7 +1180,7 @@ def verify_trace_claim(
         # the ARK is pinned out of band. Hardware-validated on live Azure SEV-SNP.
         from cmcp_verify.azure_cvm import verify_azure_cvm_measurement
 
-        raw_bytes = base64.b64decode(_runtime["raw_evidence"])
+        raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
         azure_result = verify_azure_cvm_measurement(
             measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,
@@ -1207,14 +1207,12 @@ def verify_trace_claim(
     elif platform == "amd-sev-snp":
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
-        raw_ev = _runtime.get("raw_evidence")
-        raw_bytes = base64.b64decode(raw_ev) if raw_ev else None
+        raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
         report_data_hex = _runtime.get("report_data")
         # VCEK/ASK/ARK chain travels with the claim (passport model); the ARK is
         # pinned by the operator out of band. Both are needed for issue #370
         # report-signature + chain verification; absent either, it stays unverified.
-        _chain_b64 = _runtime.get("cert_chain")
-        cert_chain_pem = base64.b64decode(_chain_b64) if _chain_b64 else None
+        cert_chain_pem = _evidence_field(claim_json, _runtime, "cert_chain")
         snp_result = verify_sev_snp_measurement(
             measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,
@@ -1246,8 +1244,7 @@ def verify_trace_claim(
     elif platform == "intel-tdx":
         from cmcp_verify.tdx import verify_tdx_measurement
 
-        raw_ev = _runtime.get("raw_evidence")
-        raw_bytes = base64.b64decode(raw_ev) if raw_ev else None
+        raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
         report_data_hex = _runtime.get("report_data")
         # The DCAP quote (with its embedded PCK cert chain) travels with the claim
         # (passport model); the Intel SGX/TDX root CA is pinned by the operator out
@@ -1288,8 +1285,7 @@ def verify_trace_claim(
     elif platform in ("opaque", "opaque-managed"):
         from cmcp_verify.opaque import verify_opaque_measurement
 
-        raw_ev = _runtime.get("raw_evidence")
-        raw_bytes = base64.b64decode(raw_ev) if raw_ev else None
+        raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
         opaque_result = verify_opaque_measurement(
             measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,

--- a/tests/unit/test_evidence_envelope_all_platforms.py
+++ b/tests/unit/test_evidence_envelope_all_platforms.py
@@ -1,0 +1,180 @@
+"""Issue #595: every hardware branch must read evidence from the cmcp envelope.
+
+#469/#370 moved signed platform evidence out of ``trace.runtime`` and into
+``gateway.attestation_evidence``, because ``RuntimeInfo`` belongs to
+agentrust-trace and is ``extra="forbid"``: a claim carrying evidence under
+``trace.runtime`` is rejected as CLAIM_MALFORMED before any platform branch
+runs. ``_evidence_field()`` exists to read the new location with a fallback to
+the old one.
+
+Only the ``tpm2`` branch used it. The other four read ``_runtime`` directly, so
+against a claim produced by current code:
+
+* ``azure-cvm-sev-snp`` did ``_runtime["raw_evidence"]`` and raised ``KeyError``
+  on a schema-valid claim;
+* ``amd-sev-snp``, ``intel-tdx`` and ``opaque``/``opaque-managed`` used
+  ``_runtime.get(...)``, silently passing ``None`` to their platform verifier,
+  so attestation degraded to unverified with no indication why.
+
+Each test below asserts the platform verifier *receives the evidence bytes*,
+which is the property that was broken. Asserting on the final verdict would
+pass for the wrong reason, since a verifier handed ``None`` also reports
+``hardware_attestation`` as unverified.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+
+from cmcp_runtime.audit.chain import AuditChain
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.audit.trace_claim import (
+    AttestationReportInfo,
+    CallGraphSummary,
+    CallSummary,
+    PolicyBundleInfo,
+    ToolCatalogInfo,
+    _to_dict,
+    canonical_json,
+    generate_trace_claim,
+)
+from cmcp_runtime.tee.base import jwk_thumbprint
+from cmcp_verify.verify import ApprovedHashes, verify_trace_claim
+
+POLICY_HASH = "sha256:" + "a" * 64
+CATALOG_HASH = "sha256:" + "b" * 64
+VALID_MEASUREMENT = "sha256:" + "c" * 64
+
+EVIDENCE = b"\xde\xad\xbe\xef" * 8
+CERT_CHAIN = b"-----BEGIN CERTIFICATE-----\nsynthetic\n-----END CERTIFICATE-----\n"
+
+
+def _claim(provider: str, *, platform_override: str | None = None) -> dict:
+    """A schema-valid claim carrying evidence through the real producer path."""
+    key = SigningKey()
+    chain = AuditChain(f"{provider}-session")
+    root_hex = chain.chain_root.removeprefix("sha256:").removeprefix("sha384:")
+    report_data = (
+        jwk_thumbprint(key.public_key_bytes)
+        + hashlib.sha256(bytes.fromhex(root_hex)).digest()
+    ).hex()
+    claim = generate_trace_claim(
+        session_id=f"{provider}-session",
+        signing_key=key,
+        attestation_report=AttestationReportInfo(
+            provider=provider,
+            measurement=VALID_MEASUREMENT,
+            report_data=report_data,
+            attestation_generated_at=datetime.now(tz=UTC).isoformat(),
+            attestation_validity_seconds=86400,
+            raw_evidence=base64.b64encode(EVIDENCE).decode(),
+            cert_chain=base64.b64encode(CERT_CHAIN).decode(),
+        ),
+        policy_bundle=PolicyBundleInfo(
+            hash=POLICY_HASH, enforcement_mode="enforcing", policy_version="1.0.0"
+        ),
+        tool_catalog=ToolCatalogInfo(hash=CATALOG_HASH),
+        call_summary=CallSummary(
+            tool_calls_total=1,
+            tool_calls_allowed=1,
+            tool_calls_denied=0,
+            tool_calls_faulted=0,
+            tools_invoked=["test.tool"],
+            session_max_sensitivity="public",
+            call_graph_summary=CallGraphSummary(
+                compliance_domains_touched=[], cross_boundary_events=[]
+            ),
+        ),
+        audit_chain_root=chain.chain_root,
+        audit_chain_tip=chain.chain_tip,
+        audit_chain_length=chain.length,
+        do_sign=False,
+    )
+    claim_dict = _to_dict(claim)
+    if platform_override is not None:
+        claim_dict["trace"]["runtime"]["platform"] = platform_override
+    # Sign last, so the signature covers the evidence and any platform override.
+    claim_dict["signature"] = (
+        base64.urlsafe_b64encode(key.sign(canonical_json(claim_dict))).rstrip(b"=").decode()
+    )
+    return claim_dict
+
+
+def _approved() -> ApprovedHashes:
+    return ApprovedHashes(policy_bundle_hash=POLICY_HASH, tool_catalog_hash=CATALOG_HASH)
+
+
+def _evidence_is_in_the_envelope_not_runtime(claim: dict) -> None:
+    """The producer path put the evidence where #469 says it goes."""
+    assert "raw_evidence" in claim["gateway"]["attestation_evidence"]
+    assert "raw_evidence" not in claim["trace"]["runtime"]
+
+
+class _Spy:
+    """Captures the kwargs the platform verifier was called with."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    def __call__(self, **kwargs):
+        self.kwargs = kwargs
+
+        class _Result:
+            verified = False
+            verified_fields: list[str] = []
+            unverified_fields: list[str] = []
+            details: dict[str, str] = {}
+            failure_reason = "spy"
+
+        return _Result()
+
+
+@pytest.mark.parametrize(
+    ("provider", "platform_override", "module", "func"),
+    [
+        ("azure-cvm-sev-snp", None, "cmcp_verify.azure_cvm", "verify_azure_cvm_measurement"),
+        ("sev-snp", None, "cmcp_verify.sev_snp", "verify_sev_snp_measurement"),
+        ("tdx", None, "cmcp_verify.tdx", "verify_tdx_measurement"),
+        ("tdx", "opaque", "cmcp_verify.opaque", "verify_opaque_measurement"),
+    ],
+)
+def test_platform_branch_reads_evidence_from_the_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    platform_override: str | None,
+    module: str,
+    func: str,
+) -> None:
+    """The branch must receive the evidence bytes, not None and not a KeyError."""
+    claim = _claim(provider, platform_override=platform_override)
+    _evidence_is_in_the_envelope_not_runtime(claim)
+
+    spy = _Spy()
+    monkeypatch.setattr(f"{module}.{func}", spy)
+
+    # Before the fix: azure-cvm-sev-snp raised KeyError here, and the other
+    # three called their verifier with raw_evidence=None.
+    verify_trace_claim(claim, _approved())
+
+    assert spy.kwargs is not None, f"{func} was never reached"
+    assert spy.kwargs["raw_evidence"] == EVIDENCE
+
+
+def test_sev_snp_reads_the_cert_chain_from_the_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The VCEK chain is the other field the SNP branch read from runtime."""
+    claim = _claim("sev-snp")
+    assert "cert_chain" in claim["gateway"]["attestation_evidence"]
+    assert "cert_chain" not in claim["trace"]["runtime"]
+
+    spy = _Spy()
+    monkeypatch.setattr("cmcp_verify.sev_snp.verify_sev_snp_measurement", spy)
+    verify_trace_claim(claim, _approved())
+
+    assert spy.kwargs is not None
+    assert spy.kwargs["cert_chain_pem"] == CERT_CHAIN


### PR DESCRIPTION
Fixes the routing half of #595.

## Confirmed, and one branch further than reported

At `e55f577`, only `tpm2` used `_evidence_field()`. Reading each branch rather than grepping for the pattern:

| branch | line | read | effect on a current claim |
|---|---|---|---|
| `tpm2` | 1067 | `_evidence_field(...)` | correct |
| `azure-cvm-sev-snp` | 1183 | `base64.b64decode(_runtime["raw_evidence"])` | **`KeyError`** on a schema-valid claim |
| `amd-sev-snp` | 1210, 1216 | `_runtime.get(...)` | evidence and VCEK chain silently `None` |
| `intel-tdx` | 1249 | `_runtime.get(...)` | evidence silently `None` |
| `opaque` / `opaque-managed` | 1291 | `_runtime.get(...)` | evidence silently `None` |

@altrudev named three. `opaque`/`opaque-managed` is a fourth with the same defect.

The silent-drop cases are the worse half. A `KeyError` is loud and gets found. Three branches passing `None` to their platform verifier means attestation degrades to `unverified` with nothing anywhere indicating the evidence was present and unread, which is the failure mode you cannot see from the output.

## The fix

Four call sites routed through the existing `_evidence_field()`, which prefers `gateway.attestation_evidence` and falls back to `trace.runtime` so pre-#469 fixtures still verify. Net 5 added, 9 removed: the helper returns decoded bytes, so the local `base64.b64decode` dance goes away.

## The tests

`tests/unit/test_evidence_envelope_all_platforms.py`, five cases, one per branch plus the SNP cert chain.

Each builds a claim **through the real producer path** (`AttestationReportInfo` -> `generate_trace_claim`), asserts the evidence landed in `gateway.attestation_evidence` and not in `trace.runtime`, then spies on the platform verifier and asserts it **received the evidence bytes**.

Asserting on the final verdict would have passed for the wrong reason: a verifier handed `None` also reports `hardware_attestation` as unverified, so the test would be green before and after the fix. The received-argument assertion is the only one that discriminates.

**Proven against the pre-fix file**, by restoring `origin/main`'s `verify.py` under the new tests:

```
azure-cvm-sev-snp   KeyError: 'raw_evidence'
amd-sev-snp         assert None == b'\xde\xad\xbe\xef...'
intel-tdx           assert None == b'\xde\xad\xbe\xef...'
opaque              assert None == b'\xde\xad\xbe\xef...'
sev-snp cert chain  assert None == b'-----BEGIN CERTIFICATE-----...'
5 failed
```

With the fix: 5 passed. Full unit suite 1474 passed; the two failures are pre-existing on `main` and unrelated (`test_release_distribution_smoke` fails with `runtime version '0.4.1' != metadata '0.4.0'`, a local install mismatch, and `test_mock_upstream_gate` passes in isolation both with and without this change).

## Deliberately not fixed here

The SNP and TDX branches also read `report_data`, and TDX reads `raw_quote`. **Neither field has a home in either model**: `RuntimeInfo` permits only `platform`, `measurement`, `rim_uri`, `nonce`, `firmware_version` and is `extra="forbid"`, and `AttestationEvidence` carries only `raw_evidence`, `quote_signature`, `cert_chain`, `ek_cert_chain`. So both are permanently `None` on any claim from current code, and routing cannot reach them: it needs a field added to `AttestationEvidence` and the producer populating it.

That matters for SNP in particular, where `report_data` is what binds the report to the claim. Raising it on #595 rather than widening this PR.

One smaller observation, not acted on: no entry in `_PROVIDER_MAP` produces `platform: "opaque"` or `"opaque-managed"`, so that branch is unreachable from our own producer and only a third-party claim can enter it. Its test sets the platform explicitly and re-signs.
