### PR TITLE
fix(verify): bind platform evidence to the TRACE nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bind SNP, Azure CVM and TDX evidence to the claim's existing
+  `trace.runtime.nonce` (#595). These branches previously read a `report_data`
+  field forbidden by the runtime schema, passing `None` to an optional binding
+  check. A valid report for a different key or audit root could therefore receive
+  hardware-verification credit on the SNP and Azure paths. The verifier now
+  requires the canonical 64-byte nonce and checks it against the report (or the
+  AK-signed quote on Azure). TDX TDREPORT-only claims remain partially verified;
+  this does not add DCAP quote collection or transport.
+
 ## [0.4.1] - 2026-09-02
 
 **Anyone running 0.4.0 should upgrade.** On 0.4.0 `verify_gateway_measurement()` could return

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -106,9 +106,14 @@ Three gaps are worth stating plainly for the TPM path:
   rejected as `CLAIM_MALFORMED` before platform verification runs. Signed
   evidence therefore travels as `gateway.attestation_evidence`, a cmcp-owned
   field. The verifier still reads `trace.runtime` as a fallback so older claims
-  keep working, but that path cannot pass schema validation. **The SEV-SNP
-  `cert_chain` path has not been migrated and remains subject to this**, so its
-  VCEK chain verification does not engage for a schema-valid claim.
+  keep working, but that path cannot pass schema validation. All current
+  platform branches read the envelope, including the SNP VCEK chain. SNP,
+  Azure CVM and TDX compare their evidence binding against the 64-byte value
+  already carried as `trace.runtime.nonce`; missing or malformed nonces cannot
+  disable that check. **TDX DCAP quote collection and transport remain absent**:
+  the current provider collects a TDREPORT, and the claim models do not carry
+  `raw_quote`. TDX claims therefore remain partially verified without a verified
+  quote signature. The standalone quote-verification API is a separate path.
 - **The gateway NV-certify pair is not an ordinary TRACE-claim property.** TPM
   startup collects a bracketing pair, and the standalone appraisal accepts it
   only with a verifier-owned root, nonce, exact NV Name and range, and expected

--- a/docs/spec/attestation.md
+++ b/docs/spec/attestation.md
@@ -284,6 +284,14 @@ nonce = JWK_thumbprint(tee_public_key) (32 bytes) || random_salt (32 bytes)
 - `random_salt`: 32 random bytes generated once per enclave startup, so two enclave instances produce distinct nonces even with the same key (e.g. blue-green deploy). On SEV-SNP, TDX and Azure CVM this half carries the gateway measurement instead; see §3.3.2.
 - The 64-byte value is passed as the `report_data` / `user_data` / `reportdata` / `qualifying_data` field when requesting the hardware attestation report. The field name varies by provider; the semantic is the same: a caller-supplied value included in the signed measurement.
 
+In a canonical TRACE Claim this value is serialized as `trace.runtime.nonce`
+(unpadded base64url), not as a separate `trace.runtime.report_data` field.
+SNP, Azure CVM and TDX verification decode that exact 64-byte nonce and compare
+it with the platform evidence. An absent or malformed nonce fails hardware
+appraisal rather than skipping the binding check. On Azure the comparison is
+against the AK-signed quote's `extraData`, which commits `SHA-256(nonce)`;
+the paravisor controls the SNP report's own `REPORT_DATA`.
+
 Verifier check (key binding, CRYPTO-001):
 
 ```

--- a/src/cmcp_verify/verify.py
+++ b/src/cmcp_verify/verify.py
@@ -192,6 +192,20 @@ def _jwk_x_to_hex(x_b64: str) -> str | None:
         return None
 
 
+def _platform_report_data(nonce: Any) -> str | None:
+    """Recover the producer's 64-byte report_data from canonical TRACE nonce.
+
+    A missing/invalid expectation must never become None at a platform verifier:
+    those lower-level APIs interpret None as skipping the binding check.
+    """
+    if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]{86}", nonce):
+        return None
+    raw = base64.b64decode(nonce + "==", altchars=b"-_", validate=True)
+    if len(raw) != 64 or base64.urlsafe_b64encode(raw).rstrip(b"=").decode() != nonce:
+        return None
+    return raw.hex()
+
+
 def _verify_signature(claim: dict[str, Any]) -> tuple[bool, str | None]:
     """Verify the Ed25519 signature using the JWK public key in trace.cnf.jwk.x."""
     try:
@@ -1052,10 +1066,21 @@ def verify_trace_claim(
 
     # Step 8: Platform-specific attestation
     platform = _runtime.get("platform", "")
+    # _build_runtime serializes AttestationReportInfo.report_data as nonce.
+    # Compare that same value with the signed evidence, rather than reading a
+    # report_data field that canonical RuntimeInfo forbids (#595).
+    report_data_hex = _platform_report_data(_runtime.get("nonce"))
 
     if _is_sw_only:
         unverified.append("hardware_attestation")
         details["hardware_attestation"] = "software-only mode - not hardware-backed"
+    elif platform in ("azure-cvm-sev-snp", "amd-sev-snp", "intel-tdx") and report_data_hex is None:
+        unverified.append("hardware_attestation")
+        failure = failure or VerificationError.HARDWARE_ATTESTATION_FAILED
+        details["hardware_attestation"] = (
+            "trace.runtime.nonce must encode exactly 64 bytes as canonical unpadded "
+            "base64url; platform report binding cannot be checked"
+        )
     elif platform == "tpm2":
         from cmcp_verify.tpm import (
             verify_ak_ek_chain,
@@ -1184,7 +1209,7 @@ def verify_trace_claim(
         azure_result = verify_azure_cvm_measurement(
             measurement=_runtime.get("measurement", ""),
             raw_evidence=raw_bytes,
-            report_data_hex=_runtime.get("report_data"),
+            report_data_hex=report_data_hex,
             trusted_ark_pem=trusted_ark_pem,
         )
         chain_ok = "vcek_cert_chain" not in azure_result.unverified_fields
@@ -1208,7 +1233,6 @@ def verify_trace_claim(
         from cmcp_verify.sev_snp import verify_sev_snp_measurement
 
         raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
-        report_data_hex = _runtime.get("report_data")
         # VCEK/ASK/ARK chain travels with the claim (passport model); the ARK is
         # pinned by the operator out of band. Both are needed for issue #370
         # report-signature + chain verification; absent either, it stays unverified.
@@ -1245,7 +1269,6 @@ def verify_trace_claim(
         from cmcp_verify.tdx import verify_tdx_measurement
 
         raw_bytes = _evidence_field(claim_json, _runtime, "raw_evidence")
-        report_data_hex = _runtime.get("report_data")
         # The DCAP quote (with its embedded PCK cert chain) travels with the claim
         # (passport model); the Intel SGX/TDX root CA is pinned by the operator out
         # of band. Both are needed for issue #370 quote-signature verification;

--- a/tests/unit/test_evidence_envelope_all_platforms.py
+++ b/tests/unit/test_evidence_envelope_all_platforms.py
@@ -53,9 +53,11 @@ EVIDENCE = b"\xde\xad\xbe\xef" * 8
 CERT_CHAIN = b"-----BEGIN CERTIFICATE-----\nsynthetic\n-----END CERTIFICATE-----\n"
 
 
-def _claim(provider: str, *, platform_override: str | None = None) -> dict:
+def _claim(
+    provider: str, *, platform_override: str | None = None, key: SigningKey | None = None
+) -> dict:
     """A schema-valid claim carrying evidence through the real producer path."""
-    key = SigningKey()
+    key = key or SigningKey()
     chain = AuditChain(f"{provider}-session")
     root_hex = chain.chain_root.removeprefix("sha256:").removeprefix("sha384:")
     report_data = (

--- a/tests/unit/test_platform_nonce_binding.py
+++ b/tests/unit/test_platform_nonce_binding.py
@@ -1,0 +1,111 @@
+"""#595: real platform appraisal must bind evidence to the signed claim nonce.
+
+Synthetic SNP/Azure signatures exercise the full cryptographic chain. TDX's
+TDREPORT-only path must detect mismatches while remaining partially verified.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+
+from cmcp_runtime.audit.keys import SigningKey
+from cmcp_runtime.audit.trace_claim import canonical_json
+from cmcp_verify.verify import VerificationError, VerificationStatus, verify_trace_claim
+from tests.unit.test_azure_cvm_verify import _build_evidence
+from tests.unit.test_evidence_envelope_all_platforms import _approved, _claim
+from tests.unit.test_snp_signature_verify import _signed_report, _synthetic_chain
+from tests.unit.test_tdx_opaque_verify import _make_tdreport
+
+
+def _resign(claim: dict, key: SigningKey) -> None:
+    claim.pop("signature", None)
+    claim["signature"] = base64.urlsafe_b64encode(key.sign(canonical_json(claim))).rstrip(b"=").decode()
+
+
+def _with_evidence(provider: str, *, mismatch: int | None = None) -> tuple[dict, SigningKey, dict]:
+    key = SigningKey()
+    claim = _claim(provider, key=key)
+    runtime = claim["trace"]["runtime"]
+    nonce = bytearray(base64.urlsafe_b64decode(runtime["nonce"] + "=="))
+    if mismatch is not None:
+        nonce[mismatch] ^= 1
+    evidence = claim["gateway"]["attestation_evidence"]
+    kwargs = {}
+    if provider == "sev-snp":
+        chain, root, vcek = _synthetic_chain()
+        raw, measurement = _signed_report(vcek, measurement_bytes=b"\x11" * 48, report_data=bytes(nonce))
+        evidence["cert_chain"] = base64.b64encode(chain).decode()
+        kwargs["trusted_ark_pem"] = root
+    elif provider == "azure-cvm-sev-snp":
+        raw, measurement, root = _build_evidence(bytes(nonce))
+        kwargs["trusted_ark_pem"] = root
+    else:
+        mrtd = b"\x11" * 48
+        raw = _make_tdreport(mrtd, bytes(nonce))
+        measurement = "sha384:" + hashlib.sha384(mrtd).hexdigest()
+    runtime["measurement"] = measurement
+    evidence["raw_evidence"] = base64.b64encode(raw).decode()
+    _resign(claim, key)
+    return claim, key, kwargs
+
+
+@pytest.mark.parametrize("provider", ["sev-snp", "azure-cvm-sev-snp", "tdx"])
+@pytest.mark.parametrize("mismatch", [None, 0, 32, 63])
+def test_platform_evidence_binds_both_nonce_halves(monkeypatch, provider, mismatch):
+    monkeypatch.setattr("cmcp_verify.tdx._check_dcap_reachable", lambda: False)
+    claim, _, kwargs = _with_evidence(provider, mismatch=mismatch)
+    result = verify_trace_claim(claim, _approved(), **kwargs)
+    assert "schema" in result.verified_fields
+    assert "signature" in result.verified_fields
+    # These generic checks only compare the claim with itself. The platform
+    # verifier must independently compare it with the hardware evidence.
+    assert "public_key_binding" in result.verified_fields
+    if mismatch is not None:
+        assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED
+        assert "hardware_attestation" not in result.verified_fields
+        assert result.status != VerificationStatus.VERIFIED
+    elif provider == "tdx":
+        assert result.failure_reason is None
+        assert result.status == VerificationStatus.PARTIALLY_VERIFIED
+        assert "report_data" in result.verified_fields
+        assert "dcap_quote_signature" in result.unverified_fields
+    else:
+        assert result.failure_reason is None
+        assert "hardware_attestation" in result.verified_fields
+        binding = "quote_nonce_binding" if provider == "azure-cvm-sev-snp" else "report_data"
+        assert binding in result.verified_fields
+
+
+@pytest.mark.parametrize("provider", ["sev-snp", "azure-cvm-sev-snp", "tdx"])
+@pytest.mark.parametrize("nonce", [None, "", "!" * 86, "oversized", "short", "noncanonical"])
+def test_invalid_nonce_never_reaches_optional_binding_verifier(monkeypatch, provider, nonce):
+    key = SigningKey()
+    claim = _claim(provider, key=key)
+    original = claim["trace"]["runtime"]["nonce"]
+    if nonce == "oversized":
+        raw = base64.urlsafe_b64decode(original + "==") + b"x"
+        nonce = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+    elif nonce == "short":
+        raw = base64.urlsafe_b64decode(original + "==")[:32]
+        nonce = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+    elif nonce == "noncanonical":
+        alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        nonce = original[:-1] + alphabet[alphabet.index(original[-1]) + 1]
+    if nonce is None:
+        claim["trace"]["runtime"].pop("nonce")
+    else:
+        claim["trace"]["runtime"]["nonce"] = nonce
+    _resign(claim, key)
+    module, func = {
+        "sev-snp": ("sev_snp", "verify_sev_snp_measurement"),
+        "azure-cvm-sev-snp": ("azure_cvm", "verify_azure_cvm_measurement"),
+        "tdx": ("tdx", "verify_tdx_measurement"),
+    }[provider]
+    def unexpected(**kwargs):
+        pytest.fail("invalid nonce must not disable the platform's optional binding check")
+    monkeypatch.setattr(f"cmcp_verify.{module}.{func}", unexpected)
+    result = verify_trace_claim(claim, _approved())
+    assert "hardware_attestation" in result.unverified_fields
+    assert "hardware_attestation" not in result.verified_fields


### PR DESCRIPTION
## What

Bind SNP, Azure CVM and TDX evidence to the 64-byte value already serialized as `trace.runtime.nonce`. These branches previously read `trace.runtime.report_data`, which the canonical schema forbids, and passed `None` to lower-level APIs where it disables the binding check. The verifier now decodes the canonical nonce, supplies its hex representation to platform appraisal, and refuses hardware credit when the expectation is absent or malformed.

## Why

Addresses the report-data portion of #595 after #607 restored evidence routing. No new report-data carrier is needed: `_build_runtime()` already encodes `AttestationReportInfo.report_data` into `trace.runtime.nonce`.

For example, a schema-valid, correctly signed SNP claim can currently contain a genuine synthetic VCEK-signed report committing a different nonce and still receive `hardware_attestation` credit. With this change, the same claim returns `HARDWARE_ATTESTATION_FAILED` and no hardware credit. Azure's comparison checks the AK-signed quote's `extraData == SHA-256(nonce)`; TDX checks TDREPORT report-data and retains partial status without an authenticated quote.

This PR deliberately does not close #595. TDX DCAP quote collection and claim transport remain absent; the current provider collects only a TDREPORT. `LIMITATIONS.md` records that remaining work and removes the obsolete statement that SNP certificate-chain routing is still missing.

## Security impact

Restores the link between the signed hardware evidence and the claim's gateway-key/audit-root nonce. Generic key/root consistency checks within a claim do not establish this link by themselves. Missing, short, oversized, illegal-alphabet and noncanonical nonce encodings cannot turn the platform's binding check off. Existing failure precedence and partial-verification reporting are preserved.

Tests use locally generated synthetic SNP/Azure certificate chains and signatures, plus synthetic TDX TDREPORTs. No new live-hardware validation is claimed. The standalone platform verifier APIs are unchanged.

## Test plan

- [x] Unit, conformance and integration suite: **1577 passed, 6 skipped**, **87.72% coverage**.
- [x] All **30 new regressions fail on base `7178c4089a022d93451077aff7ec090759c45b7a`** and pass with this change. They cover matching reports, mismatches in both nonce halves, and invalid expectations across SNP, Azure and TDX.
- [x] Existing five evidence-envelope routing regressions pass.
- [x] `ruff check src/ tests/`
- [x] `mypy src/cmcp_runtime/ src/cmcp_verify/` (66 source files)
- [x] `bandit -r src/ -c pyproject.toml`
- [x] `pip-audit --skip-editable` (no known dependency vulnerabilities)
- [x] `git diff --check`

## DCO sign-off

- [x] I certify that I wrote or have the right to submit this contribution, and I agree to the Developer Certificate of Origin (https://developercertificate.org).
