### PR TITLE
fix(security): pin actions to SHAs, scope tokens, broaden credential redaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -21,9 +24,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,7 +51,7 @@ jobs:
         run: pytest tests/unit/ tests/conformance/ tests/integration/ -v --tb=short --cov=src --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: false
 
@@ -57,9 +60,9 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -95,7 +98,7 @@ jobs:
           test "$status" -eq 0 || test "$status" -eq 1
 
       - name: Upload governance artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: agt-governance-${{ github.sha }}
           path: |
@@ -109,9 +112,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -122,7 +125,7 @@ jobs:
         run: python -m cmcp_runtime.benchmarks --provider software-only --calls 10000 --out benchmarks/
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: benchmark-results
           path: benchmarks/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,18 +25,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.9
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.9
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.9
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: /language:python

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -27,11 +30,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +47,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -54,7 +57,7 @@ jobs:
 
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/')
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.10.1
 
       - name: Sign the image (keyless, by digest)
         if: startsWith(github.ref, 'refs/tags/')
@@ -64,7 +67,7 @@ jobs:
 
       - name: Attest build provenance (SLSA)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.0.0
         with:
           subject-name: ghcr.io/agentrust-io/cmcp-gateway
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/limitations-parity.yml
+++ b/.github/workflows/limitations-parity.yml
@@ -32,7 +32,7 @@ jobs:
   parity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compare the shared block with trace-spec
         run: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,21 +5,25 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   draft-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "cmcp ${{ github.ref_name }}" \
+          gh release create "$REF_NAME" \
+            --title "cmcp $REF_NAME" \
             --generate-notes \
             --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,15 @@ jobs:
 
       - name: Install and smoke-test wheel and sdist
         shell: bash
+        env:
+          # Never interpolate a tag name into the shell: ${{ }} expands before
+          # bash parses the line, so the tag is code rather than a value.
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           expected_version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
-          if [[ "${{ github.event_name }}" == "release" ]] && [[ "${{ github.event.release.tag_name }}" != "v$expected_version" ]]; then
-            echo "release tag ${{ github.event.release.tag_name }} does not match package version $expected_version" >&2
+          if [[ "$EVENT_NAME" == "release" ]] && [[ "$RELEASE_TAG" != "v$expected_version" ]]; then
+            echo "release tag $RELEASE_TAG does not match package version $expected_version" >&2
             exit 1
           fi
           index=0
@@ -113,6 +118,8 @@ jobs:
 
       - name: Attach evidence to release
         if: github.event_name == 'release'
-        run: gh release upload ${{ github.ref_name }} agt-evidence.json agt-attestation.json
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "$REF_NAME" agt-evidence.json agt-attestation.json
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,6 +9,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+permissions:
+  contents: read
+
 jobs:
   sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -35,6 +35,6 @@ jobs:
           publish_results: false
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: scorecard-results.sarif

--- a/src/cmcp_verify/opaque.py
+++ b/src/cmcp_verify/opaque.py
@@ -15,10 +15,36 @@ _OPAQUE_API_KEY_ENV = "OPAQUE_API_KEY"
 _OPAQUE_TIMEOUT_SECONDS = 10
 
 
+# HW-008: header names whose values never reach a log. Matched as substrings
+# against the lower-cased header name, so x-api-key, proxy-authorization and
+# set-cookie are all covered without enumerating every vendor spelling.
+_SENSITIVE_HEADER_PARTS = (
+    "authorization",
+    "auth",
+    "api-key",
+    "apikey",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "signature",
+)
+
+
 def _redact_auth_headers(headers: dict[str, str]) -> dict[str, str]:
-    """HW-008: return a copy of headers with Authorization value replaced by [REDACTED]."""
+    """HW-008: return a copy of headers with every credential-bearing value redacted.
+
+    Redacting only Authorization was too narrow: the same call is configured with
+    OPAQUE_API_KEY, and a deployment that carries it in x-api-key or a cookie would
+    have logged it in clear. Redaction is now deny-by-default over a name match.
+    """
     return {
-        k: "[REDACTED]" if k.lower() == "authorization" else v
+        k: (
+            "[REDACTED]"
+            if any(part in k.lower() for part in _SENSITIVE_HEADER_PARTS)
+            else v
+        )
         for k, v in headers.items()
     }
 

--- a/tests/unit/test_opaque_fail_closed_594.py
+++ b/tests/unit/test_opaque_fail_closed_594.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cmcp_verify.opaque import OpaqueVerificationResult, verify_opaque_measurement
+from cmcp_verify.opaque import (
+    OpaqueVerificationResult,
+    _redact_auth_headers,
+    verify_opaque_measurement,
+)
 from cmcp_verify.verify import VerificationError, verify_trace_claim
 from tests.unit.test_verify import _approved, _make_signed_claim
 
@@ -141,3 +145,45 @@ def test_failed_opaque_appraisal_cannot_credit_hardware_attestation(monkeypatch)
     assert "hardware_attestation" not in result.verified_fields
     assert "hardware_attestation" in result.unverified_fields
     assert result.failure_reason == VerificationError.HARDWARE_ATTESTATION_FAILED
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Authorization",
+        "authorization",
+        "Proxy-Authorization",
+        "X-API-Key",
+        "x-apikey",
+        "Cookie",
+        "Set-Cookie",
+        "X-Auth-Token",
+        "X-Opaque-Secret",
+        "X-Client-Password",
+        "X-Signed-Credential",
+        "X-Request-Signature",
+    ],
+)
+def test_credential_bearing_headers_are_never_logged_in_clear(header: str) -> None:
+    """HW-008: redaction is deny-by-default, not an Authorization special case.
+
+    Redacting only Authorization left OPAQUE_API_KEY in clear for any deployment
+    that carries it under a vendor header spelling or a cookie.
+    """
+    redacted = _redact_auth_headers({header: "super-secret-value"})
+
+    assert redacted[header] == "[REDACTED]"
+    assert "super-secret-value" not in str(redacted)
+
+
+def test_redaction_leaves_non_credential_headers_readable() -> None:
+    """Redaction must not blind the debug log to the fields that explain a failure."""
+    redacted = _redact_auth_headers(
+        {"Content-Type": "application/json", "User-Agent": "cmcp/1.0", "Accept": "*/*"}
+    )
+
+    assert redacted == {
+        "Content-Type": "application/json",
+        "User-Agent": "cmcp/1.0",
+        "Accept": "*/*",
+    }

--- a/tests/unit/test_tls_pinning.py
+++ b/tests/unit/test_tls_pinning.py
@@ -130,6 +130,9 @@ def tls_material(tmp_path_factory):
 def tls_server(tls_material):
     server = _QuietHTTPServer(("127.0.0.1", 0), _MockMCPHandler)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # PROTOCOL_TLS_SERVER leaves TLSv1 and TLSv1.1 reachable. The pinning tests
+    # should exercise the same floor the gateway enforces, not a weaker one.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.load_cert_chain(tls_material["cert_file"], tls_material["key_file"])
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
     thread = threading.Thread(target=server.serve_forever, daemon=True)


### PR DESCRIPTION
Part of a proactive security sweep across agentrust-io. cmcp had the largest share of the real findings.

## Action pinning (24 refs)

Every third-party action ran from a mutable tag. The ones that matter are on the release path and hold credentials:

- `docker/login-action@v4` (registry credentials)
- `sigstore/cosign-installer@v3` (signing)
- `actions/attest-build-provenance@v4` (`id-token: write`)
- `docker/build-push-action@v7`

A tag is repointable by whoever controls the action repo, so signing and publishing trusted a moving target. All now pin a commit SHA with the version kept in a trailing comment.

## Token scope

`ci.yml`, `docker.yml`, `release-drafter.yml` and `sbom.yml` had no top-level `permissions:` block, so any job without its own block inherited the repository default. Added `contents: read` as the floor. `docker.yml` and `sbom.yml` already declared job-level `packages: write` / `id-token: write` and keep them, so no job loses a capability it was using.

## Shell injection

Four sites interpolated `github.event.release.tag_name` or `github.ref_name` directly into `run:` blocks. `${{ }}` expands before bash parses the line, so those names were shell input rather than arguments. All now go through `env:`.

Defence in depth rather than a live hole, since creating a tag or release already needs write access.

## Credential redaction (code-scanning #136)

`_redact_auth_headers` redacted only `Authorization`. The same call is configured with `OPAQUE_API_KEY`, so a deployment carrying it in `x-api-key`, `x-auth-token` or a cookie would have written it to the debug log in clear. Redaction is now deny-by-default over a name match, with a parametrized test across the spellings that leaked and a companion test proving non-credential headers stay readable, since blinding that log would cost the failure diagnostics it exists for.

## TLS floor (code-scanning #2)

The pinning fixture built its server with `PROTOCOL_TLS_SERVER` and no floor, leaving TLSv1 and TLSv1.1 reachable in the very test that asserts the gateway transport rules. Sets `minimum_version = TLSv1_2`.

## Verification

`tests/unit/test_tls_pinning.py` 12 passed, `test_opaque_fail_closed_594.py` 29 passed. Full suite 1604 passed with 4 failures that reproduce on a clean checkout of `main`: the local venv has agent-manifest 0.11.1 against a `>=0.11.2` pin. Unrelated to this change, and CI installs the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t