### PR TITLE
fix(catalog): make cert-pinned rotation mode reachable

### DIFF
--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -40,6 +40,15 @@
           "pattern": "^SHA256:[A-Za-z0-9+/=]{43,44}$",
           "description": "Colon-separated SHA-256 TLS certificate fingerprint in OpenSSL format."
         },
+        "rotation_mode": {
+          "type": "string",
+          "enum": [
+            "key-pinned",
+            "cert-pinned"
+          ],
+          "default": "key-pinned",
+          "description": "How tls_fingerprint survives certificate renewal. key-pinned matches the public key, so a renewal with the same key still verifies. cert-pinned matches the certificate, so any renewal is an identity mismatch until the catalog is updated. See docs/spec/tool-identity.md."
+        },
         "spiffe_id": {
           "type": [
             "string",

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -242,3 +242,35 @@ def test_extra_sensitivity_levels_does_not_loosen_built_in_check(catalog_file):
     entry = dict(ENTRY_1, sensitivity_level="secret")
     with pytest.raises(ConfigError, match="is not one of"):
         load_catalog(catalog_file([entry]), extra_sensitivity_levels=frozenset({"top_secret"}))
+
+
+def test_cert_pinned_rotation_mode_is_expressible_in_a_catalog(catalog_file):
+    """docs/spec/tool-identity.md offers cert-pinned; the schema has to accept it.
+
+    The loader has always read server.rotation_mode and the proxy uses it to
+    decide whether a certificate renewal counts as an identity change. But the
+    server block is additionalProperties: false, so a catalog that asked for
+    cert-pinned was rejected before the loader saw it, and every deployment ran
+    on the weaker key-pinned default with no way to opt out.
+    """
+    entry = json.loads(json.dumps(ENTRY_1))
+    entry["server"]["rotation_mode"] = "cert-pinned"
+
+    catalog = load_catalog(catalog_file([entry]))
+
+    assert catalog.require("crm.query").server.rotation_mode == "cert-pinned"
+
+
+def test_rotation_mode_defaults_to_key_pinned_when_absent(catalog_file):
+    catalog = load_catalog(catalog_file([ENTRY_1]))
+
+    assert catalog.require("crm.query").server.rotation_mode == "key-pinned"
+
+
+def test_unknown_rotation_mode_is_rejected(catalog_file):
+    """The enum is the point: a typo must fail loudly, not silently downgrade."""
+    entry = json.loads(json.dumps(ENTRY_1))
+    entry["server"]["rotation_mode"] = "cert_pinned"
+
+    with pytest.raises(ConfigError):
+        load_catalog(catalog_file([entry]))


### PR DESCRIPTION
Found while auditing why the demos catalogs stopped loading, during a proactive security sweep across the org.

## The problem

`server.rotation_mode` is a real control. The loader reads it, `MCPServer` carries it, and `mcp/proxy.py` uses it in the server execution key that decides whether an upstream certificate renewal counts as an identity change. `docs/spec/tool-identity.md` documents both values and tells operators exactly what to write:

> - Catalog field: `"rotation_mode": "cert-pinned"`

But `schemas/catalog-entry.schema.json` declares the `server` block `additionalProperties: false` and never listed `rotation_mode`. So a catalog that follows the documentation is rejected at load:

```
ConfigError: Catalog entry 'write_file' schema violation:
Additional properties are not allowed ('rotation_mode' was unexpected)
```

The only catalog that loads is one that omits the field. Which means every deployment has been running the weaker `key-pinned` default, and the documented way to ask for `cert-pinned` was unreachable. A security control you cannot turn on.

Worth being precise about the impact: `key-pinned` still verifies the upstream public key, so this is not an unauthenticated path. What was lost is the stricter posture, where a re-issued certificate on the same key forces a catalog review instead of being accepted silently.

## The fix

Adds `rotation_mode` to the schema as an enum of the two values the loader and the spec already name, with `default: "key-pinned"`. Existing catalogs are unaffected: the field stays optional and the default is what they already get.

`schemas/` is the single source, mapped into the package by `pyproject.toml`, so the one edit covers both the repo and the wheel.

## Tests

- `cert-pinned` in a catalog now loads and arrives at `MCPServer.rotation_mode`
- an absent field still defaults to `key-pinned`
- a misspelled value (`cert_pinned`) raises `ConfigError` rather than silently downgrading

`tests/unit/test_catalog.py` 26 passed. Full suite 1607 passed, with the same 4 failures that reproduce on a clean `main` (local venv has agent-manifest 0.11.1 against a `>=0.11.2` pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
