### PR TITLE
Fix cMCP tutorial trust assumptions and clarify the reader path

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,26 @@
+name: Documentation checks
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'overrides/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - 'scripts/check_docs_quickstart.py'
+      - '.github/workflows/docs-check.yml'
+permissions:
+  contents: read
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - run: python -m pip install -r requirements-docs.txt -e .
+      - run: python -m mkdocs build --strict
+      - run: python scripts/check_docs_quickstart.py

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,6 +19,7 @@ flowchart TB
         decision{Decision}
         audit[Audit entries]
         claim[Signed session claim]
+        response[Response inspection and egress policy]
         policy --> decision
         decision -->|record decision| audit
         audit -->|session closes| claim
@@ -26,7 +27,8 @@ flowchart TB
     agent -->|tool request| policy
     decision -->|allow| tool[Upstream MCP tool server]
     decision -->|deny: return error| agent
-    tool -->|response inspection and egress policy| runtime
+    tool -->|tool response| response
+    response -->|response or egress denial| agent
     claim -->|evidence| verifier[Independent verifier]
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,163 +1,81 @@
 ---
-description: How cMCP works. The four design ideas behind hardware-attested MCP tool-call governance: tamper-evident audit, TRACE Claims as evidence, TEE-measured Cedar policy, and operator-independent verification.
+description: Understand the cMCP tool-call boundary, policy decisions, signed session records, and the checks needed for hardware provenance.
 ---
 
-# How cMCP Works
+# How cMCP works
 
-This page explains the four core design ideas behind cMCP. The [quickstart](quickstart.md) shows you how to run it; this page explains why it works.
+cMCP sits between an MCP client and its tool servers. It evaluates routed calls against a Cedar policy, records decisions, and signs a session record when the session closes.
 
----
+[Run the local allow/deny example](quickstart.md){ .md-button .md-button--primary }
+[Read the verification guide](tutorials/verifying-a-trace-claim.md){ .md-button }
 
-## The problem: logs can be edited
+## Where enforcement runs
 
-Traditional agent audit logs are written by the agent process or its operator. Any party with write access to the log can modify it after the fact. An operator could:
+```mermaid
+flowchart TB
+    agent[Agent and MCP client]
+    subgraph runtime[cMCP runtime]
+        policy[Catalog lookup and Cedar policy]
+        decision{Decision}
+        audit[Audit entries]
+        claim[Signed session claim]
+        policy --> decision
+        decision -->|record decision| audit
+        audit -->|session closes| claim
+    end
+    agent -->|tool request| policy
+    decision -->|allow| tool[Upstream MCP tool server]
+    decision -->|deny: return error| agent
+    tool -->|response inspection and egress policy| runtime
+    claim -->|evidence| verifier[Independent verifier]
+```
 
-- Remove tool calls that should not have happened
-- Replace a policy hash with a different one after a breach
-- Replay a different session's clean audit trail for a production incident
+The runtime box is a **process boundary in software mode**. With a supported confidential-computing deployment, it can also be a hardware isolation boundary. The agent, model inference, and upstream tool server do not automatically move inside that boundary. A TPM can provide measured-state evidence; it does not by itself isolate the runtime's memory from the host.
 
-cMCP closes this by moving the audit anchor point to hardware, not software.
+Only calls routed through cMCP are governed. The deployment must prevent an agent from bypassing the gateway. In `enforcing` mode, a policy denial stops forwarding; in `advisory` mode, the same decision is logged while the call proceeds. See the [component model](spec/component-model.md), [enforcement modes](configuration.md), and [provider limitations](limitations.md).
 
----
+## What the signed record tells you
 
-## TRACE Claims: evidence, not logs
+A cMCP `GatewayClaim` contains an inner TRACE Trust Record plus session summaries and audit-chain information. The signature binds the claim's contents. Whether those contents establish hardware provenance depends on the attestation evidence and the verifier's trust policy.
 
-A TRACE Claim is not a log. It is a cryptographically signed statement of what happened during a session, produced by hardware that the operator cannot modify.
-
-The key difference:
-
-| | Log | TRACE Claim |
+| Question | Evidence to inspect | Additional check |
 |---|---|---|
-| Who produces it | Agent process or operator | TEE firmware + cMCP runtime |
-| Can it be edited post-hoc? | Yes | No: signature would fail |
-| Can the operator forge it? | Yes | No: signing key never leaves the TEE |
-| Who can verify it? | Anyone with read access | Anyone with the public key (no trust in operator) |
+| Which identity signed? | Subject and signing public key | Authenticate the key; a self-declared identity is insufficient |
+| Which policy was loaded? | `trace.policy.bundle_hash` and enforcement mode | Compare with the verifier's independently approved bundle hash |
+| Which tools were approved? | `gateway.catalog.hash` | Compare with an independently approved catalog hash |
+| What calls were recorded? | Session summary and signed transcript commitment | Verify the exported audit entries when individual calls matter |
+| Where did the runtime run? | Platform, measurement, and raw attestation evidence | Verify the platform's signature chain, key binding, freshness, and required measurements |
 
-A TRACE Claim is a [TRACE Trust Record](https://trace.agentrust-io.com) with a `GatewayClaim` envelope. The envelope adds the session summary and audit chain. The inner trust record follows the TRACE v0.2 spec.
+In the [software quickstart](quickstart.md), the signature and consistency checks pass, but hardware attestation does not. The expected result is `partially_verified`, with CLI exit code 1. A consumer that requires hardware provenance must reject that result.
 
-### What a TRACE Claim asserts
+## Policy approval is a separate input
 
-Every cMCP TRACE Claim makes four categories of assertion:
+The verifier needs to know what your organization approved **before** inspecting a claim. Compute the bundle and catalog hashes from reviewed build artifacts, then deliver them through a verifier-controlled channel.
 
-1. **Identity**: Which gateway TEE produced this claim (`subject` field, SPIFFE URI)
-2. **Policy**: Which Cedar policy bundle was loaded at startup, and whether it was in enforcing or advisory mode (`policy.bundle_hash`, `policy.enforcement_mode`)
-3. **Transcript**: How many tool calls were made, what their Merkle root is, and what the highest-sensitivity data class touched was (`tool_transcript`, `data_class`)
-4. **Attestation**: What hardware platform produced the signing key, and what measurement was recorded at boot (`runtime.platform`, `runtime.measurement`)
+Copying the hashes out of the claim and comparing them with that same claim does not establish approval. It only repeats the producer's assertion. The [quickstart](quickstart.md#confirm-your-setup) computes expected hashes from local input files before starting the runtime; a production deployment should obtain them from its approved build artifacts.
 
----
+Cedar rules decide authorization using the context supplied by the runtime. A catalog tag such as `pii` describes the configured tool; it is not a scan of the agent's request. Session sensitivity can rise after inspected responses, but the runtime cannot see the model's internal context or prove which earlier response influenced a later call. See [Cedar policy](spec/cedar-policy.md) and [call graph and tag propagation](spec/call-graph.md).
 
-## Hardware attestation: why the claim is trustworthy
+## Audit entries and their limits
 
-The signing key for a cMCP TRACE Claim is generated inside the TEE and never leaves it. The TEE also measures its own state at boot: recording a SHA-384 digest of the firmware, the Cedar policy bundle, and the tool catalog into a PCR/measurement register.
+The runtime hashes canonical audit entries that include the previous entry's hash. A verifier with the entries can recompute the chain and compare it with the signed commitment. Modification, deletion, or reordering can then be detected relative to that commitment.
 
-This means:
+A signed chain tip alone does not replay or inspect every entry. It also does not prove that every real-world action was routed through the runtime. Use the exported audit bundle when you need transcript verification, and retain the approved signed record separately from the logs it commits to.
 
-- If anyone changes the policy bundle between sessions, the `runtime.measurement` changes. Old claims and new claims have different measurements. An auditor can detect the switch.
-- If the operator tries to swap the signing key, the new key produces a different `cnf.jwk`. Old claims signed with the original key no longer verify under the new key.
-- If the TEE is compromised at the firmware level, the PCR values change. The RIM (Reference Integrity Manifest) check fails.
+See the [audit implementation](https://github.com/agentrust-io/cmcp/blob/main/src/cmcp_runtime/audit/chain.py) and [verification library](spec/verification-library.md) for the exact serialized fields and checks. Hash formats and platform measurement rules are implementation-specific; the diagram above does not define their wire format.
 
-The verification chain for a Level 1 claim:
+## Hardware verification is platform-specific
 
-```
-AMD CA (root of trust)
-  └─ VCEK certificate (chip-unique, from AMD KDS)
-       └─ SNP attestation report (signed by VCEK)
-            └─ runtime.measurement (from report)
-            └─ report.REPORT_DATA == SHA-256(tee_public_key)
-                  └─ cnf.jwk (TEE-bound signing key)
-                       └─ signature (over the TRACE Claim body)
-```
+Hardware provenance requires more than changing `provider` or moving a process to a confidential VM. A verifier must check the evidence chain, bind the signing key to the attested environment, and apply its expected measurements and freshness policy. Provider support and trust anchors differ.
 
-Each step in the chain is independently verifiable. The final verifier does not trust the runtime operator at any point.
+- [Attestation specification](spec/attestation.md): provider evidence and binding rules.
+- [Hardware validation](testing/hardware-validation.md): recorded platform validation.
+- [Limitations](limitations.md): supported checks and remaining assumptions.
+- [Verify a TRACE claim](tutorials/verifying-a-trace-claim.md): approved hashes and consumer acceptance.
 
-See [Spec: Attestation](spec/attestation.md) for the full verification protocol.
+## Choose the next step
 
----
-
-## Audit chains: tamper-evidence for the transcript
-
-Each tool call within a session is recorded as an audit entry. cMCP chains these entries using a Merkle-style hash:
-
-```
-entry_0_hash = SHA-256(session_id || tool_name_0 || args_hash_0 || result_hash_0)
-entry_1_hash = SHA-256(entry_0_hash || tool_name_1 || args_hash_1 || result_hash_1)
-...
-chain_tip    = entry_N_hash
-```
-
-The TRACE Claim records `audit_chain.root` (the first entry hash) and `audit_chain.tip` (the final entry hash). The `tool_transcript.hash` in the inner trust record equals the chain tip.
-
-**Why this matters:** An auditor who has the individual audit log entries can recompute the chain tip and verify it matches the TRACE Claim. If any entry was modified, deleted, or reordered, the recomputed tip will not match. The audit log is self-certifying.
-
-The audit chain does not need to be stored on-chain or in a third-party system. The signed TRACE Claim is sufficient to detect tampering after the fact: as long as the claim itself was not forged (which the hardware attestation prevents).
-
-See [Spec: Call Graph](spec/call-graph.md) for the full chain construction.
-
----
-
-## Cedar policy: authorization that is auditable by design
-
-Cedar is an authorization policy language designed to be auditable. cMCP uses it for three reasons:
-
-**1. The policy is versioned and hash-bound.** The SHA-256 of the policy bundle is measured into the TEE at startup. Every TRACE Claim carries that hash. An auditor can compare the hash in a claim to the policy bundle in the repository and prove which policy was active for a given session: even if the policy was later changed.
-
-**2. Policy effects are data, not code.** Cedar policies are declarative and cannot execute arbitrary code. A `forbid` rule can block a tool call; it cannot read files or make network requests. This means policy review is tractable: the policy file is the complete specification of what the agent is allowed to do.
-
-**3. Cedar supports fine-grained context conditions.** Policies can condition on session attributes like `session_max_sensitivity`, `workflow_id`, or `data_class`. This enables dynamic policy enforcement without code changes: the same binary can enforce different rules for different tenant configurations.
-
-Example: this policy blocks `salesforce.contacts` once PII has entered the session:
-
-```cedar
-forbid (
-  principal,
-  action == cMCP::Action::"call_tool",
-  resource == cMCP::Resource::"salesforce.contacts"
-) when {
-  context.session_max_sensitivity == "pii"
-};
-```
-
-If the agent tries to call `salesforce.contacts` after handling PII data, cMCP records the denial in the audit chain and (in `enforcing` mode) returns HTTP 403. The TRACE Claim records the attempt and the denial count, so the auditor can see that the policy blocked the call.
-
-See [Spec: Cedar Policy](spec/cedar-policy.md) for the full schema and supported context attributes.
-
----
-
-## How the pieces fit together
-
-```
- ┌─────────────────────────────────────────────────────┐
- │  At startup:                                        │
- │  1. TEE generates Ed25519 key (never leaves TEE)    │
- │  2. Cedar policy bundle measured into PCR           │
- │  3. Tool catalog loaded and hashed                  │
- └─────────────────────────────────────────────────────┘
-                         │
-                         │ session begins
-                         ▼
- ┌─────────────────────────────────────────────────────┐
- │  Per tool call:                                     │
- │  4. Cedar policy evaluated (allow / deny)           │
- │  5. Audit entry appended to hash chain              │
- │  6. Call forwarded (or blocked) based on policy     │
- └─────────────────────────────────────────────────────┘
-                         │
-                         │ session ends
-                         ▼
- ┌─────────────────────────────────────────────────────┐
- │  TRACE Claim produced:                              │
- │  7. Build GatewayClaim with chain root/tip          │
- │  8. Sign with TEE-bound key                         │
- │  9. Return to caller / push to registry             │
- └─────────────────────────────────────────────────────┘
-```
-
-The signed claim ties together: hardware identity (attestation), policy version (policy hash), transcript integrity (audit chain), and cryptographic non-repudiation (TEE signature).
-
-## Next steps
-
-- [Quickstart](quickstart.md): run a cMCP gateway locally in under 30 minutes
-- [Configuration](configuration.md): full configuration reference
-- [Tutorial: Cedar policy walkthrough](tutorials/cedar-policy-walkthrough.md): write and test policies
-- [Tutorial: Verify a TRACE claim](tutorials/verifying-a-trace-claim.md): verify a claim without trusting the operator
-- [Spec: Component Model](spec/component-model.md): detailed architecture
+- **First local result:** [allow and deny a tool call](quickstart.md).
+- **Connect an application:** [use an existing MCP client](tutorials/existing-mcp-clients.md).
+- **Write policy:** [Cedar walkthrough](tutorials/cedar-policy-walkthrough.md).
+- **Consume evidence:** [verify a signed session record](tutorials/verifying-a-trace-claim.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,72 +1,38 @@
 ---
-title: The secure, confidential way to run MCP
-description: cMCP is a hardware-attested MCP runtime. Every tool call an agent makes passes through a TEE-isolated gateway that evaluates it against a Cedar policy and emits a signed TRACE receipt a verifier can check without trusting the operator.
+title: Govern MCP tool calls and verify the evidence
+description: cMCP checks routed MCP tool calls against Cedar policy and signs session records. Run a local allow/deny example, then explore hardware-backed deployment.
 ---
 
-# cMCP
+# Govern tool calls. Verify the evidence.
 
-cMCP (Confidential MCP) is a hardware-attested runtime for the Model Context Protocol. Every MCP tool call an agent makes passes through a TEE-isolated gateway that evaluates it against a Cedar policy bundle and produces a TRACE claim: a signed, hardware-attested artifact a verifier can check without trusting the operator.
+cMCP (Confidential MCP) is an open-source gateway between your AI agent's MCP client and its tool servers. It checks routed calls against Cedar policy, blocks denied calls in enforcing mode, and produces a signed TRACE session record.
 
-**Prove that the policy you describe in documents is the policy that actually ran on your traffic.**
+[Block a call in 10 minutes](https://agentrust-io.com/quickstart/){ .md-button .md-button--primary }
+[See the architecture](concepts.md){ .md-button }
 
-!!! tip "TL;DR"
-    - MCP authenticates the caller. It does not constrain what a tool call may do, and it leaves no evidence of what it did.
-    - cMCP runs the tool call inside a TEE, decides it against Cedar, and emits a signed receipt for every call.
-    - Install with `pip install cmcp-runtime`, or follow the [guided quickstart](https://agentrust-io.com/quickstart/) and watch a policy block a real data leak in about ten minutes.
-    - Two bounds worth stating up front: the plaintext guarantee holds where the egress policy denies telemetry and APM endpoints, and the receipt is hardware-attested when the gateway runs in a TEE and signed-only in software mode.
+The first demo runs on your laptop with a mock tool and software attestation. You will see `403 POLICY_DENY`, then the expected `partially_verified` result because no hardware attestation is present. It needs Python 3.11+ and no cloud account.
 
-```bash
-pip install cmcp-runtime
-```
+## Choose your next step
 
-## The gap it closes
+| You want to… | Start here | Result |
+|---|---|---|
+| Understand a policy denial | [Guided first demo](https://agentrust-io.com/quickstart/) | A blocked request and a signed session record |
+| Exercise a real local upstream | [Allow/deny quickstart](quickstart.md) | One denied tool call and one forwarded call |
+| Connect an existing agent | [MCP client integration](tutorials/existing-mcp-clients.md) | Your client sends requests through the gateway |
+| Evaluate the trust boundary | [How it works](concepts.md) | Distinguish policy enforcement, signing, and hardware provenance |
+| Deploy with hardware evidence | [TEE attestation](tutorials/tee-attestation.md) | Provider prerequisites and verification requirements |
+| Implement against the protocol | [Specification index](spec-index.md) | The relevant component, transport, and policy contracts |
 
-An agent calling a tool over MCP presents a token. The token says who is calling. It does not say what the call is allowed to touch, and once the call returns there is no artifact proving what actually happened.
+## What changes at the tool boundary
 
-Software-only enforcement does not close this. A privileged operator can change a policy between the approval that was reviewed and the traffic that ran, and then write the log that describes it. The log is authored by the system being audited.
+Authentication identifies a caller; your Cedar policy decides what a routed call may do. The gateway records the decision and binds the session's evidence into a signed claim when the session closes.
 
-cMCP moves the decision and the evidence inside a TEE. The policy bundle is measured, the decision happens where the operator cannot reach it, and the receipt is signed by a key that never leaves the enclave. Phase 1 attests the agent-to-tool boundary on the consumer side, in the runtime. Phase 2 attests it on the provider side, in the server.
+A hardware deployment can protect the runtime from its host, subject to the provider's threat model and verification support. The agent, model, and upstream tool server remain separate components. Calls that bypass the gateway are outside its enforcement. Host confidentiality also depends on the configured egress policy.
 
-## Where to start
+Read the [architecture](concepts.md), [enforcement modes](configuration.md), and [limitations](limitations.md) before treating a successful software demo as evidence of hardware isolation.
 
-<div class="grid cards" markdown>
+## How it fits AgenTrust
 
--   __Run it__
+[Agent Manifest](https://manifest.agentrust-io.com) declares identity and intended authority. cMCP governs the MCP tool-call path. [TRACE](https://trace.agentrust-io.com) defines signed runtime evidence, and [cA2A](https://ca2a.agentrust-io.com) addresses delegation between agents. Use the components required by your application's trust boundaries.
 
-    ---
-
-    Write one policy, watch it block a tool call, and verify the receipt it produced.
-
-    [Quick Start](quickstart.md)
-
--   __Understand it__
-
-    ---
-
-    The component model, trust boundaries, and how a tool call becomes a signed claim.
-
-    [How It Works](concepts.md)
-
--   __Read the spec__
-
-    ---
-
-    Problem taxonomy, the thirteen threat shapes, and the Phase 1 and Phase 2 coverage matrix.
-
-    [SPEC.md](SPEC.md)
-
--   __Check the bounds__
-
-    ---
-
-    What is attested against real silicon, what is parsed, and what is not appraised at all.
-
-    [Limitations](limitations.md)
-
-</div>
-
-## How it fits the rest of the stack
-
-cMCP is the enforcement layer of the AgenTrust chain. [Agent Manifest](https://manifest.agentrust-io.com) declares what an agent is and what it may do before it runs. cMCP enforces that at the tool-call boundary. [TRACE](https://trace.agentrust-io.com) is the evidence format the receipts are written in, and [cA2A](https://ca2a.agentrust-io.com) carries the same guarantees across agent-to-agent hops.
-
-Issues in this repository track specification decisions rather than implementation bugs. To propose a change, open an issue describing the problem with the current spec, then submit a pull request. See [Contributing](https://github.com/agentrust-io/cmcp/blob/main/CONTRIBUTING.md).
+For implementation bugs or specification feedback, include the failing command, runtime version, and expected behavior in an [issue](https://github.com/agentrust-io/cmcp/issues). See [Contributing](https://github.com/agentrust-io/cmcp/blob/main/CONTRIBUTING.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,15 +15,17 @@ You'll run a cMCP Runtime that intercepts tool calls from a demo agent and enfor
 1. **Block** a call to a sensitive tool (`salesforce.contacts`). The gateway returns HTTP 403 and the call never reaches any upstream.
 2. **Allow** a call to a non-sensitive tool (`echo`) and forward it to a small mock upstream.
 
-At the end you close the session and get a signed TRACE Claim that records both calls, which policy decided each one, and the policy bundle hash measured at startup. You verify the claim without trusting the operator.
+At the end you close the session and get a signed TRACE Claim that records both calls, which policy decided each one, and the policy bundle hash measured at startup. You inspect its signature and consistency. This software demo does not establish hardware provenance.
 
 ---
 
 ## Prerequisites
 
-- Ubuntu 24.04 (or any Linux distro with Python 3.11+); macOS also works
-- Python 3.11 or newer
-- pip
+- Python 3.11+, pip, and curl
+- Bash on Linux, macOS, or Windows with WSL
+- Three terminal windows: gateway, client requests, and mock tool server
+
+Expected finish: one `403 POLICY_DENY`, one `200 OK`, and `cmcp verify` reporting `partially_verified` with exit code 1. No Salesforce account or real personal data is used.
 
 Verify:
 
@@ -37,7 +39,9 @@ pip --version
 ## Install
 
 ```bash
-pip install cmcp-runtime
+python3 -m venv cmcp-env
+source cmcp-env/bin/activate
+python3 -m pip install cmcp-runtime==0.4.1
 ```
 
 This installs:
@@ -211,13 +215,31 @@ print('sha256:' + hashlib.sha256(s.encode()).hexdigest())
 
 ## Confirm your setup
 
-Before starting the gateway, check that the config, policy bundle, and catalog all parse:
+First check the YAML configuration:
 
 ```bash
 cmcp validate-config --config cmcp-config.yaml
 ```
 
-If this reports an error, fix it now. It is easier to read here than mixed into the startup logs.
+This command checks the YAML; it does not load the policy bundle and tool catalog. Check those inputs and record their expected hashes **before** starting the gateway:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+from cmcp_runtime.policy.bundle import load_policy_bundle
+from cmcp_runtime.catalog.loader import load_catalog
+
+approved = {
+    "policy_bundle_hash": load_policy_bundle("policies").bundle_hash,
+    "tool_catalog_hash": load_catalog("catalog.json").catalog_hash,
+}
+Path("approved-hashes.json").write_text(json.dumps(approved, indent=2))
+print(json.dumps(approved, indent=2))
+PY
+```
+
+This validates the input files and creates `approved-hashes.json` from your local artifacts. Keep it unchanged while running the demo. In production, generate these values from reviewed build artifacts and deliver them through a verifier-controlled channel.
 
 ---
 
@@ -276,10 +298,10 @@ This is the point of the gateway: the sensitive call was stopped at the policy b
 
 Now the `echo` tool, which the policy permits. For an allowed call the gateway forwards to the upstream, so start a small mock upstream first.
 
-If you cloned the repo, run the bundled one:
+If you cloned the repo, run the bundled one in Terminal 3, replacing `/path/to/cmcp` with your checkout path:
 
 ```bash
-python3 scripts/mock_upstream.py --port 9001
+python3 /path/to/cmcp/scripts/mock_upstream.py --port 9001
 ```
 
 If you only installed the package, write a compact mock into a file and run it:
@@ -303,7 +325,7 @@ class H(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 print("mock upstream listening on :9001", flush=True)
-HTTPServer(("0.0.0.0", 9001), H).serve_forever()
+HTTPServer(("127.0.0.1", 9001), H).serve_forever()
 PY
 python3 mock_upstream.py
 ```
@@ -379,13 +401,15 @@ Expected output in dev mode:
 [cmcp verify] RESULT: FAIL (partially_verified)
 ```
 
-`partially_verified` is expected in dev mode: every cryptographic field verifies, but there is no hardware attestation to bind them to. To pin the policy and catalog hashes, read them from the claim and pass them explicitly:
+`partially_verified` with exit code 1 is expected when the software checks pass and only hardware attestation is missing. Pin the expected policy and catalog hashes from the file you created before startup:
 
 ```bash
 cmcp verify claim.json \
-  --policy-hash "$(python3 -c "import json; print(json.load(open('claim.json'))['trace']['policy']['bundle_hash'])")" \
-  --catalog-hash "$(python3 -c "import json; print(json.load(open('claim.json'))['gateway']['catalog']['hash'])")"
+  --policy-hash "$(python3 -c "import json; print(json.load(open('approved-hashes.json'))['policy_bundle_hash'])")" \
+  --catalog-hash "$(python3 -c "import json; print(json.load(open('approved-hashes.json'))['tool_catalog_hash'])")"
 ```
+
+Taking expected hashes from the claim itself would not establish approval. These pins verify a match with your selected artifacts; they do not give the software claim hardware provenance.
 
 On a real TPM 2.0 host, pass a verifier-owned CA certificate bundle to authenticate the
 attestation-key chain:
@@ -404,7 +428,7 @@ The `cmcp_verify` Python library is also available for programmatic checks (`fro
 
 ## What's in the TRACE Claim
 
-| Field | What it proves |
+| Field | What it records |
 |---|---|
 | `trace.runtime.platform` | Which TEE hardware produced the attestation report (`tpm2`, `amd-sev-snp`, etc.) |
 | `trace.runtime.measurement` | PCR/measurement recorded by hardware at enclave boot - all zeros in dev mode |
@@ -414,16 +438,20 @@ The `cmcp_verify` Python library is also available for programmatic checks (`fro
 | `trace.tool_transcript.hash` | SHA-256 of the audit chain tip - binds the call log to this Trust Record |
 | `trace.tool_transcript.call_count` | Number of tool calls in the session |
 | `trace.cnf.jwk` | Ed25519 public key used to sign this claim - bound to the TEE signing key |
-| `gateway.audit_chain.root` / `.tip` | Hash-chained audit log root and tip - verifiable without replaying individual entries |
+| `gateway.audit_chain.root` / `.tip` | Hash-chained audit log root and tip; verifying individual entries requires the exported audit bundle |
 | `gateway.call_summary` | Per-session statistics: total, allowed, denied, faulted calls and tools invoked |
 | `gateway.catalog.drift_detected` | `true` if any tool definition changed after catalog load - signals a rug-pull attempt |
 | `signature` | Ed25519 signature over canonical JSON of the entire claim body (excluding `signature`) |
 
 ---
 
+## Stop the demo
+
+Use Ctrl+C in the gateway and mock-server terminals. Keep `claim.json` and `approved-hashes.json` if you want to inspect the result later.
+
 ## Next steps
 
 - **Full financial-services scenario**: see `examples/bfsi-demo/` for a multi-tool scenario with MNPI and PHI policies, cross-boundary events, and a KYC workflow.
 - **Spec reference**: see `docs/SPEC.md` for the full product specification and `docs/spec/` for individual component specs.
 - **Advisory mode**: set `enforcement_mode: advisory` in `cmcp-config.yaml`. Policy denies are logged and flagged in the claim (`would_have_denied`) but the call is still forwarded - useful while tuning a new policy.
-- **Hardware TEE**: remove `CMCP_DEV_MODE=1` on an Azure DCasv5 (SEV-SNP) or DCedsv5 (TDX) VM. The `trace.runtime.measurement` will reflect real hardware values and verification status becomes `verified`.
+- **Hardware deployment**: follow the [TEE attestation guide](tutorials/tee-attestation.md) and [hardware validation record](testing/hardware-validation.md). Hardware placement alone does not guarantee `verified`; evidence, trust anchors, measurements, and freshness must pass the verifier's checks.

--- a/docs/tutorials/verifying-a-trace-claim.md
+++ b/docs/tutorials/verifying-a-trace-claim.md
@@ -30,7 +30,7 @@ from cmcp_verify import verify_trace_claim, ApprovedHashes
 
 ## Obtain the approved hashes
 
-The approved hashes are the SHA-256 values printed by the gateway at startup:
+The expected hashes must come from artifacts your verifier trusts. The [quickstart](../quickstart.md#confirm-your-setup) computes them from local input files before startup. Gateway logs also print hashes, but those logs alone do not establish approval:
 
 ```
 [cmcp] policy bundle loaded: sha256:abc123...
@@ -43,32 +43,27 @@ In production, these values come from your deployment pipeline: not from the ope
 
 ## Call verify_trace_claim
 
+Save this as `inspect_claim.py` beside the quickstart's `claim.json` and `approved-hashes.json`, then run `python inspect_claim.py`:
+
 ```python
 import json
+from pathlib import Path
 from cmcp_verify import verify_trace_claim, ApprovedHashes
 
-with open("claim.json") as f:
-    claim = json.load(f)
-
-approved = ApprovedHashes(
-    policy_bundle_hash="sha256:abc123...",
-    tool_catalog_hash="sha256:def456...",
-)
-
+claim = json.loads(Path("claim.json").read_text())
+hashes = json.loads(Path("approved-hashes.json").read_text())
+approved = ApprovedHashes(**hashes)
 result = verify_trace_claim(claim, approved)
 
-print(f"Status:           {result.status.value}")
-print(f"Verified fields:  {result.verified_fields}")
-print(f"Unverified fields:{result.unverified_fields}")
-print(f"Attestation age:  {result.attestation_age_seconds}s")
-print(f"Attestation fresh:{result.is_attestation_fresh}")
-if result.failure_reason:
-    print(f"Failure reason:   {result.failure_reason}")
-if result.details:
-    print(f"Details:          {result.details}")
+print(f"Status: {result.status.value}")
+print(f"Verified fields: {result.verified_fields}")
+print(f"Unverified fields: {result.unverified_fields}")
+print(f"Details: {result.details}")
 ```
 
-The function also accepts optional parameters:
+This inspection script prints the result; it is not an acceptance gate. The software quickstart should report `partially_verified`. Use the consuming-job example below when evidence is required before processing output.
+
+Integration sketch: the function also accepts optional parameters. Replace the key placeholder with a verifier-approved key before running:
 
 ```python
 result = verify_trace_claim(
@@ -137,7 +132,7 @@ Attestation fresh:True
 Details:          {'hardware_attestation': 'software-only mode - not hardware-backed'}
 ```
 
-`hardware_attestation` is in `unverified_fields` but no `failure_reason` is set for it in isolation: the status rolls up to `partially_verified` because other fields were verified. On a real TEE host, `hardware_attestation` moves to `verified_fields` and status becomes `verified`.
+`hardware_attestation` is in `unverified_fields` but no `failure_reason` is set for it in isolation: the status rolls up to `partially_verified` because other fields were verified. A hardware deployment reaches `verified` only when the required checks pass; moving the process to a TEE alone is insufficient.
 
 `unverified` (with no verified fields at all) means the claim is either malformed, signature-invalid, or the hashes do not match. Treat this as a hard rejection.
 
@@ -145,44 +140,33 @@ Details:          {'hardware_attestation': 'software-only mode - not hardware-ba
 
 ## Integrate verification at job start
 
-The right integration point is before your pipeline processes any agent output. Verify the TRACE claim at the start of the consuming job, before reading `tool_transcript` or acting on results:
+If a consuming job requires fully verified evidence, reject **every** other status before processing agent output. `partially_verified` can include failures beyond missing hardware; freshness alone is not an acceptance rule.
+
+Save the following as `accept_claim.py`. It uses the same two files as the inspection example. Supply `approved-hashes.json` through your deployment's trusted artifact channel. This is a result gate; configure any additional platform trust inputs required by your deployment when calling the verifier.
 
 ```python
 import json
-import sys
+from pathlib import Path
 from cmcp_verify import verify_trace_claim, ApprovedHashes
 
-def load_approved_hashes() -> ApprovedHashes:
-    # Fetch from your secrets manager / artifact registry
-    return ApprovedHashes(
-        policy_bundle_hash=get_secret("cmcp/policy-bundle-hash"),
-        tool_catalog_hash=get_secret("cmcp/catalog-hash"),
-    )
 
-def verify_session_claim(claim_path: str) -> None:
-    with open(claim_path) as f:
-        claim = json.load(f)
+def verify_session_claim(claim_path, approved_path):
+    claim = json.loads(Path(claim_path).read_text())
+    hashes = json.loads(Path(approved_path).read_text())
+    result = verify_trace_claim(claim, ApprovedHashes(**hashes))
+    if result.status.value != "verified":
+        raise SystemExit(
+            f"CLAIM REJECTED: {result.status.value}; "
+            f"failed or unchecked: {result.unverified_fields}"
+        )
+    return claim
 
-    result = verify_trace_claim(claim, load_approved_hashes())
 
-    if result.status.value == "unverified":
-        print(f"CLAIM REJECTED: {result.failure_reason}", file=sys.stderr)
-        sys.exit(1)
-
-    if result.status.value == "partially_verified":
-        # Accept in staging; reject in production if hardware attestation is required
-        if not result.is_attestation_fresh:
-            print(f"CLAIM STALE: age={result.attestation_age_seconds}s", file=sys.stderr)
-            sys.exit(1)
-        print(f"WARNING: partially verified: {result.unverified_fields}")
-
+if __name__ == "__main__":
+    claim = verify_session_claim("claim.json", "approved-hashes.json")
     print(f"Claim verified. Tools called: {claim['gateway']['call_summary']['tools_invoked']}")
 ```
 
----
+Run `python accept_claim.py`. It must reject the software quickstart record with a nonzero exit and `CLAIM REJECTED: partially_verified`. A development workflow that permits software evidence needs an explicit, narrower acceptance policy and must preserve that distinction in its output.
 
-## Summary
-
-You called `verify_trace_claim` with `ApprovedHashes` sourced from your deployment pipeline (not from the operator), read `VerificationResult` fields to distinguish full verification from partial (dev-mode) verification, and integrated the check at pipeline entry. A claim that returns `unverified` must be rejected before any downstream processing uses the session output.
-
-Related tutorials: [Cedar policy walkthrough](./cedar-policy-walkthrough.md): the policy bundle hash you verify here is the hash of the Cedar bundle loaded at runtime. [TEE attestation](./tee-attestation.md): switching from software-only to a real TEE makes `hardware_attestation` move from `unverified_fields` to `verified_fields`.
+Next: [Cedar policy walkthrough](cedar-policy-walkthrough.md), [TEE attestation](tee-attestation.md), and [verification library reference](../spec/verification-library.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: cMCP
-site_description: "The secure, confidential way to run MCP: hardware-attested, TEE-enforced tool-call policy for the Model Context Protocol, with signed TRACE receipts."
+site_description: "Govern routed MCP tool calls with Cedar policy and signed TRACE session records. Start in software mode; evaluate hardware provenance separately."
 site_url: https://cmcp.agentrust-io.com
 repo_url: https://github.com/agentrust-io/cmcp
 repo_name: agentrust-io/cmcp
@@ -65,17 +65,12 @@ plugins:
   - llmstxt:
       full_output: llms-full.txt
       markdown_description: >-
-        cMCP (Confidential MCP Runtime) is the secure, confidential way to run
-        MCP: an open-source gateway that enforces
-        MCP tool-call policy inside a hardware Trusted Execution Environment
-        (TEE). Every tool call is intercepted, evaluated against a Cedar policy
-        bundle, and enforced by a policy engine the governed process cannot
-        reach. The Cedar bundle hash is measured into the hardware attestation
-        report before any code runs, and each session produces a signed,
-        hardware-attested TRACE Claim that a verifier checks without trusting the
-        operator. Supports TPM, AMD SEV-SNP, Intel TDX, and OPAQUE providers,
-        with enforcing, advisory, and silent modes. If you are looking for a
-        secure version of MCP, this is the AgenTrust runtime for it.
+        cMCP is an open-source gateway for MCP tool-call policy enforcement.
+        It evaluates routed calls against Cedar policy and signs session records.
+        Software mode demonstrates policy and signature checks without hardware
+        provenance. Hardware deployments require provider-specific attestation
+        verification, trusted inputs, and a deployment that prevents gateway bypass.
+        The agent, model, and upstream tool server remain separate components.
       sections:
         Getting started:
           - index.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -39,7 +39,7 @@
         "name": "cMCP (Confidential MCP Runtime)",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Linux",
-        "description": "Hardware-attested policy enforcement for MCP tool calls. cMCP intercepts every tool call, evaluates it against a Cedar policy bundle inside a Trusted Execution Environment, and produces a signed TRACE Claim that a verifier checks without trusting the operator.",
+        "description": "cMCP evaluates routed MCP tool calls against Cedar policy and produces signed TRACE session records. Hardware provenance depends on attestation verification; software mode provides no hardware isolation.",
         "url": "{{ config.site_url }}",
         "softwareHelp": "{{ config.site_url }}",
         "license": "https://opensource.org/licenses/MIT",

--- a/scripts/check_docs_quickstart.py
+++ b/scripts/check_docs_quickstart.py
@@ -1,0 +1,117 @@
+"""Exercise the Markdown tutorial's files, requests, and verification gate."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = [sys.executable, "-c", "from cmcp_runtime.cli import main; main()"]
+
+
+def blocks(path):
+    return re.findall(r"^```[^\n]*\n(.*?)^```", path.read_text(encoding="utf-8-sig"), re.M | re.S)
+
+
+def wait_for_server(url, process):
+    for _ in range(80):
+        if process.poll() is not None:
+            raise RuntimeError("Tutorial server exited before readiness")
+        try:
+            httpx.get(url, timeout=1)
+            return
+        except httpx.ConnectError:
+            time.sleep(.25)
+    raise TimeoutError(url)
+
+
+def main():
+    snippets = blocks(ROOT / "docs/quickstart.md")
+    tutorial = blocks(ROOT / "docs/tutorials/verifying-a-trace-claim.md")
+    environment = dict(os.environ, CMCP_DEV_MODE="1", PYTHONIOENCODING="utf-8")
+    # Tokenless localhost is the documented path, regardless of caller settings.
+    environment.pop("CMCP_BEARER_TOKEN", None)
+    with tempfile.TemporaryDirectory(prefix="cmcp-docs-") as temporary:
+        work = Path(temporary)
+        (work / "policies").mkdir()
+        def save(name, text):
+            (work / name).write_text(text, encoding="utf-8")
+        save("cmcp-config.yaml", next(b for b in snippets if b.startswith("attestation:")))
+        save("policies/manifest.json", next(b for b in snippets if b.startswith('{\n  "version"')))
+        save("policies/demo.cedar", next(b for b in snippets if b.startswith("// Rule 1")))
+        save("policies/schema.cedarschema", next(b for b in snippets if b.startswith('{"cMCP"')))
+        save("catalog.json", next(b for b in snippets if b.startswith("[\n")))
+        pins = next(b for b in snippets if 'Path("approved-hashes.json")' in b)
+        pins = pins.split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        subprocess.run([sys.executable, "-c", pins], cwd=work, env=environment, check=True)
+        mock = next(b for b in snippets if "cat > mock_upstream.py" in b)
+        mock = mock.split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        save("mock_upstream.py", mock)
+        with (work / "runtime.log").open("w", encoding="utf-8") as log:
+            processes = []
+            try:
+                runtime = subprocess.Popen(CLI + ["start", "--config", "cmcp-config.yaml"], cwd=work, env=environment, stdout=log, stderr=log)
+                processes.append(runtime)
+                wait_for_server("http://localhost:8443/health", runtime)
+                requests = [json.loads(re.search(r"-d '(.*?)'", b, re.S)[1]) for b in snippets if "curl -i -X POST" in b]
+                denied = httpx.post("http://localhost:8443/mcp", json=requests[0])
+                assert denied.status_code == 403 and "POLICY_DENY" in denied.text, denied.text
+                upstream = subprocess.Popen([sys.executable, "mock_upstream.py"], cwd=work, env=environment, stdout=log, stderr=log)
+                processes.append(upstream)
+                wait_for_server("http://localhost:9001", upstream)
+                allowed = httpx.post("http://localhost:8443/mcp", json=requests[1])
+                assert allowed.status_code == 200 and "mock response" in allowed.text, allowed.text
+                audit = httpx.get("http://localhost:8443/audit/export?session_id=demo-session-001").json()
+                sid = audit["entries"][0]["session_id"]
+                response = httpx.post(f"http://localhost:8443/sessions/{sid}/close")
+                response.raise_for_status()
+                claim = response.json()
+                summary = claim["gateway"]["call_summary"]
+                assert summary["tool_calls_total"] == 2 and summary["tool_calls_allowed"] == 1 and summary["tool_calls_denied"] == 1, summary
+                save("claim.json", json.dumps(claim))
+                hashes = json.loads((work / "approved-hashes.json").read_text())
+                result = subprocess.run(CLI + ["verify", "claim.json", "--policy-hash", hashes["policy_bundle_hash"], "--catalog-hash", hashes["tool_catalog_hash"]], cwd=work, env=environment, capture_output=True, text=True, encoding="utf-8")
+                assert result.returncode == 1 and "partially_verified" in result.stdout, result.stdout + result.stderr
+                for name in ("schema", "signature", "policy_bundle.hash", "tool_catalog.hash", "attestation_freshness", "audit_chain"):
+                    assert re.search(re.escape(name) + r"\s+PASS", result.stdout), result.stdout
+                inspection = next(b for b in tutorial if 'print(f"Status:' in b)
+                subprocess.run([sys.executable, "-c", inspection], cwd=work, env=environment, check=True)
+                gate = next(b for b in tutorial if "def verify_session_claim" in b)
+                result = subprocess.run([sys.executable, "-c", gate], cwd=work, env=environment, capture_output=True, text=True)
+                assert result.returncode != 0 and "CLAIM REJECTED: partially_verified" in result.stderr, result.stdout + result.stderr
+                # The consumer must reject a fresh partial result regardless of cause.
+                namespace = {"__name__": "tutorial_test"}
+                exec(compile(gate, "documented acceptance gate", "exec"), namespace)
+                for status, fields in [("partially_verified", ["hardware_attestation"]), ("partially_verified", ["policy_bundle.hash"]), ("unverified", ["signature"])]:
+                    verdict = SimpleNamespace(status=SimpleNamespace(value=status), unverified_fields=fields, is_attestation_fresh=True, failure_reason=None, details={})
+                    namespace["verify_trace_claim"] = lambda *args, verdict=verdict: verdict
+                    try:
+                        namespace["verify_session_claim"](work / "claim.json", work / "approved-hashes.json")
+                    except SystemExit:
+                        pass
+                    else:
+                        raise AssertionError(f"Consumer accepted {status}: {fields}")
+                print("PASS: documented deny, allow, two-call summary, independently pinned software verification, and consumer rejection cases")
+            finally:
+                for process in reversed(processes):
+                    if os.name == "nt":
+                        # Windows venv launchers have a child interpreter holding SQLite.
+                        subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"], check=True, capture_output=True)
+                    else:
+                        process.terminate()
+                    process.wait(timeout=15)
+                log.flush()
+                if sys.exc_info()[0]:
+                    print((work / "runtime.log").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
cMCP's documentation described the software demo as a real data leak blocked inside a TEE, used receipt-supplied hashes as approval inputs, and let a fresh `partially_verified` result pass a consuming-job example that printed “Claim verified.” Readers now get a clear first-demo path, an architecture diagram with explicit component boundaries, independently computed expected hashes, and a consumer gate that rejects every result below full verification.

The longer quickstart includes environment setup, terminal roles, expected exit codes, and cleanup. The architecture explanation distinguishes TPM evidence from memory isolation and signed commitments from transcript replay. Search metadata and the model-facing description match the visible page.

Validation: strict MkDocs build passed. The Markdown-driven smoke check exercised a 403 denial, a 200 allowed mock call, the two-call signed summary, six passing software checks with independently computed hashes, and expected software-mode exit 1. The inspection example runs; the acceptance example rejects hardware-missing, policy-mismatch, and unverified results. Reproducing the old example confirmed it accepted fresh partial results with both missing hardware and a failed policy hash. New PR CI builds docs and runs the examples.

This changes documentation and its validation, not runtime authorization or cryptographic verification. Hardware platforms were not exercised. Diagram visual verification is pending deployment.
