### PR TITLE
fix(policy): compute the bundle hash with RFC 8785, as the spec requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
     "uvicorn>=0.29",
     "click>=8.1",
     "cedarpy>=4.0",
+    # The policy bundle hash is specified as RFC 8785 (docs/spec/cedar-policy.md
+    # section 1). Declared directly rather than relied on transitively: the
+    # bundle hash is a startup gate, not an incidental dependency.
+    "rfc8785>=0.1.4",
 ]
 
 [project.optional-dependencies]

--- a/src/cmcp_runtime/policy/bundle.py
+++ b/src/cmcp_runtime/policy/bundle.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import rfc8785
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
@@ -153,17 +154,29 @@ def _canonical_bundle_hash(
         for name, content in sorted(policy_files.items())
     }
     hashed_manifest = {k: v for k, v in manifest.items() if k not in _UNHASHED_MANIFEST_KEYS}
-    canonical = json.dumps(
+    # docs/spec/cedar-policy.md section 1 defines canonical_json as RFC 8785
+    # (JCS), so this uses a JCS implementation rather than approximating one.
+    #
+    # json.dumps(sort_keys=True, ensure_ascii=True) agrees with JCS for
+    # ASCII-only, integer-only bundles, which is why the divergence went
+    # unnoticed. It differs on two input classes the spec explicitly allows:
+    #
+    #   non-ASCII strings   JCS emits raw UTF-8; ensure_ascii emits an escape
+    #   float-typed numbers JCS 3.2.2.3 requires the ES6 shortest form (1),
+    #                       json.dumps emits 1.0
+    #
+    # Section 1 defines author_identity as a SPIFFE SVID or git identity, and
+    # git identities routinely carry non-ASCII names, so this is ordinary input
+    # rather than an adversarial edge case. Two implementations following the
+    # written spec would have computed different hashes for the same bundle.
+    canonical = rfc8785.dumps(
         {
             "manifest": hashed_manifest,
             "policy_files": policy_hashes,
             "schema_hash": _sha256_hex(schema_content.encode()),
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
+        }
     )
-    return _sha256_hex(canonical.encode())
+    return _sha256_hex(canonical)
 
 
 def load_policy_bundle(

--- a/tests/unit/test_policy_bundle.py
+++ b/tests/unit/test_policy_bundle.py
@@ -335,3 +335,84 @@ def test_load_bundle_warns_that_agent_os_version_is_legacy(bundle_dir, caplog):
         bundle = load_policy_bundle(str(bundle_dir))
     assert bundle is not None
     assert any("POLICY-007" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# GHSA-wh6r-6j4v-p4p6: docs/spec/cedar-policy.md section 1 defines the bundle
+# hash over RFC 8785 canonical JSON. The implementation used
+# json.dumps(sort_keys=True, ensure_ascii=True), which agrees with JCS only for
+# ASCII-only, integer-only input. Two implementations following the written
+# spec computed different hashes for the same bundle.
+# ---------------------------------------------------------------------------
+
+def _bundle_hash(manifest):
+    return bundle_module._canonical_bundle_hash(
+        manifest, {"policy.cedar": CEDAR_POLICY}, SCHEMA
+    )
+
+
+def test_bundle_hash_matches_rfc8785_for_non_ascii_author_identity():
+    """author_identity is a git identity by spec, and git identities carry names."""
+    import hashlib
+
+    import rfc8785
+
+    manifest = dict(MANIFEST, author_identity="Sørina Müller")
+    expected = hashlib.sha256(
+        rfc8785.dumps(
+            {
+                "manifest": {
+                    k: v
+                    for k, v in manifest.items()
+                    if k not in bundle_module._UNHASHED_MANIFEST_KEYS
+                },
+                "policy_files": {
+                    "policy.cedar": hashlib.sha256(CEDAR_POLICY.encode()).hexdigest()
+                },
+                "schema_hash": hashlib.sha256(SCHEMA.encode()).hexdigest(),
+            }
+        )
+    ).hexdigest()
+
+    assert _bundle_hash(manifest) == expected
+
+
+def test_bundle_hash_diverges_from_the_ascii_escaping_form():
+    """The old form emitted an ASCII escape where JCS emits raw UTF-8 bytes."""
+    manifest = dict(MANIFEST, author_identity="Sørina Müller")
+    legacy = json.dumps(
+        {
+            "manifest": {
+                k: v
+                for k, v in manifest.items()
+                if k not in bundle_module._UNHASHED_MANIFEST_KEYS
+            },
+            "policy_files": {"policy.cedar": bundle_module._sha256_hex(CEDAR_POLICY.encode())},
+            "schema_hash": bundle_module._sha256_hex(SCHEMA.encode()),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+    assert _bundle_hash(manifest) != bundle_module._sha256_hex(legacy.encode())
+
+
+def test_ascii_only_bundles_keep_the_hash_they_already_had():
+    """The common case is byte-identical, so existing pinned hashes still match."""
+    legacy = json.dumps(
+        {
+            "manifest": {
+                k: v
+                for k, v in MANIFEST.items()
+                if k not in bundle_module._UNHASHED_MANIFEST_KEYS
+            },
+            "policy_files": {"policy.cedar": bundle_module._sha256_hex(CEDAR_POLICY.encode())},
+            "schema_hash": bundle_module._sha256_hex(SCHEMA.encode()),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+    assert _bundle_hash(MANIFEST) == bundle_module._sha256_hex(legacy.encode())


### PR DESCRIPTION
Closes GHSA-wh6r-6j4v-p4p6. Reproduced against current `main` before changing anything.

## The divergence

`docs/spec/cedar-policy.md` section 1 defines the policy bundle hash as SHA-256 over `canonical_json` of the bundle structure, and states verbatim that *"canonical_json means RFC 8785 (JSON Canonicalization Scheme)"*.

`_canonical_bundle_hash` computed it with:

```python
json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)
```

The function's own docstring cited section 1 as its definition, so the code documented the contract it diverged from.

The two agree for ASCII-only, integer-only bundles, which is why it went unnoticed. They differ on two input classes the spec explicitly allows:

| Input | JCS | `json.dumps(ensure_ascii=True)` |
|---|---|---|
| non-ASCII string | raw UTF-8 bytes | an ASCII escape |
| float-typed number | `1` (ES6 shortest form, §3.2.2.3) | `1.0` |

Section 1 defines `author_identity` as a SPIFFE SVID or a git identity, and git identities routinely carry non-ASCII names. This is ordinary input, not an adversarial edge case.

The consequence is that an independent implementation following the written spec would compute a different hash for the same bundle, and so could not reproduce the gateway's startup gate. That is a correctness and interoperability failure in a value used to decide whether the gateway starts.

## The fix

Uses a real JCS implementation instead of approximating one. `rfc8785` becomes a declared dependency rather than an incidental transitive one, because the bundle hash is a startup gate and its canonicalizer should not arrive by accident.

## Compatibility

ASCII-only, integer-only bundles hash **exactly as before**, and there is a test pinning that, so existing pinned `expected_hash` values for them keep matching. That is the common case.

Bundles carrying non-ASCII text or float-typed numbers change hash. Those are precisely the bundles that were computing a value the spec does not define, so there is no way to fix the divergence without moving them. A deployment pinning such a bundle will need to re-pin, and will get a clear `PolicyHashMismatch` naming both values rather than a silent difference.

## Tests

Three, in `test_policy_bundle.py`:

- the hash matches an independently computed `rfc8785.dumps` digest for a non-ASCII `author_identity`
- it no longer matches the old ASCII-escaping form
- ASCII-only bundles are byte-identical to what they hashed before

Reverting only `bundle.py` turns the first two red.

Full suite: 1607 passed, with the same 4 failures that reproduce on a clean `main` (local venv has agent-manifest 0.11.1 against a `>=0.11.2` pin).

## Note for the backlog

This is the third canonical-JSON dialect I ran into in this repo today: `catalog/approval.py` hand-rolls its own JCS-ish `canonical_json` with `ensure_ascii=False`, which fixes the string case but not the number case. Worth a follow-up to converge them on one implementation; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
