### PR TITLE
fix(compliance): make compliance_domain extensible and fix the dead boundary control

### DIFF
--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -197,16 +197,7 @@
     },
     "compliance_domain": {
       "type": "string",
-      "enum": [
-        "hipaa_phi",
-        "pci_data",
-        "mnpi",
-        "pii",
-        "internal",
-        "external",
-        "public"
-      ],
-      "description": "Compliance classification domain for this tool."
+      "description": "Compliance classification domain for this tool. Validated at catalog load time against the built in vocabulary plus any deployment configured additions, not enumerated here, since the legal set is deployment dependent. Mirrors sensitivity_level."
     },
     "requires_baa": {
       "type": "boolean",

--- a/src/cmcp_runtime/catalog/loader.py
+++ b/src/cmcp_runtime/catalog/loader.py
@@ -18,7 +18,7 @@ from cmcp_runtime.errors import (
     ToolNotInCatalog,
 )
 from cmcp_runtime.mcp.stdio import StdioSpawn
-from cmcp_runtime.session.state import SENSITIVITY_ORDER
+from cmcp_runtime.session.state import COMPLIANCE_DOMAINS, SENSITIVITY_ORDER
 
 _PACKAGED_ENTRY_SCHEMA_PATH = (
     Path(__file__).parent.parent / "schemas" / "catalog-entry.schema.json"
@@ -219,6 +219,7 @@ def load_catalog(
     catalog_path: str,
     expected_hash: str | None = None,
     extra_sensitivity_levels: frozenset[str] = frozenset(),
+    extra_compliance_domains: frozenset[str] = frozenset(),
 ) -> ToolCatalog:
     """
     Load and validate the tool catalog from a JSON file.
@@ -231,6 +232,12 @@ def load_catalog(
     built in sensitivity vocabulary, from Config.sensitivity.vocabulary. A
     catalog entry's sensitivity_level must be a built in label or one of these,
     or loading fails closed, same as the fixed six value set used to.
+
+    extra_compliance_domains: the same contract for compliance_domain. The
+    schema used to pin a closed seven value enum, which meant a deployment with
+    its own classification could not express it at all and the catalog simply
+    would not load. Validation moves here so the legal set can be deployment
+    dependent while still failing closed on a value nobody declared.
     """
     path = Path(catalog_path)
     try:
@@ -258,6 +265,14 @@ def load_catalog(
             raise ConfigError(
                 f"Catalog entry '{raw.get('tool_name', '?')}' sensitivity_level "
                 f"'{sensitivity_level}' is not one of {sorted(allowed_sensitivity_levels)}"
+            )
+
+        compliance_domain = raw.get("compliance_domain", "external")
+        allowed_compliance_domains = frozenset(COMPLIANCE_DOMAINS) | extra_compliance_domains
+        if compliance_domain not in allowed_compliance_domains:
+            raise ConfigError(
+                f"Catalog entry '{raw.get('tool_name', '?')}' compliance_domain "
+                f"'{compliance_domain}' is not one of {sorted(allowed_compliance_domains)}"
             )
 
         tool_name: str = raw["tool_name"]

--- a/src/cmcp_runtime/config.py
+++ b/src/cmcp_runtime/config.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 
 from cmcp_runtime.errors import ConfigError
-from cmcp_runtime.session.state import SENSITIVITY_ORDER
+from cmcp_runtime.session.state import COMPLIANCE_DOMAINS, SENSITIVITY_ORDER
 
 # TEE-002: read exactly once at import time so the value is immutable for the
 # lifetime of the process. No code may call os.environ.get("CMCP_DEV_MODE")
@@ -80,6 +80,14 @@ class SensitivityConfig:
     """
 
     vocabulary: dict[str, int] = field(default_factory=dict)
+
+    #: Deployment supplied additions to the built in compliance-domain
+    #: vocabulary, name -> regulated. Same additive contract as vocabulary: a
+    #: key must not collide with a built in COMPLIANCE_DOMAINS name. regulated
+    #: True means a call leaving the domain is recorded as a compliance
+    #: boundary crossing, so the deployment has to say, because nothing else
+    #: can know what its own classification means.
+    compliance_domains: dict[str, bool] = field(default_factory=dict)
 
 
 @dataclass
@@ -168,7 +176,7 @@ _KNOWN_KILL_SWITCH_KEYS = {
     "deny_rate_threshold",
     "min_calls",
 }
-_KNOWN_SENSITIVITY_KEYS = {"vocabulary"}
+_KNOWN_SENSITIVITY_KEYS = {"vocabulary", "compliance_domains"}
 _KNOWN_ATTEST_KEYS = {
     "provider",
     "enforcement_mode",
@@ -352,6 +360,30 @@ def load_config(path: str) -> Config:
             )
         sensitivity_vocabulary[label] = rank
 
+    domains_raw = sens_raw.get("compliance_domains", {})
+    if domains_raw is None:
+        domains_raw = {}
+    if not isinstance(domains_raw, dict):
+        raise ConfigError("sensitivity.compliance_domains must be a mapping")
+    compliance_domains: dict[str, bool] = {}
+    for label, regulated in domains_raw.items():
+        if not isinstance(label, str) or not label:
+            raise ConfigError(
+                "sensitivity.compliance_domains keys must be non empty strings"
+            )
+        if label in COMPLIANCE_DOMAINS:
+            raise ConfigError(
+                f"sensitivity.compliance_domains key '{label}' collides with a built "
+                "in compliance domain. Custom domains may only add to the built in "
+                "set, never rename or replace one."
+            )
+        if not isinstance(regulated, bool):
+            raise ConfigError(
+                f"sensitivity.compliance_domains['{label}'] must be true or false, "
+                "saying whether leaving this domain is a compliance boundary crossing"
+            )
+        compliance_domains[label] = regulated
+
     try:
         provider = TEEProvider(attest_raw.get("provider", "auto"))
     except ValueError as err:
@@ -487,7 +519,10 @@ def load_config(path: str) -> Config:
             deny_rate_threshold=float(ks_threshold),
             min_calls=ks_min_calls,
         ),
-        sensitivity=SensitivityConfig(vocabulary=sensitivity_vocabulary),
+        sensitivity=SensitivityConfig(
+            vocabulary=sensitivity_vocabulary,
+            compliance_domains=compliance_domains,
+        ),
         catalog=CatalogConfig(drift_policy=drift_policy),
         policy_bundle_path=policy_bundle_path,
         catalog_path=catalog_path,

--- a/src/cmcp_runtime/session/call_log.py
+++ b/src/cmcp_runtime/session/call_log.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from cmcp_runtime.session.state import effective_compliance_domains
+
 
 @dataclass
 class CallRecord:
@@ -79,9 +81,30 @@ class CallLog:
 #: Sentinel for the compliance_domain of calls where no catalog entry exists.
 _UNKNOWN_DOMAIN = "unknown"
 
-#: High-sensitivity compliance domains that trigger cross-boundary event recording
-#: when a call transitions away from them.
-_HIGH_SENSITIVITY_DOMAINS: frozenset[str] = frozenset({"pii", "phi", "pci", "restricted"})
+#: Compliance domains that trigger cross-boundary event recording when a call
+#: transitions away from them.
+#:
+#: Derived from COMPLIANCE_DOMAINS rather than written out here. The hardcoded
+#: set this replaces was {"pii", "phi", "pci", "restricted"}, and the catalog
+#: schema permits {hipaa_phi, pci_data, mnpi, pii, internal, external, public}.
+#: The two overlapped on "pii" alone: "phi", "pci" and "restricted" could never
+#: appear as a compliance_domain, and hipaa_phi, pci_data and mnpi never matched.
+#: So the control was silently dead for the three most regulated domains the
+#: field can express, which are the reason the field exists. The legacy spellings
+#: stay in the set so a deployment that somehow carried one keeps its behaviour.
+_LEGACY_HIGH_SENSITIVITY_DOMAINS: frozenset[str] = frozenset({"phi", "pci", "restricted"})
+
+
+def high_sensitivity_domains(extra: dict[str, bool] | None = None) -> frozenset[str]:
+    """Regulated domains, from the shared vocabulary plus deployment additions."""
+    domains = effective_compliance_domains(extra)
+    return frozenset(
+        {name for name, regulated in domains.items() if regulated}
+        | _LEGACY_HIGH_SENSITIVITY_DOMAINS
+    )
+
+
+_HIGH_SENSITIVITY_DOMAINS: frozenset[str] = high_sensitivity_domains()
 
 
 @dataclass
@@ -120,9 +143,18 @@ class SessionCallLog:
         "A -> B means B was called immediately after A within this session."
     )
 
-    def __init__(self, session_id: str) -> None:
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        extra_compliance_domains: dict[str, bool] | None = None,
+    ) -> None:
         self._session_id = session_id
         self._entries: list[CallLogEntry] = []
+        # A deployment that declares its own regulated domain gets cross-boundary
+        # recording for it too. Defaults to the built in set, so callers that do
+        # not configure anything behave exactly as before.
+        self._high_sensitivity_domains = high_sensitivity_domains(extra_compliance_domains)
 
     @property
     def entries(self) -> list[CallLogEntry]:
@@ -209,7 +241,7 @@ class SessionCallLog:
             prev = self._entries[i - 1]
             curr = self._entries[i]
             if (
-                prev.compliance_domain in _HIGH_SENSITIVITY_DOMAINS
+                prev.compliance_domain in self._high_sensitivity_domains
                 and curr.compliance_domain != prev.compliance_domain
             ):
                 cross_boundary.append(

--- a/src/cmcp_runtime/session/state.py
+++ b/src/cmcp_runtime/session/state.py
@@ -19,6 +19,35 @@ SENSITIVITY_ORDER: dict[str, int] = {
 }
 
 
+# Compliance domains a catalog entry may declare. Kept here, beside
+# SENSITIVITY_ORDER, because the two vocabularies overlap by name and drifting
+# them apart is exactly how the cross-boundary control below stopped firing.
+#
+# regulated=True means a call leaving this domain is a compliance boundary
+# crossing worth recording. The three regulated names are the reason the field
+# exists; internal/external/public are ordinary traffic.
+COMPLIANCE_DOMAINS: dict[str, bool] = {
+    "hipaa_phi": True,
+    "pci_data": True,
+    "mnpi": True,
+    "pii": True,
+    "internal": False,
+    "external": False,
+    "public": False,
+}
+
+
+def effective_compliance_domains(extra: dict[str, bool] | None = None) -> dict[str, bool]:
+    """Built in domains plus any deployment configured additions.
+
+    Same additive contract as effective_sensitivity_order: extra can add a
+    domain, for example a regulator's own classification, but a built in name
+    always keeps its built in regulated flag. A deployment that adds a domain
+    says whether it is regulated, because nothing else can know.
+    """
+    return {**(extra or {}), **COMPLIANCE_DOMAINS}
+
+
 def effective_sensitivity_order(extra: dict[str, int] | None = None) -> dict[str, int]:
     """Built in vocabulary plus any deployment configured additions (#479).
 

--- a/src/cmcp_runtime/startup.py
+++ b/src/cmcp_runtime/startup.py
@@ -552,6 +552,7 @@ def run_startup(config_path: str) -> RuntimeContext:
             config.catalog_path,
             expected_hash=catalog_expected_hash,
             extra_sensitivity_levels=frozenset(config.sensitivity.vocabulary),
+            extra_compliance_domains=frozenset(config.sensitivity.compliance_domains),
         )
     except CatalogHashMismatch as exc:
         _fatal(

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -274,3 +274,40 @@ def test_unknown_rotation_mode_is_rejected(catalog_file):
 
     with pytest.raises(ConfigError):
         load_catalog(catalog_file([entry]))
+
+
+# ---------------------------------------------------------------------------
+# compliance_domain was a closed seven-value enum in the schema, so a
+# deployment with its own classification could not express it at all: the
+# catalog simply would not load. Validation moves to load time, mirroring what
+# sensitivity_level already does (#479), so the legal set can be deployment
+# dependent while still failing closed on a value nobody declared.
+# ---------------------------------------------------------------------------
+
+def test_builtin_compliance_domains_load(catalog_file):
+    for domain in ["hipaa_phi", "pci_data", "mnpi", "pii", "internal", "external", "public"]:
+        entry = json.loads(json.dumps(ENTRY_1))
+        entry["compliance_domain"] = domain
+
+        catalog = load_catalog(catalog_file([entry]))
+
+        assert catalog.require("crm.query").compliance_domain == domain
+
+
+def test_an_undeclared_compliance_domain_fails_closed(catalog_file):
+    entry = json.loads(json.dumps(ENTRY_1))
+    entry["compliance_domain"] = "clinical"
+
+    with pytest.raises(ConfigError, match="compliance_domain"):
+        load_catalog(catalog_file([entry]))
+
+
+def test_a_deployment_declared_compliance_domain_loads(catalog_file):
+    entry = json.loads(json.dumps(ENTRY_1))
+    entry["compliance_domain"] = "clinical"
+
+    catalog = load_catalog(
+        catalog_file([entry]), extra_compliance_domains=frozenset({"clinical"})
+    )
+
+    assert catalog.require("crm.query").compliance_domain == "clinical"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -410,3 +410,43 @@ def test_non_dev_mode_preserves_wildcard_default(config_file, monkeypatch):
     cfg = load_config(config_file(""))
 
     assert cfg.listen_addr == "0.0.0.0:8443"
+
+
+# ── configurable compliance-domain vocabulary ─────────────────────────────────
+
+
+def test_compliance_domains_load(config_file):
+    path = config_file(
+        "sensitivity:\n  compliance_domains:\n    clinical: true\n    marketing: false\n"
+    )
+    cfg = load_config(path)
+    assert cfg.sensitivity.compliance_domains == {"clinical": True, "marketing": False}
+
+
+def test_compliance_domains_default_to_empty(config_file):
+    path = config_file("attestation:\n  provider: tpm\n")
+    cfg = load_config(path)
+    assert cfg.sensitivity.compliance_domains == {}
+
+
+def test_compliance_domain_colliding_with_a_builtin_raises(config_file):
+    """Additive only: a deployment may add a domain, never redefine one.
+
+    Letting a config say hipaa_phi is unregulated would turn off the
+    cross-boundary control for the domain that most needs it.
+    """
+    path = config_file("sensitivity:\n  compliance_domains:\n    hipaa_phi: false\n")
+    with pytest.raises(ConfigError, match="collides with a built in"):
+        load_config(path)
+
+
+def test_compliance_domain_non_boolean_raises(config_file):
+    path = config_file("sensitivity:\n  compliance_domains:\n    clinical: maybe\n")
+    with pytest.raises(ConfigError, match="true or false"):
+        load_config(path)
+
+
+def test_compliance_domains_non_mapping_raises(config_file):
+    path = config_file("sensitivity:\n  compliance_domains: not_a_mapping\n")
+    with pytest.raises(ConfigError, match="mapping"):
+        load_config(path)

--- a/tests/unit/test_session_call_log.py
+++ b/tests/unit/test_session_call_log.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from cmcp_runtime.session.call_log import SessionCallLog
 
 # ---------------------------------------------------------------------------
@@ -317,3 +319,57 @@ def test_trace_claim_call_graph_summary_from_session_call_log():
     # Temporal adjacency note must appear
     assert "edges_represent" in cg
     assert "temporal adjacency" in cg["edges_represent"].lower()
+
+
+# ---------------------------------------------------------------------------
+# The cross-boundary control had drifted away from the vocabulary it guards.
+#
+# _HIGH_SENSITIVITY_DOMAINS was the literal {"pii", "phi", "pci", "restricted"}
+# while the catalog schema permitted {hipaa_phi, pci_data, mnpi, pii, internal,
+# external, public}. The two sets overlapped on "pii" alone: "phi", "pci" and
+# "restricted" could never appear as a compliance_domain, and hipaa_phi,
+# pci_data and mnpi never matched. So the control was silently dead for the
+# three most regulated domains the field can express.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("domain", ["hipaa_phi", "pci_data", "mnpi", "pii"])
+def test_leaving_a_regulated_domain_is_a_cross_boundary_event(domain):
+    log = SessionCallLog("sess-001")
+    log.record_call("c1", _entry("t1", domain), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+
+    events = log.get_call_graph_summary()["cross_boundary_events"]
+
+    assert len(events) == 1
+    assert events[0]["from_domain"] == domain
+    assert events[0]["to_domain"] == "external"
+
+
+def test_legacy_domain_spellings_keep_working():
+    """phi/pci/restricted stay in the set so no deployment regresses."""
+    for domain in ["phi", "pci", "restricted"]:
+        log = SessionCallLog("sess-001")
+        log.record_call("c1", _entry("t1", domain), "allow")
+        log.record_call("c2", _entry("t2", "external"), "allow")
+
+        assert len(log.get_call_graph_summary()["cross_boundary_events"]) == 1
+
+
+def test_a_deployment_declared_regulated_domain_triggers_events():
+    log = SessionCallLog("sess-001", extra_compliance_domains={"uae_ncsp": True})
+    log.record_call("c1", _entry("t1", "uae_ncsp"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+
+    events = log.get_call_graph_summary()["cross_boundary_events"]
+
+    assert len(events) == 1
+    assert events[0]["from_domain"] == "uae_ncsp"
+
+
+def test_a_deployment_declared_unregulated_domain_does_not():
+    """The deployment says what its own classification means; false is honoured."""
+    log = SessionCallLog("sess-001", extra_compliance_domains={"marketing": False})
+    log.record_call("c1", _entry("t1", "marketing"), "allow")
+    log.record_call("c2", _entry("t2", "external"), "allow")
+
+    assert log.get_call_graph_summary()["cross_boundary_events"] == []


### PR DESCRIPTION
Two problems in one vocabulary. The first is the one I set out to fix; the second is what I found doing it, and it is the one that matters.

## 1. The closed enum

`compliance_domain` was pinned to a seven-value enum in `schemas/catalog-entry.schema.json`. A deployment with its own classification could not express it at all: the catalog would not load.

`sensitivity_level` already solved this in #479 and its schema description says so: *"Validated at catalog load time against the built in vocabulary plus any deployment configured additions, not enumerated here, since the legal set is config dependent."*

`compliance_domain` now follows the same pattern, with the same additive contract: `sensitivity.compliance_domains` in config may add a domain but can never redefine a built-in one.

## 2. The cross-boundary control was dead for HIPAA PHI, PCI and MNPI

This is the part worth reviewing carefully.

`call_log._HIGH_SENSITIVITY_DOMAINS` decides whether a call leaving a domain is recorded as a compliance boundary crossing in the TRACE claim's `call_graph_summary`. It was a hardcoded literal:

```python
frozenset({"pii", "phi", "pci", "restricted"})
```

The catalog schema permitted:

```
hipaa_phi, pci_data, mnpi, pii, internal, external, public
```

The two sets overlap on `pii` alone.

- `phi`, `pci`, `restricted` **could never appear** as a `compliance_domain` — the schema rejected them
- `hipaa_phi`, `pci_data`, `mnpi` **never matched** the high-sensitivity set

So a session that read HIPAA PHI and then called an external tool recorded **no** cross-boundary event. Same for PCI data and for material non-public information. The control worked only for `pii`.

The existing tests did not catch it because they were written against the drifted set — `test_summary_domains_sorted` asserts on `"phi"`, a value the schema never permitted.

`session/state.py` had already anticipated exactly this class of failure, in the docstring for `effective_sensitivity_order`: *"if one of those names silently dropped out of the effective vocabulary it would rank at 0 by ... fail open default."* The same drift happened one module over, to a different vocabulary.

## The fix

A single `COMPLIANCE_DOMAINS` mapping in `session/state.py`, deliberately beside `SENSITIVITY_ORDER` because the two overlap by name and keeping them apart is how they drifted. Each domain carries a `regulated` flag, and the high-sensitivity set is derived from it rather than restated.

The legacy spellings `phi`, `pci`, `restricted` stay in the derived set, so any deployment that somehow carried one keeps its behaviour. Nothing loses an event.

A deployment adding a domain says whether it is regulated, because nothing else can know what its own classification means. Config rejects a boolean-less value and rejects any key colliding with a built-in — letting a config declare `hipaa_phi: false` would turn the control off for the domain that most needs it.

## Tests

- four proving each regulated built-in (`hipaa_phi`, `pci_data`, `mnpi`, `pii`) now records a crossing; three of the four fail on current `main`
- legacy spellings still fire
- a deployment-declared regulated domain fires, an unregulated one does not
- loader accepts every built-in, fails closed on an undeclared value, accepts a declared one
- config rejects a built-in collision, a non-boolean, and a non-mapping

Full suite: **1624 passed**. Five failures, all reproducing on a clean `main`: four from the local venv carrying agent-manifest 0.11.1 against a `>=0.11.2` pin, plus `test_far_oversized_request_beyond_the_drain_ceiling_still_gets_a_clean_response`, which is flaky — it fails roughly one run in four on an unmodified checkout. Worth a separate look.

## Follow-on

This unblocks `agentrust-io/demos`, whose `demo-04` and `demo-05` catalogs use `finance`, `clinical` and `external-analytics` and have been unable to load. They will declare those domains in config once this ships, which demonstrates the new capability rather than working around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
