### PR TITLE
docs: align architecture, transport, and benchmark pages with runtime behavior

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -11,6 +11,10 @@ cMCP sits between an MCP client and its tool servers. It evaluates routed calls 
 
 ## Where enforcement runs
 
+Scroll the diagram horizontally on smaller screens. The text below explains the same boundaries.
+
+<div class="at-diagram" role="region" aria-label="cMCP enforcement diagram; scroll horizontally" tabindex="0" markdown>
+
 ```mermaid
 flowchart TB
     agent[Agent and MCP client]
@@ -31,6 +35,8 @@ flowchart TB
     response -->|response or egress denial| agent
     claim -->|evidence| verifier[Independent verifier]
 ```
+
+</div>
 
 The runtime box is a **process boundary in software mode**. With a supported confidential-computing deployment, it can also be a hardware isolation boundary. The agent, model inference, and upstream tool server do not automatically move inside that boundary. A TPM can provide measured-state evidence; it does not by itself isolate the runtime's memory from the host.
 

--- a/docs/spec/stdio-transport.md
+++ b/docs/spec/stdio-transport.md
@@ -1,11 +1,17 @@
 # stdio Transport: the Gateway as Parent
 
 ---
-Status: Proposal
+Status: Implemented; design rationale retained below
 Written: 2026-08-09
-Supersedes: the stdio section of [transport.md](transport.md), if accepted
-Stability: Unstable, no code written
+Supersedes: the original stdio exclusion in [transport.md](transport.md)
+Implementation: `src/cmcp_runtime/mcp/stdio.py` and `mcp/proxy.py`
 ---
+
+## Current behavior
+
+The gateway starts a configured stdio server on first use within a session. A child is reused within that session by execution identity, and session close terminates it. An expected digest mismatch refuses the spawn; a missing digest requires explicit `allow_unmeasured_spawn`. In software-only mode this creates no enclave assurance.
+
+Stderr content is kept out of the shareable audit chain but can reach gateway logs. Framing errors fail the session. The gateway process and child share their deployment isolation domain; a VM boundary does not isolate the gateway from its child.
 
 ## Cache identity
 
@@ -101,15 +107,15 @@ the launch measurement and must be reported as a distinct evidence class, not fo
 | `spawn-measured` | The gateway digested the executable, matched it against the catalog, spawned it, and recorded the digest in the audit chain. The response came from that process. |
 | `spawn-unmeasured` | The gateway spawned a child with no digest in the catalog to check against. Recorded, never silently treated as measured. Configuration should be able to refuse this. |
 
-## Open questions
+## Original design questions and current answers
 
-1. **Lifecycle.** One child per session, or a pool reused across sessions? A pool is
+1. **Lifecycle.** Implemented as children scoped to a session, reused by execution identity within it, and closed with that session. The original alternative was a pool across sessions. A pool is
    faster and leaks state between sessions, which is exactly the kind of cross-session
    contamination the audit chain cannot see.
-2. **stderr.** MCP servers write diagnostics there. Capturing it into the audit chain risks
+2. **stderr.** The implementation logs diagnostics through the gateway logger and records a byte count in evidence. MCP servers write diagnostics there. Capturing it into the audit chain risks
    payload leakage into an artifact meant to be shareable; discarding it loses the only
    signal when a child misbehaves.
-3. **Framing.** MCP stdio uses newline-delimited JSON-RPC. A child that writes an unframed
+3. **Framing.** Implemented as fail-closed newline-delimited JSON-RPC. A child that writes an unframed
    blob, or writes to stdout for logging, desynchronizes the stream. The reader must treat
    a parse failure as a fatal session error rather than resynchronizing, because
    resynchronizing means guessing which bytes were a response.
@@ -118,11 +124,11 @@ the launch measurement and must be reported as a distinct evidence class, not fo
    network upstream" and "server attests itself", and the phase model does not currently
    have a place for it.
 
-## Recommendation
+## Original recommendation
 
 Adopt the gateway-as-parent model and retire both bridging options, which exist only to
 serve an assumption this architecture already discarded. Implement behind configuration,
 default off, with `spawn-measured` required and `spawn-unmeasured` refused unless
 explicitly enabled.
 
-No code has been written against this proposal.
+The gateway-as-parent implementation now ships in the runtime. The proposed privilege and sandboxing mitigations above should not be read as a claim that all have been implemented.

--- a/docs/spec/transport.md
+++ b/docs/spec/transport.md
@@ -33,12 +33,12 @@ Closes #20, #21.
 | Transport | Phase 1 Status | Reason |
 |-----------|---------------|--------|
 | HTTP/SSE | **In scope** | MCP server runs as a network-addressable process. The runtime terminates the connection at the TEE boundary, inspects each call, and forwards to the upstream server over a separate internal connection. No subprocess spawning required. |
-| stdio | **Out of Phase 1 scope** | The stdio transport requires the agent (or MCP client) to spawn the MCP server as a child subprocess. A subprocess cannot cross the TEE boundary: the agent process lives outside the enclave and cannot fork a child that executes inside isolated TEE memory. The memory isolation guarantee of SEV-SNP, TDX, and TPM Trusted Launch is per-VM or per-enclave, not per-process-tree. Bridging stdio into the TEE would require a new component (see options below), deferred to Phase 2 or a future extension. |
+| stdio | **Implemented as a gateway child** | The gateway spawns the catalog-configured MCP server within its own deployment boundary. Digest checks and explicit unmeasured-spawn configuration apply. See [stdio transport](stdio-transport.md) for behavior and isolation limits. |
 | WebSocket | **TBD** | WebSocket provides bidirectional framing over HTTP/1.1 or HTTP/2. The runtime can terminate WebSocket connections in principle; evaluation is deferred pending the MCP specification WebSocket profile stabilizing. |
 
 ---
 
-## stdio Gap: Technical Reason
+## Original stdio Gap Analysis (historical)
 
 The MCP stdio transport works as follows:
 
@@ -104,16 +104,7 @@ Agent
 | Agent developer effort | Low | Medium |
 | Recommended | No | Workaround only |
 
-**Decision for Phase 1**: stdio transport is unsupported. Agents using stdio-only MCP servers must either migrate those servers to HTTP/SSE or use Option B as an undocumented workaround at their own risk.
-
-> **Under review (2026-08-09).** Both options above share an assumption that does not hold
-> once cMCP is in the path: that the *agent* spawns the MCP server. It does not — this
-> document's own agent-configuration section states that the agent reaches only the gateway
-> and that the runtime catalog is authoritative. [`stdio-transport.md`](stdio-transport.md)
-> proposes the gateway spawning the server as its own child *inside* the enclave, which
-> introduces no component outside the TEE and makes the server binary measurable before it
-> runs. It also states what that costs, which is that the server then executes inside the
-> same isolation domain as the policy evaluator.
+**Current decision:** the gateway-as-parent stdio path is implemented. The earlier exclusion and bridging options above record the original design analysis; they are not the current support matrix. See [stdio transport](stdio-transport.md) for session lifecycle, executable identity, and the shared isolation boundary.
 
 ---
 

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -2,9 +2,9 @@
 
 ## Latest results
 
-Benchmark results are committed to [`benchmarks/`](https://github.com/agentrust-io/cmcp/tree/main/benchmarks) by the nightly CI workflow after each run on TEE hardware. Each result file covers one provider and reports p50/p95/p99 latency in microseconds.
+The main-branch CI benchmark runs in `software-only` mode on a standard Ubuntu runner. It uploads a `benchmark-results` workflow artifact; it does not commit nightly hardware measurements to the repository. See the [CI workflow](https://github.com/agentrust-io/cmcp/blob/main/.github/workflows/ci.yml).
 
-The directory is currently empty: results will appear after the first scheduled CI run on production TEE hardware. TEE hardware benchmarks are run on Azure DCasv5 (SEV-SNP) and GCP C3 Confidential VM (TDX).
+The committed `benchmarks/` directory currently contains only its placeholder. The latency figures below are targets and estimates, not measured results or service guarantees. For recorded hardware validation, see [hardware runs](hardware-validation.md); those reports have their own scope and do not establish these latency targets.
 
 ---
 
@@ -26,9 +26,9 @@ Attestation is a startup cost, not a per-call cost. It is not included in the pe
 | TEE Provider    | Target     | Notes                                              |
 |-----------------|------------|----------------------------------------------------|
 | TPM             | < 500ms    | Hardware I/O bound; TPM attestation is slow        |
-| SEV-SNP         | < 100ms    | Azure DCasv5, AWS C6a Nitro                        |
+| SEV-SNP         | < 100ms    | Provider-specific deployment; verify the actual attestation profile                        |
 | TDX             | < 100ms    | Azure DCedsv5, GCP C3                              |
-| OPAQUE Managed  | < 50ms     | OPAQUE Managed Runtime, highest assurance          |
+| OPAQUE Managed  | < 50ms     | Configured managed runtime; assurance depends on verified evidence          |
 
 ### Per-Call Runtime Overhead
 

--- a/docs/testing/hardware-validation.md
+++ b/docs/testing/hardware-validation.md
@@ -320,8 +320,8 @@ pair as part of an ordinary claim.
 
 ## TPM2_NV_Certify for the gateway measurement, Azure Trusted Launch vTPM, 2026-08-01
 
-`Standard_D2s_v7`, eastus2. Validates the signed half of #432 (#459, corrected by
-#461). This run **found two defects in code that had already merged**, which is the
+`Standard_D2s_v7`, eastus2. Validates the signed half of #432 (#459, corrected by #461).
+This run **found two defects in code that had already merged**, which is the
 argument for running it.
 
 **Defect 1: the call was wrong and could never have worked.** `ESAPI.nv_certify`


### PR DESCRIPTION
The architecture diagram shrank below readable size on mobile, a hardware-validation issue reference became a second H1, and transport and benchmark pages described outdated behavior.

This PR adds a labeled, keyboard-focusable diagram scroll region, repairs the heading, documents the implemented gateway-child stdio path, and distinguishes software-only CI benchmark artifacts from hardware measurements and latency targets.

Validation: strict MkDocs build; 48 rendered HTML pages and 6,831 local links checked with zero broken targets. Current CI passes across all six Python/OS combinations, governance, security, and docs checks. An earlier run exposed a Manifest dependency incompatibility reproduced on clean main; that comparison remains in the PR discussion and related work is in #616. No runtime compatibility change is included here. All further audit fixes stay here.
