### PR TITLE
fix: unbreak release.yml and adopt agent-manifest 0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
       - name: Attach evidence to release
         if: github.event_name == 'release'
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           REF_NAME: ${{ github.ref_name }}
         run: gh release upload "$REF_NAME" agt-evidence.json agt-attestation.json
-        env:
-          GITHUB_TOKEN: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,12 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "agentrust-trace>=0.5",
-    # 0.11.2 is the floor: verification binds the manifest's declared policy
-    # enforcement mode to the runtime's attested enforcement mode.
-    "agent-manifest>=0.11.2",
+    # 0.12.0 is the floor: it makes the full-binding requirement enforceable
+    # independently of Pydantic's model validator (GHSA-6hjj-gh3c-r6wv), which
+    # changes what this gateway accepts, and it moves the TPM AK chain onto the
+    # shared certificate-chain verifier, which changes the failure detail this
+    # repo asserts on.
+    "agent-manifest>=0.12.0",
     "cryptography>=50.0,<51.0",
     "pyyaml>=6.0",
     "httpx>=0.27",

--- a/src/cmcp_runtime/agent_manifest.py
+++ b/src/cmcp_runtime/agent_manifest.py
@@ -285,6 +285,20 @@ def _verify_with_sdk(
                 else None
             ),
             trusted_keys=_trusted_keys_for_sdk(trusted_keys),
+            # The gateway performs a deliberately scoped appraisal. It holds the
+            # running policy bundle and tool catalog and verifies those two
+            # bindings; it does not hold the agent's system prompt or model
+            # identity and never claims to. Leaving strict on makes the SDK
+            # return INCOMPLETE for every well-formed full-binding manifest,
+            # because those artifacts are bound and this verifier has no runtime
+            # hash to check them against, which would make the gateway unable to
+            # accept a correct manifest.
+            #
+            # Nothing is skipped as a result: _raise_for_sdk_result still
+            # requires policy_bundle and tool_manifest to be MATCH under
+            # require_runtime_artifacts, and the SDK attaches a warning naming
+            # every binding it did not verify.
+            strict_artifact_verification=False,
         ),
         agent_manifest_sdk.RevocationStore(),
     )

--- a/tests/unit/test_agent_manifest.py
+++ b/tests/unit/test_agent_manifest.py
@@ -57,6 +57,13 @@ def _signed_manifest(
         "issuer": "spiffe://factory.example/signing-authority/development",
         "crypto_profile": "standard",
         "artifacts": {
+            # agent-manifest 0.12.0 (GHSA-6hjj-gh3c-r6wv) enforces the
+            # full-binding requirement independently of the model validator, so
+            # a manifest with no profile must carry all three required
+            # artifacts. This fixture previously omitted two and still verified,
+            # because a nested omission was suppressing the check.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "policy_bundle": {
                 "hash": policy_hash,
                 "policy_language": "cedar",

--- a/tests/unit/test_agent_manifest_cose.py
+++ b/tests/unit/test_agent_manifest_cose.py
@@ -47,6 +47,11 @@ def _manifest(version: str = "0.2") -> dict:
         "issuer": ISSUER,
         "crypto_profile": "standard",
         "artifacts": {
+            # agent-manifest 0.12.0 (GHSA-6hjj-gh3c-r6wv) enforces the
+            # full-binding requirement, so a manifest with no profile must
+            # carry system_prompt, policy_bundle and model_identity.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "policy_bundle": {
                 "hash": POLICY_HASH,
                 "policy_language": "cedar",

--- a/tests/unit/test_intent_binding.py
+++ b/tests/unit/test_intent_binding.py
@@ -57,6 +57,11 @@ def _signed_manifest(intent: dict | None = None) -> tuple[dict, dict[str, bytes]
         "issuer": "spiffe://factory.example/manifest-authority",
         "crypto_profile": "standard",
         "artifacts": {
+            # agent-manifest 0.12.0 (GHSA-6hjj-gh3c-r6wv) enforces the
+            # full-binding requirement, so a manifest with no profile must
+            # carry system_prompt, policy_bundle and model_identity.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "policy_bundle": {"hash": POLICY_HASH, "policy_language": "cedar"},
             "tool_manifest": {"catalog_hash": CATALOG_HASH, "tools": []},
         },

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -72,6 +72,11 @@ def _write_agent_manifest_files(
         "issuer": "spiffe://factory.example/signing-authority/development",
         "crypto_profile": "standard",
         "artifacts": {
+            # agent-manifest 0.12.0 (GHSA-6hjj-gh3c-r6wv) enforces the
+            # full-binding requirement, so a manifest with no profile must
+            # carry system_prompt, policy_bundle and model_identity.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "policy_bundle": {"hash": policy_hash, "policy_language": "cedar"},
             "tool_manifest": {"catalog_hash": catalog_hash, "tools": []},
         },

--- a/tests/unit/test_tpm_chained_verify.py
+++ b/tests/unit/test_tpm_chained_verify.py
@@ -244,7 +244,7 @@ def test_a_chain_whose_root_is_not_pinned_is_rejected_distinctly() -> None:
 
     assert verified is False
     assert "chain_error" in details
-    assert "not among the supplied trusted" in details["chain_error"]
+    assert "does not match any trusted root" in details["chain_error"]
 
 
 def test_a_malformed_signature_blob_is_reported_as_such() -> None:

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -161,6 +161,11 @@ def _signed_manifest(
         "issuer": "spiffe://factory.example/signing-authority/development",
         "crypto_profile": "standard",
         "artifacts": {
+            # agent-manifest 0.12.0 (GHSA-6hjj-gh3c-r6wv) enforces the
+            # full-binding requirement, so a manifest with no profile must
+            # carry system_prompt, policy_bundle and model_identity.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "policy_bundle": (
                 {"hash": POLICY_HASH, "policy_language": "cedar", "enforcement_mode": enforcement_mode}
                 if enforcement_mode is not None


### PR DESCRIPTION
Two things, both needed to get 0.5.0 out. Found while cutting the release.

## 1. My own regression: release.yml was unloadable

Hardening the tag interpolation in #609 added an `env:` block **before** `run:` on the "Attach evidence to release" step. That step already had one **after** `run:`. Two `env` keys in one mapping:

```yaml
        env:
          REF_NAME: ${{ github.ref_name }}
        run: gh release upload "$REF_NAME" ...
        env:
          GITHUB_TOKEN: ${{ github.token }}
```

GitHub Actions refuses to load a workflow with a duplicate key. `release.yml` has produced "workflow file issue" failures on every push since #609 merged, and the `v0.5.0` release event ran nothing, so cmcp-runtime 0.5.0 never reached PyPI.

**Why local validation missed it:** I checked with `yaml.safe_load`, which keeps the last value for a duplicate key without complaining. I have since re-checked every workflow across the org with a loader that rejects duplicates; this was the only occurrence. An `actionlint` step in CI would catch this class directly — worth considering, not added here to keep the fix minimal.

## 2. agent-manifest 0.12.0 changes what this gateway accepts

0.12.0 shipped today and this repo's floor let CI pull it in immediately. Two of its changes land here.

**GHSA-6hjj-gh3c-r6wv** makes the full-binding requirement enforceable independently of Pydantic's model validator. Five test fixtures here built manifests with no `profile` carrying only `policy_bundle` and `tool_manifest`. They verified because a nested omission was suppressing the check. They are `MISMATCH` now, correctly, and declare all three required artifacts.

**That exposed a real integration question, not just a fixture one.** Once a manifest carries `system_prompt` and `model_identity`, the SDK's strict artifact verification returns `INCOMPLETE`, because those bindings are present and this verifier holds no runtime hash to check them against. A gateway holds the running policy bundle and tool catalog and nothing else. Under strict mode it could not accept **any** well-formed full-binding manifest.

So the gateway now declares its appraisal as scoped, `strict_artifact_verification=False`. **This is the judgement call in this PR and the part worth reviewing.**

Nothing is skipped as a result:

- `_raise_for_sdk_result` still requires `policy_bundle` and `tool_manifest` to be `MATCH` under `require_runtime_artifacts`, which is the whole of what this verifier can attest
- the SDK attaches a warning naming every binding it did not verify, so a `VALID` from this path is never mistakable for "all artifacts checked"

The alternative — leaving strict on — means the gateway rejects correct manifests, which is a worse failure than being explicit about scope.

**GHSA-mp83-94pc-7wqh** moved TPM AK chain appraisal onto the shared certificate-chain verifier, changing the failure detail this repo asserts on. Behaviour is unchanged: an unpinned root is still rejected, with a different message.

Floor raised to `>=0.12.0`, since both behaviours are now depended on.

## Verification

Full suite: **1628 passed**, 23 skipped. One local failure, `test_distribution_smoke_script_exercises_installed_public_api`, is the venv carrying cmcp-runtime metadata 0.4.0 against the tree's 0.5.0; CI reinstalls from `pyproject.toml`.

Once this merges I will re-run the release so 0.5.0 reaches PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
