### PR TITLE
test: let the drain-ceiling test survive the reset it documents

### DIFF
--- a/tests/unit/test_mock_upstream_gate.py
+++ b/tests/unit/test_mock_upstream_gate.py
@@ -226,8 +226,32 @@ def test_far_oversized_request_beyond_the_drain_ceiling_still_gets_a_clean_respo
         # a defect.
         with contextlib.suppress(BrokenPipeError, ConnectionResetError):
             sock.sendall(body)
-        raw_response = sock.recv(65536)
-    assert b"413" in raw_response.split(b"\r\n", 1)[0]
+        # The same applies to the read. Once the server has stopped draining
+        # and closed, the reset can arrive before the buffered 413 is read,
+        # and on Windows that surfaces as ConnectionAbortedError (WinError
+        # 10053) rather than an empty read. The comment above always said a
+        # connection-level failure was acceptable here; only sendall was
+        # actually allowed one, which made this test fail about one run in
+        # four on an unmodified tree.
+        raw_response = b""
+        with contextlib.suppress(
+            ConnectionResetError, ConnectionAbortedError, TimeoutError, OSError
+        ):
+            raw_response = sock.recv(65536)
+
+    # If a response did come back it must be the rejection, never an
+    # acceptance. If the connection was torn down first, that is the
+    # give-up-and-close path this test exists to cover.
+    if raw_response:
+        assert b"413" in raw_response.split(b"\r\n", 1)[0]
+
+    # The contract that holds either way: a 15 MB body must not wedge the
+    # server. Whichever path the request above took, the next one is served
+    # normally. This is what makes the test meaningful when the connection is
+    # reset before any bytes are read.
+    status, resp = _post(upstream, VALID_REQUEST)
+    assert status == 200
+    assert resp["id"] == "req-1"
 
 
 def test_request_at_the_limit_is_accepted(upstream):


### PR DESCRIPTION
The last thing keeping a `main` red after today's work, and a pre-existing flake rather than a regression.

`test_far_oversized_request_beyond_the_drain_ceiling_still_gets_a_clean_response` fails roughly **one run in four** on an unmodified tree, and it took `main` red after the 0.5.0 release with `ConnectionAbortedError: [WinError 10053]` on `windows-latest`.

## The race

Its own comment already said the right thing:

> Above `DRAIN_CEILING_BYTES` the server stops draining and closes instead, so this is allowed to surface as a connection-level failure on the client side rather than a parsed response.

But only `sendall` was actually allowed one. The `recv` was not. When the server rejects on the header, sends the 413 and closes while the client is still writing 15 MB, the reset can arrive before the buffered response is read — an empty read on Linux, `WinError 10053` on Windows. The test then failed on behaviour it was written to permit.

## The fix

`recv` gets the same suppression, and the 413 assertion applies only when bytes actually came back.

That alone would weaken it to passing on silence, so it gains the assertion carrying the real contract: **a 15 MB body must not wedge the server.** Whichever path the oversized request took, a following valid request is still served normally. That property holds on both sides of the race and is the one worth protecting.

## Verification

Six consecutive local runs of the file, 38 passed each time. Full suite 1628 passed, with the one local failure being the venv carrying cmcp-runtime metadata 0.4.0 against the tree's 0.5.0; CI reinstalls from `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t