### PR TITLE
fix(deps): raise pymdown-extensions past two path-traversal/ReDoS advisories

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,6 +2,6 @@ mkdocs>=1.6.1
 mkdocs-material>=9.7.7
 mkdocs-minify-plugin>=0.8
 mkdocs-llmstxt>=0.5,<1.0
-pymdown-extensions>=10.21.3
+pymdown-extensions>=11.0.2
 mkdocstrings[python]>=1.0.6
 griffe>=2.2.0


### PR DESCRIPTION
Closes the two advisories OpenSSF Scorecard reports against this repo. Dependabot reports nothing here because this is an open version range in `requirements-docs.txt` rather than a lockfile it tracks.

| Advisory | Fixed in | What |
|---|---|---|
| PYSEC-2026-3609 | 11.0.0 | Path traversal in the b64 extension: an `<img src>` can read files outside `base_path` |
| PYSEC-2026-3654 | 11.0.1 | Exponential-backtracking ReDoS in the caret, tilde, betterem and magiclink inline processors |

The floor was `>=10.21.3`, which covers the earlier sibling-prefix traversal regression but sits below both of these. Raised to `>=11.0.2`, the current release and the floor `ca2a` and `trace-tests` already use.

Docs tooling only. Nothing here reaches `cmcp-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t