### PR TITLE
fix: recognize announced repository maintainers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # Default owners for all files
-* @agentrust-io/maintainers
+* @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
 
 # Security-sensitive paths require security-reviewers sign-off
-src/cmcp_runtime/audit/ @agentrust-io/security-reviewers @agentrust-io/maintainers
-src/cmcp_runtime/tee/ @agentrust-io/security-reviewers @agentrust-io/maintainers
-src/cmcp_runtime/policy/ @agentrust-io/security-reviewers @agentrust-io/maintainers
-src/cmcp_verify/ @agentrust-io/security-reviewers @agentrust-io/maintainers
+src/cmcp_runtime/audit/ @agentrust-io/security-reviewers @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
+src/cmcp_runtime/tee/ @agentrust-io/security-reviewers @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
+src/cmcp_runtime/policy/ @agentrust-io/security-reviewers @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
+src/cmcp_verify/ @agentrust-io/security-reviewers @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
 
 # CI/CD workflow changes
-.github/workflows/ @agentrust-io/maintainers
+.github/workflows/ @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07
 
 # Package configuration
-pyproject.toml @agentrust-io/maintainers
+pyproject.toml @agentrust-io/maintainers @carloshvp @zohebk8s @qubeena07

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -41,3 +41,13 @@ Maintainers who are no longer active may move to emeritus status. Emeritus maint
 ## Changes to This File
 
 Changes to MAINTAINERS.md must be approved by at least one existing maintainer.
+
+## Repository Maintainers
+
+| Name | GitHub | Appointment |
+|---|---|---|
+| Carlos Hernandez | [@carloshvp](https://github.com/carloshvp) | [Project Lead announcement](https://github.com/orgs/agentrust-io/discussions/20) |
+| Zoheb | [@zohebk8s](https://github.com/zohebk8s) | [Project Lead announcement](https://github.com/orgs/agentrust-io/discussions/31) |
+| Dipika Ranabhat | [@qubeena07](https://github.com/qubeena07) | [Project Lead announcement](https://github.com/orgs/agentrust-io/discussions/32) |
+
+These appointments cover this repository. CODEOWNERS determines which paths each reviewer can approve for protected merges.


### PR DESCRIPTION
## What this changes

The announced maintainers (@carloshvp, @zohebk8s, @qubeena07) already have active Maintain access and appear in the approval workflow, but CODEOWNERS excludes them. Add them alongside existing repository owners and record their appointments in MAINTAINERS.md.

The change is confined to cmcp; it grants no organization-team membership and changes no branch rules. Existing owners remain on every rule.

## Type of change

Repository ownership and maintainer documentation; no runtime or normative specification change.

## Security impact

Adds the announced repository maintainers as eligible code-owner reviewers, including existing general-maintainer alternatives on security-sensitive paths. Preserves current owners and review counts.

## Validation

- Rechecked each appointee's active Maintain role through GitHub's permissions API.
- Checked the existing approval workflow and all ownership patterns, including overriding paths.
- `git diff --check` passed. No runtime tests were run locally because no runtime code changed.

## Checklist

- [x] DCO sign-off on the commit.
- CHANGELOG, spec sections, and breaking-change requirements: not applicable.
